### PR TITLE
게시글 단건 조회 오류 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
@@ -49,7 +49,7 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
                                 chatRoom.product.id.eq(productId),
                                 chatRoom.member1.eq(member).or(chatRoom.member2.eq(member))
                         )
-                        .fetchOne()
+                        .fetchFirst()
         );
     }
 

--- a/src/main/java/team/startup/gwangsan/domain/post/repository/ProductImageRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/ProductImageRepository.java
@@ -8,7 +8,7 @@ import team.startup.gwangsan.domain.post.repository.custom.ProductImageCustomRep
 import java.util.List;
 
 public interface ProductImageRepository extends JpaRepository<ProductImage, Long>, ProductImageCustomRepository {
-    List<ProductImage> findByProductId(Long productId);
+    List<ProductImage> findAllByProductId(Long productId);
 
     void deleteByProductIdAndImageId(Long productId, Long imageId);
 

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImpl.java
@@ -51,7 +51,7 @@ public class FindProductByIdServiceImpl implements FindProductByIdService {
 
         validateSamePlace(myPlace, productPlace);
 
-        List<GetImageResponse> images = productImageRepository.findByProductId(product.getId())
+        List<GetImageResponse> images = productImageRepository.findAllByProductId(product.getId())
                 .stream()
                 .map(pi -> new GetImageResponse(
                         pi.getImage().getId(),

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/UpdateProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/UpdateProductServiceImpl.java
@@ -51,7 +51,7 @@ public class UpdateProductServiceImpl implements UpdateProductService {
         List<Image> images = imageRepository.findByIdIn(imageIds);
         ImageValidateUtil.validateExistence(imageIds, images);
 
-        List<ProductImage> existingImages = productImageRepository.findByProductId(productId);
+        List<ProductImage> existingImages = productImageRepository.findAllByProductId(productId);
 
         Set<Long> existingImageIds = extractImageIds(existingImages);
         Set<Long> requestImageIds = new HashSet<>(imageIds);


### PR DESCRIPTION
## 💡 배경 및 개요

> 게시글 단건 조회 시 여러 개의 채팅방이 조회되는 오류를 수정하였습니다

Resolves: #136 

## 📃 작업내용

> `.fetchOne`에서 `.fetchFirst`로 수정

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타