### PR TITLE
채팅 메세지 읽음 서비스 클래스 성능 개선

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/ChatMessageCustomRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/ChatMessageCustomRepository.java
@@ -8,5 +8,5 @@ import java.util.List;
 public interface ChatMessageCustomRepository {
     List<ChatMessage> findChatMessageByRoomIdsWithCursorPaging(List<Long> roomIds, LocalDateTime lastCreatedAt, Long lastMessageId, int limit);
 
-    List<ChatMessage> findUnreadMessages(Long roomId, Long lastMessageId, Long readerId);
+    void readMessage(Long roomId, Long lastMessageId, Long readerId);
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatMessageCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatMessageCustomRepositoryImpl.java
@@ -2,6 +2,8 @@ package team.startup.gwangsan.domain.chat.repository.custom.impl;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import team.startup.gwangsan.domain.chat.entity.ChatMessage;
@@ -18,6 +20,8 @@ import static team.startup.gwangsan.domain.member.entity.QMember.member;
 public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomRepository {
 
     private final JPAQueryFactory queryFactory;
+    @PersistenceContext
+    private EntityManager em;
 
     @Override
     public List<ChatMessage> findChatMessageByRoomIdsWithCursorPaging(List<Long> roomIds, LocalDateTime lastCreatedAt, Long lastMessageId, int limit) {
@@ -34,16 +38,20 @@ public class ChatMessageCustomRepositoryImpl implements ChatMessageCustomReposit
     }
 
     @Override
-    public List<ChatMessage> findUnreadMessages(Long roomId, Long lastMessageId, Long readerId) {
-        return queryFactory
-                .selectFrom(chatMessage)
+    public void readMessage(Long roomId, Long lastMessageId, Long readerId) {
+        long updated = queryFactory
+                .update(chatMessage)
+                .set(chatMessage.checked, true)
                 .where(
                         chatMessage.room.id.eq(roomId),
                         chatMessage.checked.isFalse(),
                         chatMessage.id.loe(lastMessageId),
                         chatMessage.sender.id.ne(readerId)
                 )
-                .fetch();
+                .execute();
+
+        em.flush();
+        em.clear();
     }
 
     private BooleanExpression buildCursorCondition(LocalDateTime lastCreatedAt, Long lastMessageId) {

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/ReadChatMessageServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/ReadChatMessageServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.gwangsan.domain.chat.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.chat.entity.ChatMessage;
@@ -13,6 +14,7 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
+@DynamicUpdate
 public class ReadChatMessageServiceImpl implements ReadChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
@@ -21,13 +23,7 @@ public class ReadChatMessageServiceImpl implements ReadChatMessageService {
     @Override
     @Transactional
     public void execute(Long roomId, Long lastMessage) {
-        Member member = memberUtil.getCurrentMember();
-        List<ChatMessage> unreadMessages = chatMessageRepository.findUnreadMessages(roomId, lastMessage, member.getId());
-
-        for (ChatMessage chatMessage : unreadMessages) {
-            chatMessage.updateChecked(true);
-        }
-
-        chatMessageRepository.saveAll(unreadMessages);
+        Long readerId = memberUtil.getCurrentMember().getId();
+        chatMessageRepository.readMessage(roomId, lastMessage, readerId);
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

> 채팅 메세지 읽음 서비스 클래스의 로직이 읽지 않는 메세지를 조회하고 `JPA`의 `dirtyChecking`을 이용해서  업데이트하는 로직으로 구현되어있었습니다. 이와 같은 로직은 성능상 문제가 발생할 뿐만 아니라 동시성 문제의 가능성 또한 가지고 있었습니다. 이를 해결하기 위해 조회 로직과 업데이트 로직을 벌크 연산을 이용하여 동시성 문제를 해결하고 업데이트 성능을 개선했습니다

Resolves: #197 

## 📃 작업내용

> 채팅 메세지 읽음 로직 벌크 연산으로 성능 개선

## 🙋‍♂️ 리뷰노트

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타