### PR TITLE
거래 취소 참여자 검증 및 취소 철회 권한 조건 반전 버그 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImpl.java
@@ -24,6 +24,7 @@ import team.startup.gwangsan.global.event.CreateAdminAlertEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.List;
+import java.util.Objects;
 
 @Service
 @RequiredArgsConstructor
@@ -45,8 +46,8 @@ public class TradeCancelServiceImpl implements TradeCancelService {
                         productId, TradeStatus.COMPLETED)
                 .orElseThrow(NotFoundTradeCompleteException::new);
 
-        if (!tradeComplete.getBuyer().getId().equals(member.getId())
-                && !tradeComplete.getSeller().getId().equals(member.getId())) {
+        if (!Objects.equals(tradeComplete.getBuyer().getId(), member.getId())
+                && !Objects.equals(tradeComplete.getSeller().getId(), member.getId())) {
             throw new TradeParticipantOnlyException();
         }
 

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImpl.java
@@ -45,8 +45,8 @@ public class TradeCancelServiceImpl implements TradeCancelService {
                         productId, TradeStatus.COMPLETED)
                 .orElseThrow(NotFoundTradeCompleteException::new);
 
-        if (tradeComplete.getBuyer().getId().equals(member.getId())
-                && tradeComplete.getSeller().getId().equals(member.getId())) {
+        if (!tradeComplete.getBuyer().getId().equals(member.getId())
+                && !tradeComplete.getSeller().getId().equals(member.getId())) {
             throw new TradeParticipantOnlyException();
         }
 

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImpl.java
@@ -17,6 +17,8 @@ import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 import team.startup.gwangsan.domain.trade.service.TradeCancelWithdrawService;
 import team.startup.gwangsan.global.util.MemberUtil;
 
+import java.util.Objects;
+
 @Service
 @RequiredArgsConstructor
 public class TradeCancelWithdrawServiceImpl implements TradeCancelWithdrawService {
@@ -38,7 +40,7 @@ public class TradeCancelWithdrawServiceImpl implements TradeCancelWithdrawServic
         TradeCancel tradeCancel = tradeCancelRepository.findByTradeCompleteIdAndStatus(tradeComplete.getId(), TradeCancelStatus.PENDING)
                 .orElseThrow(NotFoundTradeCancelException::new);
 
-        if (!tradeCancel.getMember().getId().equals(member.getId())) {
+        if (!Objects.equals(tradeCancel.getMember().getId(), member.getId())) {
             throw new NotTradeCancelRequesterException();
         }
 

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImpl.java
@@ -38,7 +38,7 @@ public class TradeCancelWithdrawServiceImpl implements TradeCancelWithdrawServic
         TradeCancel tradeCancel = tradeCancelRepository.findByTradeCompleteIdAndStatus(tradeComplete.getId(), TradeCancelStatus.PENDING)
                 .orElseThrow(NotFoundTradeCancelException::new);
 
-        if (tradeCancel.getMember().getId().equals(member.getId())) {
+        if (!tradeCancel.getMember().getId().equals(member.getId())) {
             throw new NotTradeCancelRequesterException();
         }
 


### PR DESCRIPTION
## 💡 배경 및 개요

거래 취소 및 취소 철회 서비스에서 참여자 검증 조건이 반전되어 있는 버그를 발견하여 수정합니다.

Resolves: #

## 📃 작업내용

- `TradeCancelServiceImpl`: 거래 취소 요청 시 참여자 검증 조건 버그 수정
  - 기존: `buyer.equals(member) && seller.equals(member)` → 한 명이 동시에 buyer이자 seller인 불가능한 조건이라 실질적으로 제3자도 취소 신청 가능했음
  - 변경: `!buyer.equals(member) && !seller.equals(member)` → 거래 참여자(buyer 또는 seller)만 취소 가능
- `TradeCancelWithdrawServiceImpl`: 거래 취소 철회 시 요청자 검증 조건 버그 수정
  - 기존: 본인이 철회 시 `NotTradeCancelRequesterException` 발생 → 정작 요청자 본인이 철회 불가능했음
  - 변경: 요청자가 아닌 사람이 철회 시 예외 발생 → 요청자 본인만 철회 가능

## 🙋‍♂️ 리뷰노트

두 케이스 모두 조건 부정 연산자(`!`) 누락으로 인한 버그입니다.
`TradeCancelServiceImpl`의 경우 `&&` 조건이라 실질적으로 예외가 절대 발생하지 않는 데드 코드 상태였습니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타