### PR TITLE
채팅 서버 거래 상태 알림 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
@@ -38,7 +38,9 @@ import team.startup.gwangsan.domain.post.service.RequestTradeCompleteService;
 import team.startup.gwangsan.global.aop.CheckBlocked;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
 import team.startup.gwangsan.global.event.SendNotificationEvent;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -83,9 +85,9 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
         validateChatExists(chatRoom, member.getId());
 
         if (isBuyer) {
-            handleBuyerTradeCompletion(product, buyerDetail, sellerDetail, reservation);
+            handleBuyerTradeCompletion(chatRoom, product, buyerDetail, sellerDetail, reservation);
         } else {
-            handleSellerTradeCompletion(product, sellerDetail.getMember(), buyerDetail.getMember());
+            handleSellerTradeCompletion(chatRoom, product, sellerDetail.getMember(), buyerDetail.getMember());
         }
 
     }
@@ -140,7 +142,7 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
         return reservation;
     }
 
-    private void handleBuyerTradeCompletion(Product product, MemberDetail buyerDetail, MemberDetail sellerDetail, ProductReservation reservation) {
+    private void handleBuyerTradeCompletion(ChatRoom chatRoom, Product product, MemberDetail buyerDetail, MemberDetail sellerDetail, ProductReservation reservation) {
         TradeComplete pending = tradeCompleteRepository
                 .findByProductAndBuyerAndSellerAndStatus(
                         product, buyerDetail.getMember(), sellerDetail.getMember(), TradeStatus.PENDING)
@@ -176,9 +178,16 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
                 NotificationType.TRADE_COMPLETE,
                 product.getId()
         ));
+
+        applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                chatRoom.getId(),
+                product.getId(),
+                true,
+                pending.getCompletedAt() != null ? pending.getCompletedAt() : LocalDateTime.now()
+        ));
     }
 
-    private void handleSellerTradeCompletion(Product product, Member seller, Member buyer) {
+    private void handleSellerTradeCompletion(ChatRoom chatRoom, Product product, Member seller, Member buyer) {
         boolean existsTradeComplete = tradeCompleteRepository
                 .existsByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING);
 
@@ -198,6 +207,13 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
                 newTradeComplete.getId(),
                 newTradeComplete.getBuyer().getId(),
                 AlertType.OTHER_MEMBER_TRADE_COMPLETE
+        ));
+
+        applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                chatRoom.getId(),
+                product.getId(),
+                false,
+                newTradeComplete.getCreatedAt() != null ? newTradeComplete.getCreatedAt() : LocalDateTime.now()
         ));
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
@@ -179,11 +179,12 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
                 product.getId()
         ));
 
+        LocalDateTime changedAt = LocalDateTime.now();
         applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
                 chatRoom.getId(),
                 product.getId(),
                 true,
-                pending.getCompletedAt() != null ? pending.getCompletedAt() : LocalDateTime.now()
+                changedAt
         ));
     }
 
@@ -209,11 +210,12 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
                 AlertType.OTHER_MEMBER_TRADE_COMPLETE
         ));
 
+        LocalDateTime changedAt = LocalDateTime.now();
         applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
                 chatRoom.getId(),
                 product.getId(),
                 false,
-                newTradeComplete.getCreatedAt() != null ? newTradeComplete.getCreatedAt() : LocalDateTime.now()
+                changedAt
         ));
     }
 }

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerProperties.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerProperties.java
@@ -1,0 +1,13 @@
+package team.startup.gwangsan.global.chat.notification;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "chatting.server")
+public record ChattingServerProperties(
+        String url,
+        String internalSecret
+) {
+    public boolean isEnabled() {
+        return url != null && !url.isBlank();
+    }
+}

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifier.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifier.java
@@ -1,0 +1,7 @@
+package team.startup.gwangsan.global.chat.notification;
+
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+public interface ChattingServerTradeStatusNotifier {
+    void notifyTradeStatusChanged(TradeStatusChangedEvent event);
+}

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
@@ -1,6 +1,5 @@
 package team.startup.gwangsan.global.chat.notification;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
@@ -9,25 +8,26 @@ import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import java.time.LocalDateTime;
 
 @Component
