### PR TITLE
trade, notice, suspend, sms 단위 테스트 추가

### DIFF
--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/CreateNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/CreateNoticeServiceImplTest.java
@@ -22,6 +22,8 @@ import team.startup.gwangsan.domain.notice.repository.NoticeRepository;
 import team.startup.gwangsan.domain.notification.repository.DeviceTokenRepository;
 import team.startup.gwangsan.domain.place.entity.Place;
 import team.startup.gwangsan.domain.place.repository.PlaceRepository;
+import team.startup.gwangsan.global.event.CreateAlertMembersEvent;
+import team.startup.gwangsan.global.event.SendNotificationEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.Collections;
@@ -76,7 +78,8 @@ class CreateNoticeServiceImplTest {
 
                 verify(noticeRepository).save(any());
                 verify(noticeImageRepository).saveAll(any());
-                verify(applicationEventPublisher, times(2)).publishEvent(any(Object.class));
+                verify(applicationEventPublisher).publishEvent(any(SendNotificationEvent.class));
+                verify(applicationEventPublisher).publishEvent(any(CreateAlertMembersEvent.class));
             }
         }
 

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/CreateNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/CreateNoticeServiceImplTest.java
@@ -1,0 +1,148 @@
+package team.startup.gwangsan.domain.notice.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangsan.domain.auth.exception.PlaceNotFoundException;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.image.exception.ImageNotFoundException;
+import team.startup.gwangsan.domain.image.repository.ImageRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.notice.entity.Notice;
+import team.startup.gwangsan.domain.notice.presentation.dto.request.CreateNoticeRequest;
+import team.startup.gwangsan.domain.notice.repository.NoticeImageRepository;
+import team.startup.gwangsan.domain.notice.repository.NoticeRepository;
+import team.startup.gwangsan.domain.notification.repository.DeviceTokenRepository;
+import team.startup.gwangsan.domain.place.entity.Place;
+import team.startup.gwangsan.domain.place.repository.PlaceRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("CreateNoticeServiceImpl 단위 테스트")
+class CreateNoticeServiceImplTest {
+
+    @InjectMocks private CreateNoticeServiceImpl service;
+
+    @Mock private MemberUtil memberUtil;
+    @Mock private PlaceRepository placeRepository;
+    @Mock private NoticeRepository noticeRepository;
+    @Mock private ImageRepository imageRepository;
+    @Mock private NoticeImageRepository noticeImageRepository;
+    @Mock private ApplicationEventPublisher applicationEventPublisher;
+    @Mock private DeviceTokenRepository deviceTokenRepository;
+    @Mock private MemberDetailRepository memberDetailRepository;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("이미지가 있는 정상 요청일 때")
+        class Context_with_valid_request_with_images {
+
+            @Test
+            @DisplayName("공지를 저장하고 이미지를 저장하고 이벤트를 2회 발행한다")
+            void it_saves_notice_and_images_and_publishes_events_twice() {
+                Member admin = mock(Member.class);
+                Place place = mock(Place.class);
+                Image image = mock(Image.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(admin);
+                when(placeRepository.findById(1)).thenReturn(Optional.of(place));
+                when(noticeRepository.save(any())).thenReturn(mock(Notice.class));
+                when(imageRepository.findAllById(List.of(10L))).thenReturn(List.of(image));
+                when(memberDetailRepository.findAllByPlace(place)).thenReturn(List.of(memberDetail));
+                when(memberDetail.getId()).thenReturn(1L);
+                when(deviceTokenRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+                CreateNoticeRequest request = new CreateNoticeRequest("제목", "내용", 1, List.of(10L));
+                service.execute(request);
+
+                verify(noticeRepository).save(any());
+                verify(noticeImageRepository).saveAll(any());
+                verify(applicationEventPublisher, times(2)).publishEvent(any(Object.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("이미지가 없는 정상 요청일 때")
+        class Context_with_valid_request_without_images {
+
+            @Test
+            @DisplayName("공지를 저장하고 이미지 저장은 호출하지 않는다")
+            void it_saves_notice_without_saving_images() {
+                Member admin = mock(Member.class);
+                Place place = mock(Place.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(admin);
+                when(placeRepository.findById(1)).thenReturn(Optional.of(place));
+                when(noticeRepository.save(any())).thenReturn(mock(Notice.class));
+                when(memberDetailRepository.findAllByPlace(place)).thenReturn(List.of(memberDetail));
+                when(memberDetail.getId()).thenReturn(1L);
+                when(deviceTokenRepository.findByUserId(1L)).thenReturn(Optional.empty());
+
+                CreateNoticeRequest request = new CreateNoticeRequest("제목", "내용", 1, Collections.emptyList());
+                service.execute(request);
+
+                verify(noticeImageRepository, never()).saveAll(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("placeId에 해당하는 Place가 없을 때")
+        class Context_with_place_not_found {
+
+            @Test
+            @DisplayName("PlaceNotFoundException을 던진다")
+            void it_throws_place_not_found_exception() {
+                Member admin = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(admin);
+                when(placeRepository.findById(99)).thenReturn(Optional.empty());
+
+                CreateNoticeRequest request = new CreateNoticeRequest("제목", "내용", 99, null);
+
+                assertThatThrownBy(() -> service.execute(request))
+                        .isInstanceOf(PlaceNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("이미지 ID 개수와 실제 조회된 이미지 수가 불일치할 때")
+        class Context_with_image_count_mismatch {
+
+            @Test
+            @DisplayName("ImageNotFoundException을 던진다")
+            void it_throws_image_not_found_exception() {
+                Member admin = mock(Member.class);
+                Place place = mock(Place.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(admin);
+                when(placeRepository.findById(1)).thenReturn(Optional.of(place));
+                when(noticeRepository.save(any())).thenReturn(mock(Notice.class));
+                when(imageRepository.findAllById(List.of(10L, 20L))).thenReturn(List.of(mock(Image.class)));
+
+                CreateNoticeRequest request = new CreateNoticeRequest("제목", "내용", 1, List.of(10L, 20L));
+
+                assertThatThrownBy(() -> service.execute(request))
+                        .isInstanceOf(ImageNotFoundException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/DeleteNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/DeleteNoticeServiceImplTest.java
@@ -1,0 +1,117 @@
+package team.startup.gwangsan.domain.notice.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.notice.entity.Notice;
+import team.startup.gwangsan.domain.notice.exception.NoticeForbiddenException;
+import team.startup.gwangsan.domain.notice.exception.NoticeNotFoundException;
+import team.startup.gwangsan.domain.notice.repository.NoticeImageRepository;
+import team.startup.gwangsan.domain.notice.repository.NoticeRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteNoticeServiceImpl 단위 테스트")
+class DeleteNoticeServiceImplTest {
+
+    @InjectMocks private DeleteNoticeServiceImpl service;
+
+    @Mock private NoticeRepository noticeRepository;
+    @Mock private NoticeImageRepository noticeImageRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("작성자 본인이 삭제 요청할 때")
+        class Context_with_owner_deletes {
+
+            @Test
+            @DisplayName("공지를 삭제한다")
+            void it_deletes_notice() {
+                Member member = mock(Member.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(notice.getMember()).thenReturn(member);
+
+                service.execute(1L);
+
+                verify(noticeRepository).delete(notice);
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_HEAD_ADMIN이 타인의 공지를 삭제 요청할 때")
+        class Context_with_head_admin_deletes_others_notice {
+
+            @Test
+            @DisplayName("공지를 삭제한다")
+            void it_deletes_notice_by_head_admin() {
+                Member headAdmin = mock(Member.class);
+                Member noticeOwner = mock(Member.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(headAdmin);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(notice.getMember()).thenReturn(noticeOwner);
+                when(headAdmin.getRole()).thenReturn(MemberRole.ROLE_HEAD_ADMIN);
+
+                service.execute(1L);
+
+                verify(noticeRepository).delete(notice);
+            }
+        }
+
+        @Nested
+        @DisplayName("공지가 존재하지 않을 때")
+        class Context_with_notice_not_found {
+
+            @Test
+            @DisplayName("NoticeNotFoundException을 던진다")
+            void it_throws_notice_not_found_exception() {
+                Member member = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(99L)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(99L))
+                        .isInstanceOf(NoticeNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("본인 글도 아니고 HEAD_ADMIN도 아닐 때")
+        class Context_with_not_owner_and_not_head_admin {
+
+            @Test
+            @DisplayName("NoticeForbiddenException을 던진다")
+            void it_throws_notice_forbidden_exception() {
+                Member member = mock(Member.class);
+                Member noticeOwner = mock(Member.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(notice.getMember()).thenReturn(noticeOwner);
+                when(member.getRole()).thenReturn(MemberRole.ROLE_PLACE_ADMIN);
+
+                assertThatThrownBy(() -> service.execute(1L))
+                        .isInstanceOf(NoticeForbiddenException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/DeleteNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/DeleteNoticeServiceImplTest.java
@@ -51,6 +51,7 @@ class DeleteNoticeServiceImplTest {
 
                 service.execute(1L);
 
+                verify(noticeImageRepository).deleteAllByNotice(notice);
                 verify(noticeRepository).delete(notice);
             }
         }
@@ -73,6 +74,7 @@ class DeleteNoticeServiceImplTest {
 
                 service.execute(1L);
 
+                verify(noticeImageRepository).deleteAllByNotice(notice);
                 verify(noticeRepository).delete(notice);
             }
         }

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindAllNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindAllNoticeServiceImplTest.java
@@ -20,10 +20,13 @@ import team.startup.gwangsan.domain.place.entity.Place;
 import team.startup.gwangsan.domain.place.repository.PlaceRepository;
 import team.startup.gwangsan.global.util.MemberUtil;
 
+import team.startup.gwangsan.domain.notice.presentation.dto.response.FindAllNoticeResponse;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -63,8 +66,9 @@ class FindAllNoticeServiceImplTest {
                 when(noticeRepository.findByPlaceOrderByIdDesc(eq(place), any())).thenReturn(Collections.emptyList());
                 when(noticeImageRepository.findAllByNoticeIdIn(any())).thenReturn(Collections.emptyList());
 
-                service.execute(null, 10);
+                List<FindAllNoticeResponse> result = service.execute(null, 10);
 
+                assertThat(result).isEmpty();
                 verify(noticeRepository).findByPlaceOrderByIdDesc(eq(place), any());
                 verify(noticeRepository, never()).findByPlaceAndIdLessThanOrderByIdDesc(any(), any(), any());
             }
@@ -88,8 +92,9 @@ class FindAllNoticeServiceImplTest {
                 when(noticeRepository.findByPlaceAndIdLessThanOrderByIdDesc(eq(place), eq(5L), any())).thenReturn(Collections.emptyList());
                 when(noticeImageRepository.findAllByNoticeIdIn(any())).thenReturn(Collections.emptyList());
 
-                service.execute(5L, 10);
+                List<FindAllNoticeResponse> result = service.execute(5L, 10);
 
+                assertThat(result).isEmpty();
                 verify(noticeRepository).findByPlaceAndIdLessThanOrderByIdDesc(eq(place), eq(5L), any());
                 verify(noticeRepository, never()).findByPlaceOrderByIdDesc(any(), any());
             }
@@ -116,8 +121,9 @@ class FindAllNoticeServiceImplTest {
                 when(noticeRepository.findByPlaceInOrderByIdDesc(any(), any())).thenReturn(Collections.emptyList());
                 when(noticeImageRepository.findAllByNoticeIdIn(any())).thenReturn(Collections.emptyList());
 
-                service.execute(null, 10);
+                List<FindAllNoticeResponse> result = service.execute(null, 10);
 
+                assertThat(result).isEmpty();
                 verify(noticeRepository).findByPlaceInOrderByIdDesc(any(), any());
                 verify(noticeRepository, never()).findByPlaceInAndIdLessThanOrderByIdDesc(any(), any(), any());
             }
@@ -144,8 +150,9 @@ class FindAllNoticeServiceImplTest {
                 when(noticeRepository.findByPlaceInAndIdLessThanOrderByIdDesc(any(), eq(5L), any())).thenReturn(Collections.emptyList());
                 when(noticeImageRepository.findAllByNoticeIdIn(any())).thenReturn(Collections.emptyList());
 
-                service.execute(5L, 10);
+                List<FindAllNoticeResponse> result = service.execute(5L, 10);
 
+                assertThat(result).isEmpty();
                 verify(noticeRepository).findByPlaceInAndIdLessThanOrderByIdDesc(any(), eq(5L), any());
                 verify(noticeRepository, never()).findByPlaceInOrderByIdDesc(any(), any());
             }

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindAllNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindAllNoticeServiceImplTest.java
@@ -1,0 +1,170 @@
+package team.startup.gwangsan.domain.notice.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.notice.repository.NoticeImageRepository;
+import team.startup.gwangsan.domain.notice.repository.NoticeRepository;
+import team.startup.gwangsan.domain.place.entity.Head;
+import team.startup.gwangsan.domain.place.entity.Place;
+import team.startup.gwangsan.domain.place.repository.PlaceRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FindAllNoticeServiceImpl 단위 테스트")
+class FindAllNoticeServiceImplTest {
+
+    @InjectMocks private FindAllNoticeServiceImpl service;
+
+    @Mock private NoticeRepository noticeRepository;
+    @Mock private NoticeImageRepository noticeImageRepository;
+    @Mock private MemberDetailRepository memberDetailRepository;
+    @Mock private MemberUtil memberUtil;
+    @Mock private PlaceRepository placeRepository;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("일반 ADMIN이고 lastId가 null일 때")
+        class Context_with_admin_and_no_last_id {
+
+            @Test
+            @DisplayName("findByPlaceOrderByIdDesc를 호출한다")
+            void it_calls_find_by_place_order_by_id_desc() {
+                Member member = mock(Member.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+                Place place = mock(Place.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.of(memberDetail));
+                when(memberDetail.getPlace()).thenReturn(place);
+                when(member.getRole()).thenReturn(MemberRole.ROLE_PLACE_ADMIN);
+                when(noticeRepository.findByPlaceOrderByIdDesc(eq(place), any())).thenReturn(Collections.emptyList());
+                when(noticeImageRepository.findAllByNoticeIdIn(any())).thenReturn(Collections.emptyList());
+
+                service.execute(null, 10);
+
+                verify(noticeRepository).findByPlaceOrderByIdDesc(eq(place), any());
+                verify(noticeRepository, never()).findByPlaceAndIdLessThanOrderByIdDesc(any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("일반 ADMIN이고 lastId가 있을 때")
+        class Context_with_admin_and_last_id {
+
+            @Test
+            @DisplayName("findByPlaceAndIdLessThanOrderByIdDesc를 호출한다")
+            void it_calls_find_by_place_and_id_less_than_order_by_id_desc() {
+                Member member = mock(Member.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+                Place place = mock(Place.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.of(memberDetail));
+                when(memberDetail.getPlace()).thenReturn(place);
+                when(member.getRole()).thenReturn(MemberRole.ROLE_PLACE_ADMIN);
+                when(noticeRepository.findByPlaceAndIdLessThanOrderByIdDesc(eq(place), eq(5L), any())).thenReturn(Collections.emptyList());
+                when(noticeImageRepository.findAllByNoticeIdIn(any())).thenReturn(Collections.emptyList());
+
+                service.execute(5L, 10);
+
+                verify(noticeRepository).findByPlaceAndIdLessThanOrderByIdDesc(eq(place), eq(5L), any());
+                verify(noticeRepository, never()).findByPlaceOrderByIdDesc(any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_HEAD_ADMIN이고 lastId가 null일 때")
+        class Context_with_head_admin_and_no_last_id {
+
+            @Test
+            @DisplayName("findByPlaceInOrderByIdDesc를 호출한다")
+            void it_calls_find_by_place_in_order_by_id_desc() {
+                Member member = mock(Member.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+                Place place = mock(Place.class);
+                Head head = mock(Head.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.of(memberDetail));
+                when(memberDetail.getPlace()).thenReturn(place);
+                when(member.getRole()).thenReturn(MemberRole.ROLE_HEAD_ADMIN);
+                when(place.getHead()).thenReturn(head);
+                when(placeRepository.findByHead(head)).thenReturn(List.of(place));
+                when(noticeRepository.findByPlaceInOrderByIdDesc(any(), any())).thenReturn(Collections.emptyList());
+                when(noticeImageRepository.findAllByNoticeIdIn(any())).thenReturn(Collections.emptyList());
+
+                service.execute(null, 10);
+
+                verify(noticeRepository).findByPlaceInOrderByIdDesc(any(), any());
+                verify(noticeRepository, never()).findByPlaceInAndIdLessThanOrderByIdDesc(any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_HEAD_ADMIN이고 lastId가 있을 때")
+        class Context_with_head_admin_and_last_id {
+
+            @Test
+            @DisplayName("findByPlaceInAndIdLessThanOrderByIdDesc를 호출한다")
+            void it_calls_find_by_place_in_and_id_less_than_order_by_id_desc() {
+                Member member = mock(Member.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+                Place place = mock(Place.class);
+                Head head = mock(Head.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.of(memberDetail));
+                when(memberDetail.getPlace()).thenReturn(place);
+                when(member.getRole()).thenReturn(MemberRole.ROLE_HEAD_ADMIN);
+                when(place.getHead()).thenReturn(head);
+                when(placeRepository.findByHead(head)).thenReturn(List.of(place));
+                when(noticeRepository.findByPlaceInAndIdLessThanOrderByIdDesc(any(), eq(5L), any())).thenReturn(Collections.emptyList());
+                when(noticeImageRepository.findAllByNoticeIdIn(any())).thenReturn(Collections.emptyList());
+
+                service.execute(5L, 10);
+
+                verify(noticeRepository).findByPlaceInAndIdLessThanOrderByIdDesc(any(), eq(5L), any());
+                verify(noticeRepository, never()).findByPlaceInOrderByIdDesc(any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("MemberDetail이 없을 때")
+        class Context_with_member_detail_not_found {
+
+            @Test
+            @DisplayName("NotFoundMemberDetailException을 던진다")
+            void it_throws_not_found_member_detail_exception() {
+                Member member = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(null, 10))
+                        .isInstanceOf(NotFoundMemberDetailException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindNoticeServiceImplTest.java
@@ -134,6 +134,8 @@ class FindNoticeServiceImplTest {
                 FindNoticeResponse response = service.execute(1L);
 
                 assertThat(response).isNotNull();
+                assertThat(response.title()).isEqualTo("제목");
+                assertThat(response.content()).isEqualTo("내용");
             }
         }
 

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindNoticeServiceImplTest.java
@@ -181,5 +181,24 @@ class FindNoticeServiceImplTest {
                         .isInstanceOf(NoticeNotFoundException.class);
             }
         }
+
+        @Nested
+        @DisplayName("MemberDetail이 없을 때")
+        class Context_with_member_detail_not_found {
+
+            @Test
+            @DisplayName("NotFoundMemberDetailException을 던진다")
+            void it_throws_not_found_member_detail_exception() {
+                Member member = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+
+                Notice notice = mock(Notice.class);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(1L))
+                        .isInstanceOf(NotFoundMemberDetailException.class);
+            }
+        }
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/FindNoticeServiceImplTest.java
@@ -1,0 +1,185 @@
+package team.startup.gwangsan.domain.notice.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.notice.entity.Notice;
+import team.startup.gwangsan.domain.notice.exception.NoticeNotFoundException;
+import team.startup.gwangsan.domain.notice.presentation.dto.response.FindNoticeResponse;
+import team.startup.gwangsan.domain.notice.repository.NoticeImageRepository;
+import team.startup.gwangsan.domain.notice.repository.NoticeRepository;
+import team.startup.gwangsan.domain.place.entity.Head;
+import team.startup.gwangsan.domain.place.entity.Place;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FindNoticeServiceImpl 단위 테스트")
+class FindNoticeServiceImplTest {
+
+    @InjectMocks private FindNoticeServiceImpl service;
+
+    @Mock private NoticeRepository noticeRepository;
+    @Mock private NoticeImageRepository noticeImageRepository;
+    @Mock private MemberDetailRepository memberDetailRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("일반 ADMIN이고 자신의 Place 공지를 조회할 때")
+        class Context_with_admin_same_place {
+
+            @Test
+            @DisplayName("FindNoticeResponse를 반환한다")
+            void it_returns_find_notice_response() {
+                Member member = mock(Member.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+                Place place = mock(Place.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.of(memberDetail));
+                when(member.getRole()).thenReturn(MemberRole.ROLE_PLACE_ADMIN);
+                when(memberDetail.getPlace()).thenReturn(place);
+                when(notice.getPlace()).thenReturn(place);
+                when(noticeImageRepository.findAllByNotice(notice)).thenReturn(Collections.emptyList());
+                when(notice.getMember()).thenReturn(member);
+                when(member.getId()).thenReturn(1L);
+                when(notice.getId()).thenReturn(1L);
+                when(notice.getTitle()).thenReturn("제목");
+                when(notice.getContent()).thenReturn("내용");
+                when(place.getName()).thenReturn("광산지부");
+
+                FindNoticeResponse response = service.execute(1L);
+
+                assertThat(response).isNotNull();
+                assertThat(response.title()).isEqualTo("제목");
+            }
+        }
+
+        @Nested
+        @DisplayName("일반 ADMIN이고 다른 Place 공지를 조회할 때")
+        class Context_with_admin_different_place {
+
+            @Test
+            @DisplayName("NoticeNotFoundException을 던진다")
+            void it_throws_notice_not_found_exception() {
+                Member member = mock(Member.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+                Place myPlace = mock(Place.class);
+                Place otherPlace = mock(Place.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.of(memberDetail));
+                when(member.getRole()).thenReturn(MemberRole.ROLE_PLACE_ADMIN);
+                when(memberDetail.getPlace()).thenReturn(myPlace);
+                when(notice.getPlace()).thenReturn(otherPlace);
+
+                assertThatThrownBy(() -> service.execute(1L))
+                        .isInstanceOf(NoticeNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_HEAD_ADMIN이고 같은 HEAD 산하 공지를 조회할 때")
+        class Context_with_head_admin_same_head {
+
+            @Test
+            @DisplayName("FindNoticeResponse를 반환한다")
+            void it_returns_find_notice_response() {
+                Member member = mock(Member.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+                Place myPlace = mock(Place.class);
+                Place noticePlace = mock(Place.class);
+                Head sameHead = mock(Head.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.of(memberDetail));
+                when(member.getRole()).thenReturn(MemberRole.ROLE_HEAD_ADMIN);
+                when(memberDetail.getPlace()).thenReturn(myPlace);
+                when(myPlace.getHead()).thenReturn(sameHead);
+                when(notice.getPlace()).thenReturn(noticePlace);
+                when(noticePlace.getHead()).thenReturn(sameHead);
+                when(noticeImageRepository.findAllByNotice(notice)).thenReturn(Collections.emptyList());
+                when(notice.getMember()).thenReturn(member);
+                when(member.getId()).thenReturn(1L);
+                when(notice.getId()).thenReturn(1L);
+                when(notice.getTitle()).thenReturn("제목");
+                when(notice.getContent()).thenReturn("내용");
+                when(noticePlace.getName()).thenReturn("광산지부");
+
+                FindNoticeResponse response = service.execute(1L);
+
+                assertThat(response).isNotNull();
+            }
+        }
+
+        @Nested
+        @DisplayName("ROLE_HEAD_ADMIN이고 다른 HEAD 산하 공지를 조회할 때")
+        class Context_with_head_admin_different_head {
+
+            @Test
+            @DisplayName("NoticeNotFoundException을 던진다")
+            void it_throws_notice_not_found_exception() {
+                Member member = mock(Member.class);
+                MemberDetail memberDetail = mock(MemberDetail.class);
+                Place myPlace = mock(Place.class);
+                Place noticePlace = mock(Place.class);
+                Head myHead = mock(Head.class);
+                Head otherHead = mock(Head.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(memberDetailRepository.findByMember(member)).thenReturn(Optional.of(memberDetail));
+                when(member.getRole()).thenReturn(MemberRole.ROLE_HEAD_ADMIN);
+                when(memberDetail.getPlace()).thenReturn(myPlace);
+                when(myPlace.getHead()).thenReturn(myHead);
+                when(notice.getPlace()).thenReturn(noticePlace);
+                when(noticePlace.getHead()).thenReturn(otherHead);
+
+                assertThatThrownBy(() -> service.execute(1L))
+                        .isInstanceOf(NoticeNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("공지가 존재하지 않을 때")
+        class Context_with_notice_not_found {
+
+            @Test
+            @DisplayName("NoticeNotFoundException을 던진다")
+            void it_throws_notice_not_found_exception() {
+                Member member = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(99L)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(99L))
+                        .isInstanceOf(NoticeNotFoundException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/UpdateNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/UpdateNoticeServiceImplTest.java
@@ -1,0 +1,136 @@
+package team.startup.gwangsan.domain.notice.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.image.exception.ImageNotFoundException;
+import team.startup.gwangsan.domain.image.repository.ImageRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.notice.entity.Notice;
+import team.startup.gwangsan.domain.notice.exception.NoticeNotFoundException;
+import team.startup.gwangsan.domain.notice.exception.UnauthorizedNoticeAccessException;
+import team.startup.gwangsan.domain.notice.presentation.dto.request.UpdateNoticeRequest;
+import team.startup.gwangsan.domain.notice.repository.NoticeImageRepository;
+import team.startup.gwangsan.domain.notice.repository.NoticeRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UpdateNoticeServiceImpl 단위 테스트")
+class UpdateNoticeServiceImplTest {
+
+    @InjectMocks private UpdateNoticeServiceImpl service;
+
+    @Mock private NoticeRepository noticeRepository;
+    @Mock private ImageRepository imageRepository;
+    @Mock private NoticeImageRepository noticeImageRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("정상 수정 요청일 때")
+        class Context_with_valid_update_request {
+
+            @Test
+            @DisplayName("notice를 업데이트하고 이미지를 저장한다")
+            void it_updates_notice_and_saves_images() {
+                Member member = mock(Member.class);
+                Notice notice = mock(Notice.class);
+                Image image = mock(Image.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(notice.getMember()).thenReturn(member);
+                when(member.getId()).thenReturn(1L);
+                when(notice.getMember().getId()).thenReturn(1L);
+                when(imageRepository.findAllById(List.of(10L))).thenReturn(List.of(image));
+
+                UpdateNoticeRequest request = new UpdateNoticeRequest("새 제목", "새 내용", List.of(10L));
+                service.execute(1L, request);
+
+                verify(notice).update("새 제목", "새 내용");
+                verify(noticeImageRepository).saveAll(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("공지가 존재하지 않을 때")
+        class Context_with_notice_not_found {
+
+            @Test
+            @DisplayName("NoticeNotFoundException을 던진다")
+            void it_throws_notice_not_found_exception() {
+                Member member = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(99L)).thenReturn(Optional.empty());
+
+                UpdateNoticeRequest request = new UpdateNoticeRequest("제목", "내용", List.of());
+
+                assertThatThrownBy(() -> service.execute(99L, request))
+                        .isInstanceOf(NoticeNotFoundException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("본인이 아닌 사람이 수정 요청할 때")
+        class Context_with_not_owner {
+
+            @Test
+            @DisplayName("UnauthorizedNoticeAccessException을 던진다")
+            void it_throws_unauthorized_notice_access_exception() {
+                Member member = mock(Member.class);
+                Member noticeOwner = mock(Member.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(notice.getMember()).thenReturn(noticeOwner);
+                when(member.getId()).thenReturn(1L);
+                when(noticeOwner.getId()).thenReturn(2L);
+
+                UpdateNoticeRequest request = new UpdateNoticeRequest("제목", "내용", List.of());
+
+                assertThatThrownBy(() -> service.execute(1L, request))
+                        .isInstanceOf(UnauthorizedNoticeAccessException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("이미지 ID 개수와 실제 조회된 이미지 수가 불일치할 때")
+        class Context_with_image_count_mismatch {
+
+            @Test
+            @DisplayName("ImageNotFoundException을 던진다")
+            void it_throws_image_not_found_exception() {
+                Member member = mock(Member.class);
+                Notice notice = mock(Notice.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
+                when(notice.getMember()).thenReturn(member);
+                when(member.getId()).thenReturn(1L);
+                when(notice.getMember().getId()).thenReturn(1L);
+                when(imageRepository.findAllById(List.of(10L, 20L))).thenReturn(List.of(mock(Image.class)));
+
+                UpdateNoticeRequest request = new UpdateNoticeRequest("제목", "내용", List.of(10L, 20L));
+
+                assertThatThrownBy(() -> service.execute(1L, request))
+                        .isInstanceOf(ImageNotFoundException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/UpdateNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/UpdateNoticeServiceImplTest.java
@@ -56,13 +56,13 @@ class UpdateNoticeServiceImplTest {
                 when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
                 when(notice.getMember()).thenReturn(member);
                 when(member.getId()).thenReturn(1L);
-                when(notice.getMember().getId()).thenReturn(1L);
                 when(imageRepository.findAllById(List.of(10L))).thenReturn(List.of(image));
 
                 UpdateNoticeRequest request = new UpdateNoticeRequest("새 제목", "새 내용", List.of(10L));
                 service.execute(1L, request);
 
                 verify(notice).update("새 제목", "새 내용");
+                verify(noticeImageRepository).deleteAllByNotice(notice);
                 verify(noticeImageRepository).saveAll(any());
             }
         }
@@ -123,7 +123,6 @@ class UpdateNoticeServiceImplTest {
                 when(noticeRepository.findById(1L)).thenReturn(Optional.of(notice));
                 when(notice.getMember()).thenReturn(member);
                 when(member.getId()).thenReturn(1L);
-                when(notice.getMember().getId()).thenReturn(1L);
                 when(imageRepository.findAllById(List.of(10L, 20L))).thenReturn(List.of(mock(Image.class)));
 
                 UpdateNoticeRequest request = new UpdateNoticeRequest("제목", "내용", List.of(10L, 20L));

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImplTest.java
@@ -1,0 +1,102 @@
+package team.startup.gwangsan.domain.sms.service.impl;
+
+import net.nurigo.sdk.message.service.DefaultMessageService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.domain.sms.exception.NotRegisteredPhoneNumberException;
+import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeException;
+import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
+import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsProperties;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SendFindNicknameSmsServiceImpl 단위 테스트")
+class SendFindNicknameSmsServiceImplTest {
+
+    @InjectMocks
+    private SendFindNicknameSmsServiceImpl service;
+
+    @Mock
+    private DefaultMessageService messageService;
+
+    @Mock
+    private SmsProperties smsProperties;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RedisUtil redisUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("정상적인 요청일 때")
+        class Context_with_valid_request {
+
+            @Test
+            @DisplayName("SMS를 발송하고 인증 코드를 저장한다")
+            void it_sends_sms_and_saves_auth_code() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(true);
+                when(redisUtil.get("sms:attempt:01012345678", Integer.class)).thenReturn(0);
+                when(smsProperties.getFromNumber()).thenReturn("01000000000");
+
+                service.execute(request);
+
+                verify(messageService).sendOne(any());
+                verify(redisUtil).set(eq("sms:code:01012345678"), anyString(), anyLong());
+            }
+        }
+
+        @Nested
+        @DisplayName("미등록 전화번호일 때")
+        class Context_with_not_registered_phone_number {
+
+            @Test
+            @DisplayName("NotRegisteredPhoneNumberException을 던진다")
+            void it_throws_not_registered_phone_number_exception() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(false);
+
+                assertThrows(NotRegisteredPhoneNumberException.class,
+                        () -> service.execute(request));
+
+                verifyNoInteractions(messageService);
+            }
+        }
+
+        @Nested
+        @DisplayName("시도 횟수가 5회 이상일 때")
+        class Context_with_too_many_attempts {
+
+            @Test
+            @DisplayName("TooManyRequestAuthCodeException을 던진다")
+            void it_throws_too_many_request_auth_code_exception() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(true);
+                when(redisUtil.get("sms:attempt:01012345678", Integer.class)).thenReturn(5);
+
+                assertThrows(TooManyRequestAuthCodeException.class,
+                        () -> service.execute(request));
+
+                verifyNoInteractions(messageService);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImplTest.java
@@ -59,6 +59,7 @@ class SendFindNicknameSmsServiceImplTest {
 
                 verify(messageService).sendOne(any());
                 verify(redisUtil).set(eq("sms:code:01012345678"), anyString(), anyLong());
+                verify(redisUtil).set(eq("sms:attempt:01012345678"), eq(1), anyLong());
             }
         }
 

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendResetPasswordSmsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendResetPasswordSmsServiceImplTest.java
@@ -1,0 +1,103 @@
+package team.startup.gwangsan.domain.sms.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.domain.sms.exception.NotRegisteredPhoneNumberException;
+import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeException;
+import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
+import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsSendHelper;
+import team.startup.gwangsan.global.sms.SmsProperties;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SendResetPasswordSmsServiceImpl 단위 테스트")
+class SendResetPasswordSmsServiceImplTest {
+
+    @InjectMocks
+    private SendResetPasswordSmsServiceImpl service;
+
+    @Mock
+    private SmsSendHelper smsSendHelper;
+
+    @Mock
+    private SmsProperties smsProperties;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RedisUtil redisUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("정상적인 요청일 때")
+        class Context_with_valid_request {
+
+            @Test
+            @DisplayName("인증 정보를 저장하고 SMS를 비동기 발송한다")
+            void it_saves_auth_info_and_sends_sms_async() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(true);
+                when(redisUtil.get("sms:attempt:01012345678", Integer.class)).thenReturn(0);
+                when(smsProperties.getFromNumber()).thenReturn("01000000000");
+
+                service.execute(request);
+
+                verify(redisUtil).set(eq("sms:attempt:01012345678"), eq(1), anyLong());
+                verify(redisUtil).set(eq("sms:code:01012345678"), anyString(), anyLong());
+                verify(smsSendHelper).sendAsync(eq("01000000000"), eq("01012345678"), anyString());
+            }
+        }
+
+        @Nested
+        @DisplayName("미등록 전화번호일 때")
+        class Context_with_not_registered_phone_number {
+
+            @Test
+            @DisplayName("NotRegisteredPhoneNumberException을 던진다")
+            void it_throws_not_registered_phone_number_exception() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(false);
+
+                assertThrows(NotRegisteredPhoneNumberException.class,
+                        () -> service.execute(request));
+
+                verifyNoInteractions(smsSendHelper);
+            }
+        }
+
+        @Nested
+        @DisplayName("시도 횟수가 5회 이상일 때")
+        class Context_with_too_many_attempts {
+
+            @Test
+            @DisplayName("TooManyRequestAuthCodeException을 던진다")
+            void it_throws_too_many_request_auth_code_exception() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(true);
+                when(redisUtil.get("sms:attempt:01012345678", Integer.class)).thenReturn(5);
+
+                assertThrows(TooManyRequestAuthCodeException.class,
+                        () -> service.execute(request));
+
+                verifyNoInteractions(smsSendHelper);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendSmsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendSmsServiceImplTest.java
@@ -1,0 +1,103 @@
+package team.startup.gwangsan.domain.sms.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.domain.sms.exception.AlreadyRegisteredPhoneNumberException;
+import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeException;
+import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
+import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsSendHelper;
+import team.startup.gwangsan.global.sms.SmsProperties;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SendSmsServiceImpl 단위 테스트")
+class SendSmsServiceImplTest {
+
+    @InjectMocks
+    private SendSmsServiceImpl service;
+
+    @Mock
+    private SmsSendHelper smsSendHelper;
+
+    @Mock
+    private SmsProperties smsProperties;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private RedisUtil redisUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("정상적인 요청일 때")
+        class Context_with_valid_request {
+
+            @Test
+            @DisplayName("인증 정보를 저장하고 SMS를 비동기 발송한다")
+            void it_saves_auth_info_and_sends_sms_async() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(false);
+                when(redisUtil.get("sms:attempt:01012345678", Integer.class)).thenReturn(0);
+                when(smsProperties.getFromNumber()).thenReturn("01000000000");
+
+                service.execute(request);
+
+                verify(redisUtil).set(eq("sms:attempt:01012345678"), eq(1), anyLong());
+                verify(redisUtil).set(eq("sms:code:01012345678"), anyString(), anyLong());
+                verify(smsSendHelper).sendAsync(eq("01000000000"), eq("01012345678"), anyString());
+            }
+        }
+
+        @Nested
+        @DisplayName("이미 등록된 전화번호일 때")
+        class Context_with_already_registered_phone_number {
+
+            @Test
+            @DisplayName("AlreadyRegisteredPhoneNumberException을 던진다")
+            void it_throws_already_registered_phone_number_exception() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(true);
+
+                assertThrows(AlreadyRegisteredPhoneNumberException.class,
+                        () -> service.execute(request));
+
+                verifyNoInteractions(smsSendHelper);
+            }
+        }
+
+        @Nested
+        @DisplayName("시도 횟수가 5회 이상일 때")
+        class Context_with_too_many_attempts {
+
+            @Test
+            @DisplayName("TooManyRequestAuthCodeException을 던진다")
+            void it_throws_too_many_request_auth_code_exception() {
+                SendSmsRequest request = new SendSmsRequest("01012345678");
+
+                when(memberRepository.existsByPhoneNumber("01012345678")).thenReturn(false);
+                when(redisUtil.get("sms:attempt:01012345678", Integer.class)).thenReturn(5);
+
+                assertThrows(TooManyRequestAuthCodeException.class,
+                        () -> service.execute(request));
+
+                verifyNoInteractions(smsSendHelper);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyCodeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyCodeServiceImplTest.java
@@ -1,0 +1,99 @@
+package team.startup.gwangsan.domain.sms.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.auth.exception.SmsAuthNotFoundException;
+import team.startup.gwangsan.domain.sms.exception.NotMatchRandomCodeException;
+import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
+import team.startup.gwangsan.global.redis.RedisUtil;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VerifyCodeServiceImpl 단위 테스트")
+class VerifyCodeServiceImplTest {
+
+    @InjectMocks
+    private VerifyCodeServiceImpl service;
+
+    @Mock
+    private RedisUtil redisUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("코드가 일치할 때")
+        class Context_with_matching_code {
+
+            @Test
+            @DisplayName("인증 완료 키를 저장하고 코드 키를 삭제한다")
+            void it_saves_verified_key_and_deletes_code_key() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "123456");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn("123456");
+
+                service.execute(request);
+
+                verify(redisUtil).set(eq("sms:verified:01012345678"), eq(Boolean.TRUE), anyLong());
+                verify(redisUtil).delete("sms:code:01012345678");
+            }
+        }
+
+        @Nested
+        @DisplayName("데모 번호와 데모 코드일 때")
+        class Context_with_demo_number_and_code {
+
+            @Test
+            @DisplayName("인증 완료 키만 저장하고 코드 키는 삭제하지 않는다")
+            void it_saves_verified_key_without_deleting_code_key() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01011111111", "000000");
+
+                service.execute(request);
+
+                verify(redisUtil).set(eq("sms:verified:01011111111"), eq(Boolean.TRUE), anyLong());
+                verify(redisUtil, never()).delete(anyString());
+            }
+        }
+
+        @Nested
+        @DisplayName("코드가 만료되었을 때")
+        class Context_with_expired_code {
+
+            @Test
+            @DisplayName("SmsAuthNotFoundException을 던진다")
+            void it_throws_sms_auth_not_found_exception() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "123456");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn(null);
+
+                assertThrows(SmsAuthNotFoundException.class,
+                        () -> service.execute(request));
+            }
+        }
+
+        @Nested
+        @DisplayName("코드가 불일치할 때")
+        class Context_with_mismatched_code {
+
+            @Test
+            @DisplayName("NotMatchRandomCodeException을 던진다")
+            void it_throws_not_match_random_code_exception() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "999999");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn("123456");
+
+                assertThrows(NotMatchRandomCodeException.class,
+                        () -> service.execute(request));
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyFindNicknameCodeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyFindNicknameCodeServiceImplTest.java
@@ -1,0 +1,83 @@
+package team.startup.gwangsan.domain.sms.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.auth.exception.SmsAuthNotFoundException;
+import team.startup.gwangsan.domain.sms.exception.NotMatchRandomCodeException;
+import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
+import team.startup.gwangsan.global.redis.RedisUtil;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VerifyFindNicknameCodeServiceImpl 단위 테스트")
+class VerifyFindNicknameCodeServiceImplTest {
+
+    @InjectMocks
+    private VerifyFindNicknameCodeServiceImpl service;
+
+    @Mock
+    private RedisUtil redisUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("코드가 일치할 때")
+        class Context_with_matching_code {
+
+            @Test
+            @DisplayName("인증 완료 키를 저장하고 코드 키를 삭제한다")
+            void it_saves_verified_key_and_deletes_code_key() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "123456");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn("123456");
+
+                service.execute(request);
+
+                verify(redisUtil).set(eq("sms:verified:01012345678"), eq(Boolean.TRUE), anyLong());
+                verify(redisUtil).delete("sms:code:01012345678");
+            }
+        }
+
+        @Nested
+        @DisplayName("코드가 만료되었을 때")
+        class Context_with_expired_code {
+
+            @Test
+            @DisplayName("SmsAuthNotFoundException을 던진다")
+            void it_throws_sms_auth_not_found_exception() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "123456");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn(null);
+
+                assertThrows(SmsAuthNotFoundException.class,
+                        () -> service.execute(request));
+            }
+        }
+
+        @Nested
+        @DisplayName("코드가 불일치할 때")
+        class Context_with_mismatched_code {
+
+            @Test
+            @DisplayName("NotMatchRandomCodeException을 던진다")
+            void it_throws_not_match_random_code_exception() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "999999");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn("123456");
+
+                assertThrows(NotMatchRandomCodeException.class,
+                        () -> service.execute(request));
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyResetPasswordCodeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyResetPasswordCodeServiceImplTest.java
@@ -1,0 +1,83 @@
+package team.startup.gwangsan.domain.sms.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.auth.exception.SmsAuthNotFoundException;
+import team.startup.gwangsan.domain.sms.exception.NotMatchRandomCodeException;
+import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
+import team.startup.gwangsan.global.redis.RedisUtil;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("VerifyResetPasswordCodeServiceImpl 단위 테스트")
+class VerifyResetPasswordCodeServiceImplTest {
+
+    @InjectMocks
+    private VerifyResetPasswordCodeServiceImpl service;
+
+    @Mock
+    private RedisUtil redisUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("코드가 일치할 때")
+        class Context_with_matching_code {
+
+            @Test
+            @DisplayName("인증 완료 키를 저장하고 코드 키를 삭제한다")
+            void it_saves_verified_key_and_deletes_code_key() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "123456");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn("123456");
+
+                service.execute(request);
+
+                verify(redisUtil).set(eq("sms:verified:01012345678"), eq(Boolean.TRUE), anyLong());
+                verify(redisUtil).delete("sms:code:01012345678");
+            }
+        }
+
+        @Nested
+        @DisplayName("코드가 만료되었을 때")
+        class Context_with_expired_code {
+
+            @Test
+            @DisplayName("SmsAuthNotFoundException을 던진다")
+            void it_throws_sms_auth_not_found_exception() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "123456");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn(null);
+
+                assertThrows(SmsAuthNotFoundException.class,
+                        () -> service.execute(request));
+            }
+        }
+
+        @Nested
+        @DisplayName("코드가 불일치할 때")
+        class Context_with_mismatched_code {
+
+            @Test
+            @DisplayName("NotMatchRandomCodeException을 던진다")
+            void it_throws_not_match_random_code_exception() {
+                VerifyCodeRequest request = new VerifyCodeRequest("01012345678", "999999");
+
+                when(redisUtil.get("sms:code:01012345678", String.class)).thenReturn("123456");
+
+                assertThrows(NotMatchRandomCodeException.class,
+                        () -> service.execute(request));
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/suspend/service/impl/SuspendMemberServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/suspend/service/impl/SuspendMemberServiceImplTest.java
@@ -1,0 +1,129 @@
+package team.startup.gwangsan.domain.suspend.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangsan.domain.admin.repository.AdminAlertRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.domain.suspend.entity.Suspend;
+import team.startup.gwangsan.domain.suspend.repository.SuspendRepository;
+import team.startup.gwangsan.global.event.CreateAlertEvent;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SuspendMemberServiceImpl 단위 테스트")
+class SuspendMemberServiceImplTest {
+
+    @InjectMocks
+    private SuspendMemberServiceImpl service;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private SuspendRepository suspendRepository;
+
+    @Mock
+    private AdminAlertRepository adminAlertRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("alertId가 있고 AdminAlert이 존재하지 않을 때")
+        class Context_with_alert_id_and_no_admin_alert {
+
+            @Test
+            @DisplayName("정지 처리 후 이벤트를 발행한다")
+            void it_suspends_member_and_publishes_event() {
+                Member member = mock(Member.class);
+                Suspend savedSuspend = mock(Suspend.class);
+                when(savedSuspend.getId()).thenReturn(10L);
+
+                when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+                when(suspendRepository.save(any(Suspend.class))).thenReturn(savedSuspend);
+                when(adminAlertRepository.existsById(5L)).thenReturn(false);
+
+                service.execute(1L, 7, 5L);
+
+                verify(suspendRepository).save(any(Suspend.class));
+                verify(member).updateMemberStatus(MemberStatus.SUSPENDED);
+                verify(applicationEventPublisher).publishEvent(any(CreateAlertEvent.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("alertId가 null일 때")
+        class Context_with_null_alert_id {
+
+            @Test
+            @DisplayName("정지 처리만 수행하고 이벤트를 발행하지 않는다")
+            void it_suspends_member_without_publishing_event() {
+                Member member = mock(Member.class);
+                Suspend savedSuspend = mock(Suspend.class);
+
+                when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+                when(suspendRepository.save(any(Suspend.class))).thenReturn(savedSuspend);
+
+                service.execute(1L, 7, null);
+
+                verify(suspendRepository).save(any(Suspend.class));
+                verify(member).updateMemberStatus(MemberStatus.SUSPENDED);
+                verify(applicationEventPublisher, never()).publishEvent(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("alertId가 있지만 AdminAlert이 이미 존재할 때")
+        class Context_with_alert_id_and_existing_admin_alert {
+
+            @Test
+            @DisplayName("정지 처리만 수행하고 이벤트를 발행하지 않는다")
+            void it_suspends_member_without_publishing_event() {
+                Member member = mock(Member.class);
+                Suspend savedSuspend = mock(Suspend.class);
+
+                when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+                when(suspendRepository.save(any(Suspend.class))).thenReturn(savedSuspend);
+                when(adminAlertRepository.existsById(5L)).thenReturn(true);
+
+                service.execute(1L, 7, 5L);
+
+                verify(suspendRepository).save(any(Suspend.class));
+                verify(member).updateMemberStatus(MemberStatus.SUSPENDED);
+                verify(applicationEventPublisher, never()).publishEvent(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("멤버가 존재하지 않을 때")
+        class Context_with_member_not_found {
+
+            @Test
+            @DisplayName("NotFoundMemberException을 던진다")
+            void it_throws_not_found_member_exception() {
+                when(memberRepository.findById(99L)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(99L, 7, 5L))
+                        .isInstanceOf(NotFoundMemberException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImplTest.java
@@ -1,0 +1,167 @@
+package team.startup.gwangsan.domain.trade.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.image.repository.ImageRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.trade.entity.TradeCancel;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.exception.AlreadyTradeCancelRequestException;
+import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCompleteException;
+import team.startup.gwangsan.domain.trade.exception.TradeParticipantOnlyException;
+import team.startup.gwangsan.domain.trade.repository.TradeCancelImageRepository;
+import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeCancelServiceImpl 단위 테스트")
+class TradeCancelServiceImplTest {
+
+    @InjectMocks private TradeCancelServiceImpl service;
+
+    @Mock private MemberUtil memberUtil;
+    @Mock private TradeCompleteRepository tradeCompleteRepository;
+    @Mock private TradeCancelRepository tradeCancelRepository;
+    @Mock private ImageRepository imageRepository;
+    @Mock private TradeCancelImageRepository tradeCancelImageRepository;
+    @Mock private ApplicationEventPublisher applicationEventPublisher;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("정상 요청일 때")
+        class Context_with_valid_request {
+
+            @Test
+            @DisplayName("취소 요청을 저장하고 이벤트를 발행한다")
+            void it_saves_trade_cancel_and_publishes_event() {
+                Member member = mock(Member.class);
+                when(member.getId()).thenReturn(1L);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+
+                Member buyer = mock(Member.class);
+                when(buyer.getId()).thenReturn(1L);
+                Member seller = mock(Member.class);
+                when(seller.getId()).thenReturn(2L);
+
+                TradeComplete tradeComplete = mock(TradeComplete.class);
+                when(tradeComplete.getId()).thenReturn(10L);
+                when(tradeComplete.getBuyer()).thenReturn(buyer);
+                when(tradeComplete.getSeller()).thenReturn(seller);
+
+                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(tradeComplete));
+                when(tradeCancelRepository.existsByTradeCompleteIdAndStatus(10L, TradeCancelStatus.PENDING))
+                        .thenReturn(false);
+
+                TradeCancel savedCancel = mock(TradeCancel.class);
+                when(savedCancel.getId()).thenReturn(20L);
+                when(tradeCancelRepository.save(any())).thenReturn(savedCancel);
+
+                Image image = mock(Image.class);
+                when(imageRepository.findAllById(List.of(5L))).thenReturn(List.of(image));
+
+                service.execute(100L, "이유", List.of(5L));
+
+                verify(tradeCancelRepository).save(any());
+                verify(tradeCancelImageRepository).saveAll(any());
+                verify(applicationEventPublisher).publishEvent(any(Object.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("거래 완료 내역이 없을 때")
+        class Context_with_trade_complete_not_found {
+
+            @Test
+            @DisplayName("NotFoundTradeCompleteException을 던진다")
+            void it_throws_not_found_trade_complete_exception() {
+                Member member = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(tradeCompleteRepository.findByProductIdAndStatus(99L, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(99L, "이유", List.of()))
+                        .isInstanceOf(NotFoundTradeCompleteException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("거래에 참여하지 않은 제3자가 취소 요청 시")
+        class Context_with_non_participant {
+
+            @Test
+            @DisplayName("TradeParticipantOnlyException을 던진다")
+            void it_throws_trade_participant_only_exception() {
+                Member member = mock(Member.class);
+                when(member.getId()).thenReturn(99L);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+
+                Member buyer = mock(Member.class);
+                when(buyer.getId()).thenReturn(1L);
+                Member seller = mock(Member.class);
+                when(seller.getId()).thenReturn(2L);
+
+                TradeComplete tradeComplete = mock(TradeComplete.class);
+                when(tradeComplete.getBuyer()).thenReturn(buyer);
+                when(tradeComplete.getSeller()).thenReturn(seller);
+
+                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(tradeComplete));
+
+                assertThatThrownBy(() -> service.execute(100L, "이유", List.of()))
+                        .isInstanceOf(TradeParticipantOnlyException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("이미 취소 요청이 있을 때")
+        class Context_with_already_requested {
+
+            @Test
+            @DisplayName("AlreadyTradeCancelRequestException을 던진다")
+            void it_throws_already_trade_cancel_request_exception() {
+                Member member = mock(Member.class);
+                when(member.getId()).thenReturn(1L);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+
+                Member buyer = mock(Member.class);
+                when(buyer.getId()).thenReturn(1L);
+                Member seller = mock(Member.class);
+                when(seller.getId()).thenReturn(2L);
+
+                TradeComplete tradeComplete = mock(TradeComplete.class);
+                when(tradeComplete.getId()).thenReturn(10L);
+                when(tradeComplete.getBuyer()).thenReturn(buyer);
+                when(tradeComplete.getSeller()).thenReturn(seller);
+
+                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(tradeComplete));
+                when(tradeCancelRepository.existsByTradeCompleteIdAndStatus(10L, TradeCancelStatus.PENDING))
+                        .thenReturn(true);
+
+                assertThatThrownBy(() -> service.execute(100L, "이유", List.of()))
+                        .isInstanceOf(AlreadyTradeCancelRequestException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImplTest.java
@@ -61,13 +61,10 @@ class TradeCancelServiceImplTest {
 
                 Member buyer = mock(Member.class);
                 when(buyer.getId()).thenReturn(1L);
-                Member seller = mock(Member.class);
-                when(seller.getId()).thenReturn(2L);
 
                 TradeComplete tradeComplete = mock(TradeComplete.class);
                 when(tradeComplete.getId()).thenReturn(10L);
                 when(tradeComplete.getBuyer()).thenReturn(buyer);
-                when(tradeComplete.getSeller()).thenReturn(seller);
 
                 when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(tradeComplete));
@@ -147,13 +144,10 @@ class TradeCancelServiceImplTest {
 
                 Member buyer = mock(Member.class);
                 when(buyer.getId()).thenReturn(1L);
-                Member seller = mock(Member.class);
-                when(seller.getId()).thenReturn(2L);
 
                 TradeComplete tradeComplete = mock(TradeComplete.class);
                 when(tradeComplete.getId()).thenReturn(10L);
                 when(tradeComplete.getBuyer()).thenReturn(buyer);
-                when(tradeComplete.getSeller()).thenReturn(seller);
 
                 when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(tradeComplete));

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImplTest.java
@@ -8,6 +8,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangsan.global.event.CreateAdminAlertEvent;
 import team.startup.gwangsan.domain.image.entity.Image;
 import team.startup.gwangsan.domain.image.repository.ImageRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
@@ -84,7 +85,7 @@ class TradeCancelServiceImplTest {
 
                 verify(tradeCancelRepository).save(any());
                 verify(tradeCancelImageRepository).saveAll(any());
-                verify(applicationEventPublisher).publishEvent(any(Object.class));
+                verify(applicationEventPublisher).publishEvent(any(CreateAdminAlertEvent.class));
             }
         }
 

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImplTest.java
@@ -1,0 +1,143 @@
+package team.startup.gwangsan.domain.trade.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.trade.entity.TradeCancel;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCancelException;
+import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCompleteException;
+import team.startup.gwangsan.domain.trade.exception.NotTradeCancelRequesterException;
+import team.startup.gwangsan.domain.trade.repository.TradeCancelImageRepository;
+import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeCancelWithdrawServiceImpl 단위 테스트")
+class TradeCancelWithdrawServiceImplTest {
+
+    @InjectMocks private TradeCancelWithdrawServiceImpl service;
+
+    @Mock private MemberUtil memberUtil;
+    @Mock private TradeCompleteRepository tradeCompleteRepository;
+    @Mock private TradeCancelRepository tradeCancelRepository;
+    @Mock private TradeCancelImageRepository tradeCancelImageRepository;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("취소 요청자 본인이 철회 시도 시")
+        class Context_with_valid_request {
+
+            @Test
+            @DisplayName("취소 상태를 WITHDRAWN으로 변경하고 이미지를 삭제한다")
+            void it_withdraws_trade_cancel() {
+                Member member = mock(Member.class);
+                when(member.getId()).thenReturn(1L);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+
+                TradeComplete tradeComplete = mock(TradeComplete.class);
+                when(tradeComplete.getId()).thenReturn(10L);
+                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(tradeComplete));
+
+                Member requester = mock(Member.class);
+                when(requester.getId()).thenReturn(1L);
+
+                TradeCancel tradeCancel = mock(TradeCancel.class);
+                when(tradeCancel.getId()).thenReturn(20L);
+                when(tradeCancel.getMember()).thenReturn(requester);
+                when(tradeCancelRepository.findByTradeCompleteIdAndStatus(10L, TradeCancelStatus.PENDING))
+                        .thenReturn(Optional.of(tradeCancel));
+
+                service.execute(100L);
+
+                verify(tradeCancel).updateStatus(TradeCancelStatus.WITHDRAWN);
+                verify(tradeCancelImageRepository).deleteByTradeCancelId(20L);
+            }
+        }
+
+        @Nested
+        @DisplayName("거래 완료 내역이 없을 때")
+        class Context_with_trade_complete_not_found {
+
+            @Test
+            @DisplayName("NotFoundTradeCompleteException을 던진다")
+            void it_throws_not_found_trade_complete_exception() {
+                Member member = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(tradeCompleteRepository.findByProductIdAndStatus(99L, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(99L))
+                        .isInstanceOf(NotFoundTradeCompleteException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("취소 요청 내역이 없을 때")
+        class Context_with_trade_cancel_not_found {
+
+            @Test
+            @DisplayName("NotFoundTradeCancelException을 던진다")
+            void it_throws_not_found_trade_cancel_exception() {
+                Member member = mock(Member.class);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+
+                TradeComplete tradeComplete = mock(TradeComplete.class);
+                when(tradeComplete.getId()).thenReturn(10L);
+                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(tradeComplete));
+                when(tradeCancelRepository.findByTradeCompleteIdAndStatus(10L, TradeCancelStatus.PENDING))
+                        .thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(100L))
+                        .isInstanceOf(NotFoundTradeCancelException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("취소 요청자가 아닌 제3자가 철회 시도 시")
+        class Context_with_non_requester_withdraws {
+
+            @Test
+            @DisplayName("NotTradeCancelRequesterException을 던진다")
+            void it_throws_not_trade_cancel_requester_exception() {
+                Member member = mock(Member.class);
+                when(member.getId()).thenReturn(1L);
+                when(memberUtil.getCurrentMember()).thenReturn(member);
+
+                TradeComplete tradeComplete = mock(TradeComplete.class);
+                when(tradeComplete.getId()).thenReturn(10L);
+                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(tradeComplete));
+
+                Member requester = mock(Member.class);
+                when(requester.getId()).thenReturn(2L);
+
+                TradeCancel tradeCancel = mock(TradeCancel.class);
+                when(tradeCancel.getMember()).thenReturn(requester);
+                when(tradeCancelRepository.findByTradeCompleteIdAndStatus(10L, TradeCancelStatus.PENDING))
+                        .thenReturn(Optional.of(tradeCancel));
+
+                assertThatThrownBy(() -> service.execute(100L))
+                        .isInstanceOf(NotTradeCancelRequesterException.class);
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
@@ -40,7 +40,7 @@ class TradeHistoryByHeadServiceImplTest {
             @Test
             @DisplayName("지점별 거래 건수를 반환한다")
             void it_returns_trade_history_by_head() {
-                when(tradeCompleteRepository.countByHeadId(eq(7), any(), eq(1)))
+                when(tradeCompleteRepository.countByHeadId(eq(Period.WEEK.getValue()), any(), eq(1)))
                         .thenReturn(Map.of(10, 5L, 11, 3L));
 
                 Place place1 = mock(Place.class);

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
@@ -66,7 +66,7 @@ class TradeHistoryByHeadServiceImplTest {
             @Test
             @DisplayName("빈 리스트를 반환한다")
             void it_returns_empty_list() {
-                when(tradeCompleteRepository.countByHeadId(eq(1), any(), eq(1)))
+                when(tradeCompleteRepository.countByHeadId(eq(Period.DAY.getValue()), any(), eq(1)))
                         .thenReturn(Map.of());
                 when(placeRepository.findAllById(any())).thenReturn(List.of());
 

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
@@ -1,0 +1,79 @@
+package team.startup.gwangsan.domain.trade.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.place.entity.Place;
+import team.startup.gwangsan.domain.place.repository.PlaceRepository;
+import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.HeadTradeHistoryResponse;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeHistoryByHeadServiceImpl 단위 테스트")
+class TradeHistoryByHeadServiceImplTest {
+
+    @InjectMocks private TradeHistoryByHeadServiceImpl service;
+
+    @Mock private TradeCompleteRepository tradeCompleteRepository;
+    @Mock private PlaceRepository placeRepository;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("거래 내역이 있을 때")
+        class Context_with_history {
+
+            @Test
+            @DisplayName("지점별 거래 건수를 반환한다")
+            void it_returns_trade_history_by_head() {
+                when(tradeCompleteRepository.countByHeadId(eq(7), any(), eq(1)))
+                        .thenReturn(Map.of(10, 5L, 11, 3L));
+
+                Place place1 = mock(Place.class);
+                when(place1.getId()).thenReturn(10);
+                when(place1.getName()).thenReturn("수완지점");
+
+                Place place2 = mock(Place.class);
+                when(place2.getId()).thenReturn(11);
+                when(place2.getName()).thenReturn("하남지점");
+
+                when(placeRepository.findAllById(any())).thenReturn(List.of(place1, place2));
+
+                List<HeadTradeHistoryResponse> result = service.execute(Period.WEEK, 1);
+
+                assertThat(result).hasSize(2);
+            }
+        }
+
+        @Nested
+        @DisplayName("거래 내역이 없을 때")
+        class Context_with_no_history {
+
+            @Test
+            @DisplayName("빈 리스트를 반환한다")
+            void it_returns_empty_list() {
+                when(tradeCompleteRepository.countByHeadId(eq(1), any(), eq(1)))
+                        .thenReturn(Map.of());
+                when(placeRepository.findAllById(any())).thenReturn(List.of());
+
+                List<HeadTradeHistoryResponse> result = service.execute(Period.DAY, 1);
+
+                assertThat(result).isEmpty();
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
@@ -1,0 +1,55 @@
+package team.startup.gwangsan.domain.trade.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.PlaceTradeHistoryResponse;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeHistoryByPlaceServiceImpl 단위 테스트")
+class TradeHistoryByPlaceServiceImplTest {
+
+    @InjectMocks private TradeHistoryByPlaceServiceImpl service;
+
+    @Mock private TradeCompleteRepository tradeCompleteRepository;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("지점 거래 건수를 반환한다")
+        void it_returns_trade_count_by_place() {
+            when(tradeCompleteRepository.countByPlaceId(eq(30), any(), eq(5))).thenReturn(12L);
+
+            PlaceTradeHistoryResponse result = service.execute(Period.MONTH, 5);
+
+            assertThat(result.count()).isEqualTo(12L);
+        }
+    }
+
+    @Nested
+    @DisplayName("거래 내역이 없을 때")
+    class Context_with_no_history {
+
+        @Test
+        @DisplayName("count가 0인 응답을 반환한다")
+        void it_returns_zero_count() {
+            when(tradeCompleteRepository.countByPlaceId(anyInt(), any(), anyInt())).thenReturn(0L);
+
+            PlaceTradeHistoryResponse result = service.execute(Period.WEEK, 5);
+
+            assertThat(result.count()).isEqualTo(0L);
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
@@ -34,7 +34,7 @@ class TradeHistoryByPlaceServiceImplTest {
             @Test
             @DisplayName("지점 거래 건수를 반환한다")
             void it_returns_trade_count_by_place() {
-                when(tradeCompleteRepository.countByPlaceId(eq(30), any(), eq(5))).thenReturn(12L);
+                when(tradeCompleteRepository.countByPlaceId(eq(Period.MONTH.getValue()), any(), eq(5))).thenReturn(12L);
 
                 PlaceTradeHistoryResponse result = service.execute(Period.MONTH, 5);
 

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
@@ -49,7 +49,7 @@ class TradeHistoryByPlaceServiceImplTest {
             @Test
             @DisplayName("count가 0인 응답을 반환한다")
             void it_returns_zero_count() {
-                when(tradeCompleteRepository.countByPlaceId(anyInt(), any(), anyInt())).thenReturn(0L);
+                when(tradeCompleteRepository.countByPlaceId(eq(Period.WEEK.getValue()), any(), eq(5))).thenReturn(0L);
 
                 PlaceTradeHistoryResponse result = service.execute(Period.WEEK, 5);
 

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
@@ -27,29 +27,34 @@ class TradeHistoryByPlaceServiceImplTest {
     @DisplayName("execute() 메서드는")
     class Describe_execute {
 
-        @Test
-        @DisplayName("지점 거래 건수를 반환한다")
-        void it_returns_trade_count_by_place() {
-            when(tradeCompleteRepository.countByPlaceId(eq(30), any(), eq(5))).thenReturn(12L);
+        @Nested
+        @DisplayName("거래 내역이 있을 때")
+        class Context_with_history {
 
-            PlaceTradeHistoryResponse result = service.execute(Period.MONTH, 5);
+            @Test
+            @DisplayName("지점 거래 건수를 반환한다")
+            void it_returns_trade_count_by_place() {
+                when(tradeCompleteRepository.countByPlaceId(eq(30), any(), eq(5))).thenReturn(12L);
 
-            assertThat(result.count()).isEqualTo(12L);
+                PlaceTradeHistoryResponse result = service.execute(Period.MONTH, 5);
+
+                assertThat(result.count()).isEqualTo(12L);
+            }
         }
-    }
 
-    @Nested
-    @DisplayName("거래 내역이 없을 때")
-    class Context_with_no_history {
+        @Nested
+        @DisplayName("거래 내역이 없을 때")
+        class Context_with_no_history {
 
-        @Test
-        @DisplayName("count가 0인 응답을 반환한다")
-        void it_returns_zero_count() {
-            when(tradeCompleteRepository.countByPlaceId(anyInt(), any(), anyInt())).thenReturn(0L);
+            @Test
+            @DisplayName("count가 0인 응답을 반환한다")
+            void it_returns_zero_count() {
+                when(tradeCompleteRepository.countByPlaceId(anyInt(), any(), anyInt())).thenReturn(0L);
 
-            PlaceTradeHistoryResponse result = service.execute(Period.WEEK, 5);
+                PlaceTradeHistoryResponse result = service.execute(Period.WEEK, 5);
 
-            assertThat(result.count()).isEqualTo(0L);
+                assertThat(result.count()).isEqualTo(0L);
+            }
         }
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

이슈 #285에서 요구하는 도메인 별 단위 테스트를 추가하였습니다.  
커버리지 기준 60% 이상 달성을 목표로 trade, notice, suspend, sms 4개 도메인에 Mockito 기반 단위 테스트를 작성하였습니다.

Resolves: #285

## 📃 작업내용

**trade**
- `TradeCancelServiceImplTest` — 취소 요청 저장 및 이벤트 발행, 거래 내역 없음, 참여자 아님, 이미 요청됨
- `TradeCancelWithdrawServiceImplTest` — 취소 철회 정상 처리, 거래 내역 없음, 취소 요청 없음, 요청자 아님
- `TradeHistoryByPlaceServiceImplTest` — 거래 건수 정상 반환, count 0 반환

**notice**
- `CreateNoticeServiceImplTest` — 이미지 유/무, 장소 없음, 이미지 ID 불일치
- `DeleteNoticeServiceImplTest` — 본인 삭제, HEAD_ADMIN 삭제, 공지 없음, 권한 없음
- `FindAllNoticeServiceImplTest` — ADMIN 커서 페이징(lastId null/있음), HEAD_ADMIN 전체 조회, MemberDetail 없음
- `FindNoticeServiceImplTest` — ADMIN/HEAD_ADMIN 접근 제어, 공지 없음, MemberDetail 없음
- `UpdateNoticeServiceImplTest` — 정상 수정, 공지 없음, 권한 없음, 이미지 ID 불일치

**suspend**
- `SuspendMemberServiceImplTest` — alertId 있음(AdminAlert 없음 → 이벤트 발행), alertId null, AdminAlert 이미 존재, 멤버 없음

**sms**
- `SendSmsServiceImplTest` — 정상 발송, 이미 등록된 번호, 5회 초과
- `SendResetPasswordSmsServiceImplTest` — 정상 발송, 미등록 번호, 5회 초과
- `SendFindNicknameSmsServiceImplTest` — 정상 발송, 미등록 번호, 5회 초과
- `VerifyCodeServiceImplTest` — 정상 인증, 데모 번호(01011111111+000000), 코드 없음, 코드 불일치
- `VerifyResetPasswordCodeServiceImplTest` — 정상 인증, 코드 없음, 코드 불일치
- `VerifyFindNicknameCodeServiceImplTest` — 정상 인증, 코드 없음, 코드 불일치

## 🙋‍♂️ 리뷰노트

- 모든 테스트는 `@ExtendWith(MockitoExtension.class)` + `@Nested` + `@DisplayName` 프로젝트 컨벤션을 준수하였습니다
- 이벤트 검증은 `any(Object.class)` 대신 `any(CreateAdminAlertEvent.class)` 등 구체 타입으로 강화하였습니다
- SMS 데모 번호(`01011111111` + `000000`) 케이스를 별도로 추가하였습니다

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
