### PR TITLE
feat :: 별칭 찾기 API 구현

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/auth/presentation/AuthController.java
+++ b/src/main/java/team/startup/gwangsan/domain/auth/presentation/AuthController.java
@@ -6,9 +6,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.startup.gwangsan.domain.auth.presentation.dto.request.FindNicknameRequest;
 import team.startup.gwangsan.domain.auth.presentation.dto.request.ResetPasswordRequest;
 import team.startup.gwangsan.domain.auth.presentation.dto.request.SignInRequest;
 import team.startup.gwangsan.domain.auth.presentation.dto.request.SignUpRequest;
+import team.startup.gwangsan.domain.auth.presentation.dto.response.FindNicknameResponse;
 import team.startup.gwangsan.domain.auth.presentation.dto.response.MemberInfoResponse;
 import team.startup.gwangsan.domain.auth.presentation.dto.response.TokenResponse;
 import team.startup.gwangsan.domain.auth.service.*;
@@ -24,6 +26,7 @@ public class AuthController {
     private final SignOutService signOutService;
     private final TokenAuthenticationService tokenAuthenticationService;
     private final ResetPasswordService resetPasswordService;
+    private final FindNicknameService findNicknameService;
 
     @PostMapping("/signup")
     public ResponseEntity<Void> signUp(@RequestBody @Valid SignUpRequest request) {
@@ -60,6 +63,12 @@ public class AuthController {
     public ResponseEntity<Void> resetPassword(@RequestBody @Valid ResetPasswordRequest request) {
         resetPasswordService.execute(request);
         return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/nickname")
+    public ResponseEntity<FindNicknameResponse> findNickname(@RequestBody @Valid FindNicknameRequest request) {
+        FindNicknameResponse response = findNicknameService.execute(request);
+        return ResponseEntity.ok(response);
     }
 }
 

--- a/src/main/java/team/startup/gwangsan/domain/auth/presentation/dto/request/FindNicknameRequest.java
+++ b/src/main/java/team/startup/gwangsan/domain/auth/presentation/dto/request/FindNicknameRequest.java
@@ -1,0 +1,12 @@
+package team.startup.gwangsan.domain.auth.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record FindNicknameRequest(
+
+        @Pattern(regexp = "^010\\d{8}$", message = "올바른 휴대폰 번호 형식이어야 합니다.")
+        @NotBlank(message = "휴대폰 번호는 필수입니다.")
+        String phoneNumber
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/auth/presentation/dto/response/FindNicknameResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/auth/presentation/dto/response/FindNicknameResponse.java
@@ -1,0 +1,6 @@
+package team.startup.gwangsan.domain.auth.presentation.dto.response;
+
+public record FindNicknameResponse(
+        String nickname
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/auth/service/FindNicknameService.java
+++ b/src/main/java/team/startup/gwangsan/domain/auth/service/FindNicknameService.java
@@ -1,0 +1,8 @@
+package team.startup.gwangsan.domain.auth.service;
+
+import team.startup.gwangsan.domain.auth.presentation.dto.request.FindNicknameRequest;
+import team.startup.gwangsan.domain.auth.presentation.dto.response.FindNicknameResponse;
+
+public interface FindNicknameService {
+    FindNicknameResponse execute(FindNicknameRequest request);
+}

--- a/src/main/java/team/startup/gwangsan/domain/auth/service/impl/FindNicknameServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/auth/service/impl/FindNicknameServiceImpl.java
@@ -1,0 +1,47 @@
+package team.startup.gwangsan.domain.auth.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.auth.exception.SmsAuthNotCompletedException;
+import team.startup.gwangsan.domain.auth.exception.SmsAuthNotFoundException;
+import team.startup.gwangsan.domain.auth.presentation.dto.request.FindNicknameRequest;
+import team.startup.gwangsan.domain.auth.presentation.dto.response.FindNicknameResponse;
+import team.startup.gwangsan.domain.auth.service.FindNicknameService;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.global.redis.RedisUtil;
+
+@Service
+@RequiredArgsConstructor
+public class FindNicknameServiceImpl implements FindNicknameService {
+
+    private static final String VERIFIED_KEY_PREFIX = "sms:verified:";
+
+    private final MemberRepository memberRepository;
+    private final RedisUtil redisUtil;
+
+    @Override
+    @Transactional(readOnly = true)
+    public FindNicknameResponse execute(FindNicknameRequest request) {
+        String phoneNumber = request.phoneNumber();
+        String verifiedKey = VERIFIED_KEY_PREFIX + phoneNumber;
+
+        Boolean verified = redisUtil.get(verifiedKey, Boolean.class);
+        if (verified == null) {
+            throw new SmsAuthNotFoundException();
+        }
+
+        if (!Boolean.TRUE.equals(verified)) {
+            throw new SmsAuthNotCompletedException();
+        }
+
+        Member member = memberRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(NotFoundMemberException::new);
+
+        redisUtil.delete(verifiedKey);
+
+        return new FindNicknameResponse(member.getNickname());
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/sms/exception/SmsSendFailedException.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/exception/SmsSendFailedException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangsan.domain.sms.exception;
+
+import team.startup.gwangsan.global.exception.ErrorCode;
+import team.startup.gwangsan.global.exception.GlobalException;
+
+public class SmsSendFailedException extends GlobalException {
+    public SmsSendFailedException() {
+        super(ErrorCode.AUTH_CODE_GENERATION_FAILURE);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/sms/presentation/SmsController.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/presentation/SmsController.java
@@ -6,10 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
-import team.startup.gwangsan.domain.sms.service.SendResetPasswordSmsService;
-import team.startup.gwangsan.domain.sms.service.SendSmsService;
-import team.startup.gwangsan.domain.sms.service.VerifyCodeService;
-import team.startup.gwangsan.domain.sms.service.VerifyResetPasswordCodeService;
+import team.startup.gwangsan.domain.sms.service.*;
 
 @RestController
 @RequestMapping("/api/sms")
@@ -20,6 +17,8 @@ public class SmsController {
     private final VerifyCodeService verifyCodeService;
     private final SendResetPasswordSmsService sendResetPasswordSmsService;
     private final VerifyResetPasswordCodeService verifyResetPasswordCodeService;
+    private final SendFindNicknameSmsService sendFindNicknameSmsService;
+    private final VerifyFindNicknameCodeService verifyFindNicknameCodeService;
 
     @PostMapping
     public ResponseEntity<Void> sendSms(@RequestBody @Valid SendSmsRequest request) {
@@ -42,6 +41,18 @@ public class SmsController {
     @PostMapping("/password/verify")
     public ResponseEntity<Void> verifyResetPasswordSms(@RequestBody @Valid VerifyCodeRequest request) {
         verifyResetPasswordCodeService.execute(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/nickname")
+    public ResponseEntity<Void> sendFindNicknameSms(@RequestBody @Valid SendSmsRequest request) {
+        sendFindNicknameSmsService.execute(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/nickname/verify")
+    public ResponseEntity<Void> verifyFindNicknameSms(@RequestBody @Valid VerifyCodeRequest request) {
+        verifyFindNicknameCodeService.execute(request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/SendFindNicknameSmsService.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/SendFindNicknameSmsService.java
@@ -1,0 +1,7 @@
+package team.startup.gwangsan.domain.sms.service;
+
+import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
+
+public interface SendFindNicknameSmsService {
+    void execute(SendSmsRequest request);
+}

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/VerifyFindNicknameCodeService.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/VerifyFindNicknameCodeService.java
@@ -1,0 +1,7 @@
+package team.startup.gwangsan.domain.sms.service;
+
+import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
+
+public interface VerifyFindNicknameCodeService {
+    void execute(VerifyCodeRequest request);
+}

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImpl.java
@@ -1,0 +1,71 @@
+package team.startup.gwangsan.domain.sms.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.domain.sms.exception.AuthCodeGenerationException;
+import team.startup.gwangsan.domain.sms.exception.NotRegisteredPhoneNumberException;
+import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeException;
+import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
+import team.startup.gwangsan.domain.sms.service.SendFindNicknameSmsService;
+import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsSendHelper;
+import team.startup.gwangsan.global.sms.SmsProperties;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
+
+@Service
+@RequiredArgsConstructor
+public class SendFindNicknameSmsServiceImpl implements SendFindNicknameSmsService {
+
+    private final SmsSendHelper smsSendHelper;
+    private final SmsProperties smsProperties;
+    private final MemberRepository memberRepository;
+    private final RedisUtil redisUtil;
+
+    @Override
+    @Transactional
+    public void execute(SendSmsRequest request) {
+
+        if (!memberRepository.existsByPhoneNumber(request.phoneNumber())) {
+            throw new NotRegisteredPhoneNumberException();
+        }
+
+        String code = generateCode();
+
+        saveAuthInfo(request.phoneNumber(), code);
+
+        smsSendHelper.sendAsync(
+                smsProperties.getFromNumber(),
+                request.phoneNumber(),
+                "[시민화폐광산] 별칭 찾기 인증번호는 " + code + "입니다. 3분 이내에 입력해주세요."
+        );
+    }
+
+    private String generateCode() {
+        try {
+            Random random = SecureRandom.getInstanceStrong();
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < 6; i++) builder.append(random.nextInt(10));
+            return builder.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new AuthCodeGenerationException();
+        }
+    }
+
+    private void saveAuthInfo(String phoneNumber, String code) {
+        String attemptKey = "sms:attempt:" + phoneNumber;
+        String codeKey = "sms:code:" + phoneNumber;
+
+        Integer attempt = redisUtil.get(attemptKey, Integer.class);
+        if (attempt == null) attempt = 0;
+
+        if (attempt >= 5) throw new TooManyRequestAuthCodeException();
+
+        redisUtil.set(attemptKey, attempt + 1, 3 * 60 * 1000);
+        redisUtil.set(codeKey, code, 3 * 60 * 1000);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImpl.java
@@ -1,27 +1,32 @@
 package team.startup.gwangsan.domain.sms.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.nurigo.sdk.message.model.Message;
+import net.nurigo.sdk.message.request.SingleMessageSendingRequest;
+import net.nurigo.sdk.message.service.DefaultMessageService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.domain.sms.exception.AuthCodeGenerationException;
 import team.startup.gwangsan.domain.sms.exception.NotRegisteredPhoneNumberException;
+import team.startup.gwangsan.domain.sms.exception.SmsSendFailedException;
 import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeException;
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 import team.startup.gwangsan.domain.sms.service.SendFindNicknameSmsService;
 import team.startup.gwangsan.global.redis.RedisUtil;
-import team.startup.gwangsan.global.sms.SmsSendHelper;
 import team.startup.gwangsan.global.sms.SmsProperties;
 
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Random;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SendFindNicknameSmsServiceImpl implements SendFindNicknameSmsService {
 
-    private final SmsSendHelper smsSendHelper;
+    private final DefaultMessageService messageService;
     private final SmsProperties smsProperties;
     private final MemberRepository memberRepository;
     private final RedisUtil redisUtil;
@@ -36,13 +41,35 @@ public class SendFindNicknameSmsServiceImpl implements SendFindNicknameSmsServic
 
         String code = generateCode();
 
-        saveAuthInfo(request.phoneNumber(), code);
+        validateAttemptLimit(request.phoneNumber());
 
-        smsSendHelper.sendAsync(
-                smsProperties.getFromNumber(),
-                request.phoneNumber(),
-                "[시민화폐광산] 별칭 찾기 인증번호는 " + code + "입니다. 3분 이내에 입력해주세요."
-        );
+        sendSms(request.phoneNumber(), code);
+
+        saveAuthInfo(request.phoneNumber(), code);
+    }
+
+    private void validateAttemptLimit(String phoneNumber) {
+        String attemptKey = "sms:attempt:" + phoneNumber;
+
+        Integer attempt = redisUtil.get(attemptKey, Integer.class);
+        if (attempt == null) attempt = 0;
+
+        if (attempt >= 5) throw new TooManyRequestAuthCodeException();
+
+        redisUtil.set(attemptKey, attempt + 1, 3 * 60 * 1000);
+    }
+
+    private void sendSms(String phoneNumber, String code) {
+        try {
+            Message message = new Message();
+            message.setFrom(smsProperties.getFromNumber());
+            message.setTo(phoneNumber);
+            message.setText("[시민화폐광산] 별칭 찾기 인증번호는 " + code + "입니다. 3분 이내에 입력해주세요.");
+            messageService.sendOne(new SingleMessageSendingRequest(message));
+        } catch (Exception e) {
+            log.error("[SMS] 발송 실패 - phoneNumber={}", phoneNumber.replaceAll("(\\d{3})\\d{4}(\\d{4})", "$1****$2"), e);
+            throw new SmsSendFailedException();
+        }
     }
 
     private String generateCode() {
@@ -57,15 +84,7 @@ public class SendFindNicknameSmsServiceImpl implements SendFindNicknameSmsServic
     }
 
     private void saveAuthInfo(String phoneNumber, String code) {
-        String attemptKey = "sms:attempt:" + phoneNumber;
         String codeKey = "sms:code:" + phoneNumber;
-
-        Integer attempt = redisUtil.get(attemptKey, Integer.class);
-        if (attempt == null) attempt = 0;
-
-        if (attempt >= 5) throw new TooManyRequestAuthCodeException();
-
-        redisUtil.set(attemptKey, attempt + 1, 3 * 60 * 1000);
         redisUtil.set(codeKey, code, 3 * 60 * 1000);
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/VerifyFindNicknameCodeServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/VerifyFindNicknameCodeServiceImpl.java
@@ -1,0 +1,42 @@
+package team.startup.gwangsan.domain.sms.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.auth.exception.SmsAuthNotFoundException;
+import team.startup.gwangsan.domain.sms.exception.NotMatchRandomCodeException;
+import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
+import team.startup.gwangsan.domain.sms.service.VerifyFindNicknameCodeService;
+import team.startup.gwangsan.global.redis.RedisUtil;
+
+@Service
+@RequiredArgsConstructor
+public class VerifyFindNicknameCodeServiceImpl implements VerifyFindNicknameCodeService {
+
+    private static final String CODE_KEY_PREFIX = "sms:code:";
+    private static final String VERIFIED_KEY_PREFIX = "sms:verified:";
+
+    private static final long VERIFIED_TTL_MILLIS = 10 * 60 * 1000L;
+
+    private final RedisUtil redisUtil;
+
+    @Override
+    @Transactional
+    public void execute(VerifyCodeRequest request) {
+        String phoneNumber = request.phoneNumber();
+        String codeKey = CODE_KEY_PREFIX + phoneNumber;
+        String verifiedKey = VERIFIED_KEY_PREFIX + phoneNumber;
+
+        String savedCode = redisUtil.get(codeKey, String.class);
+        if (savedCode == null) {
+            throw new SmsAuthNotFoundException();
+        }
+
+        if (!savedCode.equals(request.code())) {
+            throw new NotMatchRandomCodeException();
+        }
+
+        redisUtil.set(verifiedKey, Boolean.TRUE, VERIFIED_TTL_MILLIS);
+        redisUtil.delete(codeKey);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
@@ -77,6 +77,8 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/api/sms/verify").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/sms/password").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/sms/password/verify").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/sms/nickname").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/sms/nickname/verify").permitAll()
 
                                 // post
                                 .requestMatchers(HttpMethod.POST, "/api/post").authenticated()

--- a/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.PATCH, "/api/auth/reissue").permitAll()
                                 .requestMatchers(HttpMethod.DELETE, "/api/auth/signout").authenticated()
                                 .requestMatchers(HttpMethod.PATCH, "/api/auth/password").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/auth/nickname").permitAll()
 
                                 // sms
                                 .requestMatchers(HttpMethod.POST, "/api/sms").permitAll()

--- a/src/test/java/team/startup/gwangsan/domain/auth/service/impl/FindNicknameServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/auth/service/impl/FindNicknameServiceImplTest.java
@@ -1,0 +1,106 @@
+package team.startup.gwangsan.domain.auth.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.auth.exception.SmsAuthNotCompletedException;
+import team.startup.gwangsan.domain.auth.exception.SmsAuthNotFoundException;
+import team.startup.gwangsan.domain.auth.presentation.dto.request.FindNicknameRequest;
+import team.startup.gwangsan.domain.auth.presentation.dto.response.FindNicknameResponse;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.global.redis.RedisUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FindNicknameServiceImpl 단위 테스트")
+class FindNicknameServiceImplTest {
+
+    @InjectMocks
+    private FindNicknameServiceImpl service;
+
+    @Mock private MemberRepository memberRepository;
+    @Mock private RedisUtil redisUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("정상적인 별칭 찾기 요청 시")
+        class Context_with_valid_request {
+
+            @Test
+            @DisplayName("별칭을 반환하고 Redis 인증 키를 삭제한다")
+            void it_returns_nickname_and_deletes_redis_key() {
+                FindNicknameRequest request = new FindNicknameRequest("01012345678");
+                Member member = mock(Member.class);
+
+                when(redisUtil.get("sms:verified:01012345678", Boolean.class)).thenReturn(true);
+                when(memberRepository.findByPhoneNumber("01012345678")).thenReturn(Optional.of(member));
+                when(member.getNickname()).thenReturn("테스트별칭");
+
+                FindNicknameResponse response = service.execute(request);
+
+                assertThat(response.nickname()).isEqualTo("테스트별칭");
+                verify(redisUtil).delete("sms:verified:01012345678");
+            }
+        }
+
+        @Nested
+        @DisplayName("SMS 인증 정보가 Redis에 없을 때")
+        class Context_with_sms_not_found {
+
+            @Test
+            @DisplayName("SmsAuthNotFoundException을 던진다")
+            void it_throws_sms_not_found_exception() {
+                FindNicknameRequest request = new FindNicknameRequest("01012345678");
+                when(redisUtil.get("sms:verified:01012345678", Boolean.class)).thenReturn(null);
+
+                assertThatThrownBy(() -> service.execute(request))
+                        .isInstanceOf(SmsAuthNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("SMS 인증이 완료되지 않았을 때")
+        class Context_with_sms_not_completed {
+
+            @Test
+            @DisplayName("SmsAuthNotCompletedException을 던진다")
+            void it_throws_sms_not_completed_exception() {
+                FindNicknameRequest request = new FindNicknameRequest("01012345678");
+                when(redisUtil.get("sms:verified:01012345678", Boolean.class)).thenReturn(false);
+
+                assertThatThrownBy(() -> service.execute(request))
+                        .isInstanceOf(SmsAuthNotCompletedException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("회원이 존재하지 않을 때")
+        class Context_with_member_not_found {
+
+            @Test
+            @DisplayName("NotFoundMemberException을 던진다")
+            void it_throws_not_found_member_exception() {
+                FindNicknameRequest request = new FindNicknameRequest("01099999999");
+                when(redisUtil.get("sms:verified:01099999999", Boolean.class)).thenReturn(true);
+                when(memberRepository.findByPhoneNumber("01099999999")).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(request))
+                        .isInstanceOf(NotFoundMemberException.class);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- SMS 인증 완료 후 전화번호로 별칭을 조회하는 `POST /api/auth/nickname` 엔드포인트 추가
- 비밀번호 재설정과 동일한 SMS 인증 플로우(`sms:verified:` Redis 키) 재활용
- SecurityConfig에 해당 엔드포인트 permitAll 설정

## Changes
- `FindNicknameRequest` / `FindNicknameResponse` DTO
- `FindNicknameService` 인터페이스 및 구현체
- `AuthController`에 엔드포인트 추가
- `SecurityConfig`에 권한 설정 추가

## Test plan
- [ ] 미인증 상태에서 호출 시 SmsAuthNotFoundException 반환 확인
- [ ] SMS 인증 완료 후 호출 시 별칭 정상 반환 확인
- [ ] 미가입 전화번호로 호출 시 NotFoundMemberException 반환 확인
- [ ] 조회 후 Redis verified 키 삭제 확인