-@RequiredArgsConstructor
 public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTradeStatusNotifier {
 
     private static final String INTERNAL_SECRET_HEADER = "X-Internal-Secret";
     private static final String TRADE_STATUS_PATH = "/internal/trade-status";
 
     private final ChattingServerProperties properties;
-    private final RestClient.Builder restClientBuilder;
+    private final RestClient restClient;
+
+    public ChattingServerTradeStatusNotifierImpl(ChattingServerProperties properties, RestClient.Builder restClientBuilder) {
+        this.properties = properties;
+        this.restClient = properties.isEnabled() ? restClientBuilder.baseUrl(properties.url()).build() : null;
+    }
 
     @Override
     public void notifyTradeStatusChanged(TradeStatusChangedEvent event) {
-        if (!properties.isEnabled()) {
+        if (restClient == null) {
             return;
         }
 
-        restClientBuilder
-                .baseUrl(properties.url())
-                .build()
-                .post()
+        restClient.post()
                 .uri(TRADE_STATUS_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(INTERNAL_SECRET_HEADER, properties.internalSecret())

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
@@ -1,0 +1,51 @@
+package team.startup.gwangsan.global.chat.notification;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTradeStatusNotifier {
+
+    private static final String INTERNAL_SECRET_HEADER = "X-Internal-Secret";
+    private static final String TRADE_STATUS_PATH = "/internal/trade-status";
+
+    private final ChattingServerProperties properties;
+    private final RestClient.Builder restClientBuilder;
+
+    @Override
+    public void notifyTradeStatusChanged(TradeStatusChangedEvent event) {
+        if (!properties.isEnabled()) {
+            return;
+        }
+
+        restClientBuilder
+                .baseUrl(properties.url())
+                .build()
+                .post()
+                .uri(TRADE_STATUS_PATH)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header(INTERNAL_SECRET_HEADER, properties.internalSecret())
+                .body(new TradeStatusChangedRequest(
+                        event.roomId(),
+                        event.productId(),
+                        event.completed(),
+                        event.changedAt()
+                ))
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    private record TradeStatusChangedRequest(
+            Long roomId,
+            Long productId,
+            boolean isCompleted,
+            LocalDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/team/startup/gwangsan/global/event/TradeStatusChangedEvent.java
+++ b/src/main/java/team/startup/gwangsan/global/event/TradeStatusChangedEvent.java
@@ -1,0 +1,11 @@
+package team.startup.gwangsan.global.event;
+
+import java.time.LocalDateTime;
+
+public record TradeStatusChangedEvent(
+        Long roomId,
+        Long productId,
+        boolean completed,
+        LocalDateTime changedAt
+) {
+}

--- a/src/main/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListener.java
+++ b/src/main/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListener.java
@@ -1,0 +1,34 @@
+package team.startup.gwangsan.global.event.handler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import team.startup.gwangsan.global.chat.notification.ChattingServerTradeStatusNotifier;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TradeStatusChangedEventListener {
+
+    private final ChattingServerTradeStatusNotifier notifier;
+
+    @Async("asyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleTradeStatusChangedEvent(TradeStatusChangedEvent event) {
+        try {
+            notifier.notifyTradeStatusChanged(event);
+        } catch (Exception e) {
+            log.warn(
+                    "Failed to notify chatting server of trade status change. roomId={}, productId={}, completed={}",
+                    event.roomId(),
+                    event.productId(),
+                    event.completed(),
+                    e
+            );
+        }
+    }
+}

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -44,3 +44,8 @@ chat:
     retryMax: 5
     retryKey: chat:retry:messages
     dlqKey: chat:dlq:messages
+
+chatting:
+  server:
+    url: ""
+    internal-secret: ""

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -66,3 +66,7 @@ chat:
     retryKey: ${CHAT_STREAM_RETRY_KEY:chat:retry:messages}
     dlqKey: ${CHAT_STREAM_DLQ_KEY:chat:dlq:messages}
 
+chatting:
+  server:
+    url: ${CHATTING_SERVER_URL:}
+    internal-secret: ${CHATTING_SERVER_INTERNAL_SECRET:}

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
@@ -2,6 +2,7 @@ package team.startup.gwangsan.domain.post.service.impl;
 
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -33,11 +34,15 @@ import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
 import team.startup.gwangsan.domain.trade.exception.*;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -314,6 +319,7 @@ class RequestTradeCompleteServiceImplTest {
             when(reservation.getReserver()).thenReturn(buyerMember);
 
             ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.getId()).thenReturn(300L);
             when(chatRoomRepository.findByProductIdAndBuyerAndSeller(
                     productId,
                     buyerMember,
@@ -344,6 +350,7 @@ class RequestTradeCompleteServiceImplTest {
             verify(pending).updateStatus(TradeStatus.COMPLETED);
             verify(pending).updateCompletedAt();
             verify(reservation).complete();
+            verifyTradeStatusChangedEvent(300L, productId, true);
         }
 
         @Test
@@ -375,6 +382,7 @@ class RequestTradeCompleteServiceImplTest {
                     .thenReturn(Optional.of(product));
 
             ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.getId()).thenReturn(300L);
             when(chatRoomRepository.findByProductIdAndBuyerAndSeller(
                     productId,
                     buyerMember,
@@ -403,6 +411,7 @@ class RequestTradeCompleteServiceImplTest {
 
             // then
             verify(tradeCompleteRepository).save(any(TradeComplete.class));
+            verifyTradeStatusChangedEvent(300L, productId, false);
         }
 
         @Test
@@ -434,6 +443,7 @@ class RequestTradeCompleteServiceImplTest {
                     .thenReturn(Optional.of(product));
 
             ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.getId()).thenReturn(300L);
             when(chatRoomRepository.findByProductIdAndBuyerAndSeller(
                     productId,
                     buyerMember,
@@ -492,6 +502,7 @@ class RequestTradeCompleteServiceImplTest {
                     .thenReturn(Optional.empty());
 
             ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.getId()).thenReturn(300L);
             when(chatRoomRepository.findByProductIdAndBuyerAndSeller(
                     productId,
                     buyerMember,
@@ -522,6 +533,7 @@ class RequestTradeCompleteServiceImplTest {
             verify(pending).updateStatus(TradeStatus.COMPLETED);
             verify(pending).updateCompletedAt();
             verifyNoInteractions(productReservationRepository);
+            verifyTradeStatusChangedEvent(300L, productId, true);
         }
 
         @Test
@@ -576,6 +588,28 @@ class RequestTradeCompleteServiceImplTest {
                     () -> service.execute(productId, sellerId));
 
             verify(product, never()).updateStatus(any());
+        }
+    }
+
+    private void verifyTradeStatusChangedEvent(Long roomId, Long productId, boolean completed) {
+        ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(applicationEventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
+
+        TradeStatusChangedEvent event = eventCaptor.getAllValues().stream()
+                .filter(TradeStatusChangedEvent.class::isInstance)
+                .map(TradeStatusChangedEvent.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+        assertEquals(roomId, event.roomId());
+        assertEquals(productId, event.productId());
+        assertEquals(completed, event.completed());
+        assertTrue(event.changedAt() != null);
+
+        if (completed) {
+            assertTrue(event.completed());
+        } else {
+            assertFalse(event.completed());
         }
     }
 

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
@@ -40,7 +40,6 @@ import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
@@ -605,12 +604,6 @@ class RequestTradeCompleteServiceImplTest {
         assertEquals(productId, event.productId());
         assertEquals(completed, event.completed());
         assertTrue(event.changedAt() != null);
-
-        if (completed) {
-            assertTrue(event.completed());
-        } else {
-            assertFalse(event.completed());
-        }
     }
 
 }

--- a/src/test/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListenerTest.java
+++ b/src/test/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListenerTest.java
@@ -1,0 +1,33 @@
+package team.startup.gwangsan.global.event.handler;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import team.startup.gwangsan.global.chat.notification.ChattingServerTradeStatusNotifier;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("TradeStatusChangedEventListener 단위 테스트")
+class TradeStatusChangedEventListenerTest {
+
+    @Test
+    @DisplayName("채팅 서버 알림 실패가 발생해도 예외를 전파하지 않는다")
+    void it_does_not_propagate_exception_when_chatting_server_notification_fails() {
+        ChattingServerTradeStatusNotifier notifier = mock(ChattingServerTradeStatusNotifier.class);
+        TradeStatusChangedEventListener listener = new TradeStatusChangedEventListener(notifier);
+        TradeStatusChangedEvent event = new TradeStatusChangedEvent(1L, 10L, false, LocalDateTime.now());
+
+        doThrow(new RuntimeException("chatting server unavailable"))
+                .when(notifier)
+                .notifyTradeStatusChanged(event);
+
+        assertDoesNotThrow(() -> listener.handleTradeStatusChangedEvent(event));
+
+        verify(notifier).notifyTradeStatusChanged(event);
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

채팅방 거래 완료 요청/수락 후 상대방 화면이 재입장 전까지 갱신되지 않는 문제가 있었습니다.

채팅방 화면은 `GET /api/chat/{roomId}` 응답의 거래 상태 필드를 기준으로 버튼을 렌더링하지만, 거래 상태 변경 이후 채팅 서버로 상태 변경을 전달하는 흐름이 없어 실시간 갱신이 되지 않았습니다.

Resolves: #319

## 📃 작업내용

- 거래 완료 요청/수락 성공 후 `TradeStatusChangedEvent`를 발행하도록 추가하였습니다.
- 트랜잭션 커밋 이후 채팅 서버 내부 API로 거래 상태 변경을 전달하는 리스너를 추가하였습니다.
- 채팅 서버 URL과 내부 secret 설정을 추가하였습니다.
- 채팅 서버 알림 실패가 거래 처리 rollback으로 이어지지 않도록 예외를 로그로 처리하였습니다.
- 거래 상태 변경 이벤트 발행 및 알림 실패 처리 테스트를 추가하였습니다.

## 🙋‍♂️ 리뷰노트

`isCompletable`은 사용자별로 달라질 수 있어 채팅 서버로 전달하지 않았습니다. 채팅 서버는 `roomId`, `productId`, `isCompleted`, `createdAt`을 앱에 emit하고, 앱은 이벤트 수신 후 채팅방 조회 API를 다시 호출하는 흐름을 전제로 하였습니다.

채팅 서버 연동 전 환경에서도 거래 처리가 실패하지 않도록 `CHATTING_SERVER_URL`이 비어 있으면 알림 호출을 생략하도록 처리하였습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

관련 테스트는 통과하였습니다.

```bash
./gradlew test --tests team.startup.gwangsan.domain.post.service.impl.RequestTradeCompleteServiceImplTest --tests team.startup.gwangsan.global.event.handler.TradeStatusChangedEventListenerTest
```

전체 테스트는 기존 `ChatStreamConsumerWorker` 통합 테스트의 Docker/Testcontainers 환경 문제로 실패하였습니다.
