### PR TITLE
거래 완료 시 FCM 알림 발송 로직 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/post/repository/TradeCompleteRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/TradeCompleteRepository.java
@@ -15,4 +15,6 @@ public interface TradeCompleteRepository extends JpaRepository<TradeComplete, Lo
     boolean existsByProductAndBuyerAndSellerAndStatus(Product product, Member buyer, Member seller, TradeStatus status);
 
     Optional<TradeComplete> findByProductAndBuyerAndSellerAndStatus(Product product, Member buyer, Member seller, TradeStatus tradeStatus);
+
+    void deleteByProductAndStatus(Product product, TradeStatus tradeStatus);
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
@@ -1,6 +1,8 @@
 package team.startup.gwangsan.domain.post.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,9 +12,10 @@ import team.startup.gwangsan.domain.chat.repository.ChatMessageRepository;
 import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
-import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
-import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.domain.notification.entity.DeviceToken;
+import team.startup.gwangsan.domain.notification.entity.constant.NotificationType;
+import team.startup.gwangsan.domain.notification.repository.DeviceTokenRepository;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.TradeComplete;
 import team.startup.gwangsan.domain.post.entity.constant.Mode;
@@ -22,19 +25,23 @@ import team.startup.gwangsan.domain.post.exception.*;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.TradeCompleteRepository;
 import team.startup.gwangsan.domain.post.service.RequestTradeCompleteService;
-import team.startup.gwangsan.global.util.MemberUtil;
+import team.startup.gwangsan.global.event.SendNotificationEvent;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteService {
 
-    private final MemberUtil memberUtil;
     private final ProductRepository productRepository;
-    private final MemberRepository memberRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final TradeCompleteRepository tradeCompleteRepository;
     private final MemberDetailRepository memberDetailRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     @Transactional
@@ -107,6 +114,26 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
 
         buyerDetail.minusGwangsan(product.getGwangsan());
         sellerDetail.plusGwangsan(product.getGwangsan());
+
+        List<Long> memberIds = new ArrayList<>();
+
+        memberIds.add(buyerDetail.getId());
+        memberIds.add(sellerDetail.getId());
+
+        List<DeviceToken> deviceTokens = new ArrayList<>();
+
+        for (Long memberId : memberIds) {
+            deviceTokenRepository.findByUserId(memberId)
+                    .ifPresent(deviceTokens::add);
+        }
+
+        tradeCompleteRepository.deleteByProductAndStatus(product, TradeStatus.PENDING);
+
+        applicationEventPublisher.publishEvent(new SendNotificationEvent(
+                deviceTokens,
+                NotificationType.TRADE_COMPLETE,
+                product.getId()
+        ));
     }
 
     private void handleSellerTradeCompletion(Product product, Member seller, Member buyer) {


### PR DESCRIPTION
## 💡 배경 및 개요

> 거래 완료시 FCM 알림 발송을 위한 이벤트를 발행하는 로직을 추가했습니다

Resolves: #217 

## 📃 작업내용

> FCM 발송 이벤트 발행 로직 추가
> 거래 완료 시 `Status`가 `PENDING`인 `TradeComplete` 데이터 삭제 로직 추가

## 🙋‍♂️ 리뷰노트

> 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술해주세요!
>
> 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트 혹은 질문을 요청하는 경우에 작성하면 좋아요!
>
> e.g. 작업을 끝내야할 시간이 얼마 없어 확장성보다는 동작을 위주로 만들었어요! 감안하고 리뷰해주세요!

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타