### PR TITLE
중간 테이블 엔티티 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/notice/entity/Notice.java
+++ b/src/main/java/team/startup/gwangsan/domain/notice/entity/Notice.java
@@ -6,13 +6,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import team.startup.gwangsan.domain.image.entity.Image;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.place.entity.Place;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -41,15 +38,10 @@ public class Notice {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
-    @JoinColumn(name = "notice_id")
-    private List<Image> images = new ArrayList<>();
-
     @Builder
-    public Notice(String content, Place place, Member member, List<Image> images) {
+    public Notice(String content, Place place, Member member) {
         this.content = content;
         this.place = place;
         this.member = member;
-        this.images = new ArrayList<>(images);
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/notice/entity/NoticeImage.java
+++ b/src/main/java/team/startup/gwangsan/domain/notice/entity/NoticeImage.java
@@ -1,0 +1,33 @@
+package team.startup.gwangsan.domain.notice.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.startup.gwangsan.domain.image.entity.Image;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "tbl_notice_image")
+public class NoticeImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notice_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id", nullable = false)
+    private Image image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "notice_id", nullable = false)
+    private Notice notice;
+
+    @Builder
+    public NoticeImage(Image image, Notice notice) {
+        this.image = image;
+        this.notice = notice;
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/post/entity/Product.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/entity/Product.java
@@ -11,11 +11,8 @@ import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.constant.Mode;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.Type;
-import team.startup.gwangsan.domain.image.entity.Image;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -62,12 +59,8 @@ public class Product {
     @Enumerated(EnumType.STRING)
     private ProductStatus status;
 
-    @OneToMany(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
-    @JoinColumn(name = "product_id")
-    private List<Image> images = new ArrayList<>();
-
     @Builder
-    public Product(String title, String description, Integer gwangsan, Member member, ProductStatus status, Type type, Mode mode, List<Image> images) {
+    public Product(String title, String description, Integer gwangsan, Member member, ProductStatus status, Type type, Mode mode) {
         this.title = title;
         this.description = description;
         this.gwangsan = gwangsan;
@@ -75,6 +68,5 @@ public class Product {
         this.status = status;
         this.type = type;
         this.mode = mode;
-        this.images = new ArrayList<>(images);
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/entity/ProductImage.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/entity/ProductImage.java
@@ -1,0 +1,33 @@
+package team.startup.gwangsan.domain.post.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import team.startup.gwangsan.domain.image.entity.Image;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "tbl_product_image")
+public class ProductImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_image_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id", nullable = false)
+    private Image image;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    @Builder
+    public ProductImage(Image image, Product product) {
+        this.image = image;
+        this.product = product;
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

> JPA `@OneToMany` 및 `@JoinColumn` 사용 시 발생할 수 있는 성능 상 문제를 해결하기 위해 `ProductImage`와 `NoticeImage`를 추가하였습니다

Resolves: #9 

## 📃 작업내용

> `Product`, `Notice`와 `Image` 사이의 중간 테이블 엔티티 추가

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타