### PR TITLE
채팅 메세지 저장 시 푸시 알림 생성 로직 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/ChatController.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/ChatController.java
@@ -30,7 +30,7 @@ public class ChatController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PostMapping
+    @PostMapping("/message")
     public ResponseEntity<SaveChatMessageResponse> saveChatMessage(@RequestBody SaveChatMessageRequest request) {
         SaveChatMessageResponse response = saveChatMessageService.execute(request.roomId(), request.content(), request.imageIds(), request.messageType());
         return ResponseEntity.ok(response);

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.gwangsan.domain.chat.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.chat.entity.ChatMessage;
@@ -17,9 +18,15 @@ import team.startup.gwangsan.domain.image.entity.Image;
 import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
 import team.startup.gwangsan.domain.image.repository.ImageRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.notification.entity.DeviceToken;
+import team.startup.gwangsan.domain.notification.entity.constant.NotificationType;
+import team.startup.gwangsan.domain.notification.repository.DeviceTokenRepository;
+import team.startup.gwangsan.global.event.SendNotificationEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,12 +37,14 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
     private final MemberUtil memberUtil;
     private final ImageRepository imageRepository;
     private final ChatMessageImageRepository chatMessageImageRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final DeviceTokenRepository deviceTokenRepository;
 
     @Override
     @Transactional
     public SaveChatMessageResponse execute(Long roomId, String content, List<Long> imageIds, MessageType messageType) {
         Member member = memberUtil.getCurrentMember();
-        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+        ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomId(roomId)
                 .orElseThrow(NotFoundChatRoomException::new);
 
         ChatMessage chatMessage = ChatMessage.builder()
@@ -55,6 +64,19 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
             chatMessageImages = mapToChatMessageImages(images, chatMessage);
             chatMessageImageRepository.saveAll(chatMessageImages);
         }
+
+        Member otherMember = member.getId().equals(chatRoom.getMember1().getId()) ? chatRoom.getMember2() : chatRoom.getMember1();
+
+        Optional<DeviceToken> optionalToken = deviceTokenRepository.findByUserId(otherMember.getId());
+
+        optionalToken.ifPresent(token -> {
+            List<String> deviceTokens = List.of(token.getDeviceToken());
+
+            applicationEventPublisher.publishEvent(new SendNotificationEvent(
+                    deviceTokens,
+                    NotificationType.CHATTING
+            ));
+        });
 
         return new SaveChatMessageResponse(
                 chatMessage.getId(),


### PR DESCRIPTION
## 💡 배경 및 개요

> 채팅 메세지 저장 시 푸시 앙림 생성하는 로직을 추가하였습니다

Resolves: #52 

## 📃 작업내용

> 채팅 메세지 저장시 푸시 알림 생성 이벤트 추가

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타