### PR TITLE
SMS 비동기로 처리로 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/sms/presentation/SmsController.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/presentation/SmsController.java
@@ -2,7 +2,6 @@ package team.startup.gwangsan.domain.sms.presentation;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import net.nurigo.sdk.message.response.SingleMessageSentResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
@@ -23,9 +22,9 @@ public class SmsController {
     private final VerifyResetPasswordCodeService verifyResetPasswordCodeService;
 
     @PostMapping
-    public ResponseEntity<SingleMessageSentResponse> sendSms(@RequestBody @Valid SendSmsRequest request) {
-        SingleMessageSentResponse response = sendSmsService.execute(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<Void> sendSms(@RequestBody @Valid SendSmsRequest request) {
+        sendSmsService.execute(request);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/verify")
@@ -35,9 +34,9 @@ public class SmsController {
     }
 
     @PostMapping("/password")
-    public ResponseEntity<SingleMessageSentResponse> sendResetPasswordSms(@RequestBody @Valid SendSmsRequest request) {
-        SingleMessageSentResponse response = sendResetPasswordSmsService.execute(request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<Void> sendResetPasswordSms(@RequestBody @Valid SendSmsRequest request) {
+        sendResetPasswordSmsService.execute(request);
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/password/verify")

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/SendResetPasswordSmsService.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/SendResetPasswordSmsService.java
@@ -1,8 +1,7 @@
 package team.startup.gwangsan.domain.sms.service;
 
-import net.nurigo.sdk.message.response.SingleMessageSentResponse;
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 
 public interface SendResetPasswordSmsService {
-    SingleMessageSentResponse execute(SendSmsRequest request);
+    void execute(SendSmsRequest request);
 }

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/SendSmsService.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/SendSmsService.java
@@ -1,8 +1,7 @@
 package team.startup.gwangsan.domain.sms.service;
 
-import net.nurigo.sdk.message.response.SingleMessageSentResponse;
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 
 public interface SendSmsService {
-    SingleMessageSentResponse execute(SendSmsRequest dto);
+    void execute(SendSmsRequest dto);
 }

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendResetPasswordSmsServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendResetPasswordSmsServiceImpl.java
@@ -1,10 +1,6 @@
 package team.startup.gwangsan.domain.sms.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import net.nurigo.sdk.message.model.Message;
-import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
-import net.nurigo.sdk.message.response.SingleMessageSentResponse;
-import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.member.repository.MemberRepository;
@@ -14,6 +10,7 @@ import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeExceptio
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 import team.startup.gwangsan.domain.sms.service.SendResetPasswordSmsService;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsSendHelper;
 import team.startup.gwangsan.global.sms.SmsProperties;
 
 import java.security.NoSuchAlgorithmException;
@@ -24,14 +21,14 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class SendResetPasswordSmsServiceImpl implements SendResetPasswordSmsService {
 
-    private final DefaultMessageService messageService;
+    private final SmsSendHelper smsSendHelper;
     private final SmsProperties smsProperties;
     private final MemberRepository memberRepository;
     private final RedisUtil redisUtil;
 
     @Override
     @Transactional
-    public SingleMessageSentResponse execute(SendSmsRequest request) {
+    public void execute(SendSmsRequest request) {
 
         if (!memberRepository.existsByPhoneNumber(request.phoneNumber())) {
             throw new NotRegisteredPhoneNumberException();
@@ -41,12 +38,11 @@ public class SendResetPasswordSmsServiceImpl implements SendResetPasswordSmsServ
 
         saveAuthInfo(request.phoneNumber(), code);
 
-        Message message = new Message();
-        message.setFrom(smsProperties.getFromNumber());
-        message.setTo(request.phoneNumber());
-        message.setText("[시민화폐광산] 비밀번호 재설정 인증번호는 " + code + "입니다. 3분 이내에 입력해주세요.");
-
-        return messageService.sendOne(new SingleMessageSendingRequest(message));
+        smsSendHelper.sendAsync(
+                smsProperties.getFromNumber(),
+                request.phoneNumber(),
+                "[시민화폐광산] 비밀번호 재설정 인증번호는 " + code + "입니다. 3분 이내에 입력해주세요."
+        );
     }
 
     private String generateCode() {

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendSmsServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendSmsServiceImpl.java
@@ -2,10 +2,6 @@ package team.startup.gwangsan.domain.sms.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import net.nurigo.sdk.message.model.Message;
-import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
-import net.nurigo.sdk.message.response.SingleMessageSentResponse;
-import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.springframework.stereotype.Service;
 import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.domain.sms.exception.AlreadyRegisteredPhoneNumberException;
@@ -14,6 +10,7 @@ import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeExceptio
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 import team.startup.gwangsan.domain.sms.service.SendSmsService;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsSendHelper;
 import team.startup.gwangsan.global.sms.SmsProperties;
 
 import java.security.NoSuchAlgorithmException;
@@ -25,13 +22,13 @@ import java.util.Random;
 @RequiredArgsConstructor
 public class SendSmsServiceImpl implements SendSmsService {
 
-    private final DefaultMessageService messageService;
+    private final SmsSendHelper smsSendHelper;
     private final SmsProperties smsProperties;
     private final MemberRepository memberRepository;
     private final RedisUtil redisUtil;
 
     @Override
-    public SingleMessageSentResponse execute(SendSmsRequest request) {
+    public void execute(SendSmsRequest request) {
 
         if (memberRepository.existsByPhoneNumber(request.phoneNumber())) {
             throw new AlreadyRegisteredPhoneNumberException();
@@ -41,14 +38,11 @@ public class SendSmsServiceImpl implements SendSmsService {
 
         saveAuthInfo(request.phoneNumber(), code);
 
-        Message message = new Message();
-        message.setFrom(smsProperties.getFromNumber());
-        message.setTo(request.phoneNumber());
-        message.setText("[시민화폐광산] 인증번호는 " + code + "입니다. 3분 이내에 입력해주세요.");
-
-        SingleMessageSentResponse response = messageService.sendOne(new SingleMessageSendingRequest(message));
-        log.info("[SMS] 발송 성공 - phoneNumber={}", request.phoneNumber().replaceAll("(\\d{3})\\d{4}(\\d{4})", "$1****$2"));
-        return response;
+        smsSendHelper.sendAsync(
+                smsProperties.getFromNumber(),
+                request.phoneNumber(),
+                "[시민화폐광산] 인증번호는 " + code + "입니다. 3분 이내에 입력해주세요."
+        );
     }
 
     private String generateCode() {

--- a/src/main/java/team/startup/gwangsan/global/sms/SmsSendHelper.java
+++ b/src/main/java/team/startup/gwangsan/global/sms/SmsSendHelper.java
@@ -17,15 +17,16 @@ public class SmsSendHelper {
 
     @Async("asyncExecutor")
     public void sendAsync(String from, String to, String text) {
+        String maskedPhoneNumber = to.replaceAll("(\\d{3})\\d{4}(\\d{4})", "$1****$2");
         try {
             Message message = new Message();
             message.setFrom(from);
             message.setTo(to);
             message.setText(text);
             messageService.sendOne(new SingleMessageSendingRequest(message));
-            log.info("[SMS] 비동기 발송 성공 - phoneNumber={}", to.replaceAll("(\\d{3})\\d{4}(\\d{4})", "$1****$2"));
+            log.info("[SMS] 비동기 발송 성공 - phoneNumber={}", maskedPhoneNumber);
         } catch (Exception e) {
-            log.error("[SMS] 비동기 발송 실패 - phoneNumber={}, error={}", to.replaceAll("(\\d{3})\\d{4}(\\d{4})", "$1****$2"), e.getMessage());
+            log.error("[SMS] 비동기 발송 실패 - phoneNumber={}", maskedPhoneNumber, e);
         }
     }
 }

--- a/src/main/java/team/startup/gwangsan/global/sms/SmsSendHelper.java
+++ b/src/main/java/team/startup/gwangsan/global/sms/SmsSendHelper.java
@@ -1,0 +1,31 @@
+package team.startup.gwangsan.global.sms;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SmsSendHelper {
+
+    private final DefaultMessageService messageService;
+
+    @Async("asyncExecutor")
+    public void sendAsync(String from, String to, String text) {
+        try {
+            Message message = new Message();
+            message.setFrom(from);
+            message.setTo(to);
+            message.setText(text);
+            messageService.sendOne(new SingleMessageSendingRequest(message));
+            log.info("[SMS] 비동기 발송 성공 - phoneNumber={}", to.replaceAll("(\\d{3})\\d{4}(\\d{4})", "$1****$2"));
+        } catch (Exception e) {
+            log.error("[SMS] 비동기 발송 실패 - phoneNumber={}, error={}", to.replaceAll("(\\d{3})\\d{4}(\\d{4})", "$1****$2"), e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

> 기존 인증번호 요청 API는 처리 과정에서 Cool SMS 외부 API를 직접 동기 호출하는 구조여서 API 지연이나 실패가 곧바로 사용자 응답 타임아웃으로 이어지는 문제가 있었습니다.                                                                                                                                                
이를 해결하기 위해 SMS 발송을 비동기로 분리하였습니다. 사용자 요청 시에는 인증번호를 Redis에 저장하는 것까지만 처리하고 즉시 응답을 반환하며 실제 SMS 발송은 SmsSendHelper를 통해 별도의 비동기 스레드에서       
수행하도록 변경하여 요청 경로에서 외부 API 의존성을 제거했습니다. 또한 Cool SMS SDK의 응답 객체를 클라이언트에 불필요하게 노출하던 반환 타입도 void로 변경하였습니다.

Resolves: #302 

## 📃 작업내용

- 비동기(@Async) 처리로 변경
- SmsSendHelper 컴포넌트 추가                                                                                                                                                                 
- 인증번호 요청 API 반환 타입 변경

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타