### PR TITLE
회원 상세 조회 시 Place lazy loading으로 인한 500 오류 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/member/repository/custom/MemberDetailCustomRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/repository/custom/MemberDetailCustomRepository.java
@@ -24,4 +24,6 @@ public interface MemberDetailCustomRepository {
     MemberDetail findByPhoneNumberWithMember(String phoneNumber);
 
     Optional<MemberDetail> findByMemberIdWithPlaceHeadDong(Long memberId);
+
+    Optional<MemberDetail> findByMemberIdWithMemberAndPlace(Long memberId);
 }

--- a/src/main/java/team/startup/gwangsan/domain/member/repository/custom/impl/MemberDetailCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/repository/custom/impl/MemberDetailCustomRepositoryImpl.java
@@ -108,6 +108,18 @@ public class MemberDetailCustomRepositoryImpl implements MemberDetailCustomRepos
         );
     }
 
+    @Override
+    public Optional<MemberDetail> findByMemberIdWithMemberAndPlace(Long memberId) {
+        return Optional.ofNullable(
+                queryFactory
+                        .selectFrom(memberDetail)
+                        .join(memberDetail.member, member).fetchJoin()
+                        .join(memberDetail.place, place).fetchJoin()
+                        .where(memberDetail.member.id.eq(memberId))
+                        .fetchOne()
+        );
+    }
+
 
     private BooleanExpression roleCondition(Integer placeId, Integer headId) {
         if (placeId != null) {

--- a/src/main/java/team/startup/gwangsan/domain/member/service/impl/FindUserInfoServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/service/impl/FindUserInfoServiceImpl.java
@@ -23,7 +23,7 @@ public class FindUserInfoServiceImpl implements FindUserInfoService {
     @Override
     @Transactional(readOnly = true)
     public FindUserInfoResponse execute(Long memberId) {
-        MemberDetail detail = memberDetailRepository.findByMemberIdWithPlaceHeadDong(memberId)
+        MemberDetail detail = memberDetailRepository.findByMemberIdWithMemberAndPlace(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
         Member member = detail.getMember();

--- a/src/main/java/team/startup/gwangsan/domain/member/service/impl/FindUserInfoServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/service/impl/FindUserInfoServiceImpl.java
@@ -8,7 +8,6 @@ import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.peresentation.dto.response.FindUserInfoResponse;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
-import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.domain.member.service.FindUserInfoService;
 import team.startup.gwangsan.domain.relatedkeyword.repository.MemberRelatedKeywordRepository;
 
@@ -18,18 +17,16 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FindUserInfoServiceImpl implements FindUserInfoService {
 
-    private final MemberRepository memberRepository;
     private final MemberDetailRepository memberDetailRepository;
     private final MemberRelatedKeywordRepository memberRelatedKeywordRepository;
 
     @Override
     @Transactional(readOnly = true)
     public FindUserInfoResponse execute(Long memberId) {
-        Member member = memberRepository.findById(memberId)
+        MemberDetail detail = memberDetailRepository.findByMemberIdWithPlaceHeadDong(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
-        MemberDetail detail = memberDetailRepository.findById(memberId)
-                .orElseThrow(NotFoundMemberException::new);
+        Member member = detail.getMember();
 
         List<String> specialties = memberRelatedKeywordRepository.findAllByMember(member).stream()
                 .map(mrk -> mrk.getRelatedKeyword().getName())

--- a/src/test/java/team/startup/gwangsan/domain/member/service/impl/FindUserInfoServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/member/service/impl/FindUserInfoServiceImplTest.java
@@ -63,7 +63,7 @@ class FindUserInfoServiceImplTest {
                 when(mrk.getRelatedKeyword()).thenReturn(keyword);
 
                 when(detail.getMember()).thenReturn(member);
-                when(memberDetailRepository.findByMemberIdWithPlaceHeadDong(2L)).thenReturn(Optional.of(detail));
+                when(memberDetailRepository.findByMemberIdWithMemberAndPlace(2L)).thenReturn(Optional.of(detail));
                 when(memberRelatedKeywordRepository.findAllByMember(member)).thenReturn(List.of(mrk));
 
                 FindUserInfoResponse response = service.execute(2L);
@@ -81,7 +81,7 @@ class FindUserInfoServiceImplTest {
             @Test
             @DisplayName("NotFoundMemberException을 던진다")
             void it_throws_not_found_member_exception() {
-                when(memberDetailRepository.findByMemberIdWithPlaceHeadDong(99L)).thenReturn(Optional.empty());
+                when(memberDetailRepository.findByMemberIdWithMemberAndPlace(99L)).thenReturn(Optional.empty());
 
                 assertThatThrownBy(() -> service.execute(99L))
                         .isInstanceOf(NotFoundMemberException.class);

--- a/src/test/java/team/startup/gwangsan/domain/member/service/impl/FindUserInfoServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/member/service/impl/FindUserInfoServiceImplTest.java
@@ -12,7 +12,6 @@ import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.peresentation.dto.response.FindUserInfoResponse;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
-import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.domain.place.entity.Place;
 import team.startup.gwangsan.domain.relatedkeyword.entity.MemberRelatedKeyword;
 import team.startup.gwangsan.domain.relatedkeyword.entity.RelatedKeyword;
@@ -32,7 +31,6 @@ class FindUserInfoServiceImplTest {
     @InjectMocks
     private FindUserInfoServiceImpl service;
 
-    @Mock private MemberRepository memberRepository;
     @Mock private MemberDetailRepository memberDetailRepository;
     @Mock private MemberRelatedKeywordRepository memberRelatedKeywordRepository;
 
@@ -64,8 +62,8 @@ class FindUserInfoServiceImplTest {
                 MemberRelatedKeyword mrk = mock(MemberRelatedKeyword.class);
                 when(mrk.getRelatedKeyword()).thenReturn(keyword);
 
-                when(memberRepository.findById(2L)).thenReturn(Optional.of(member));
-                when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(detail));
+                when(detail.getMember()).thenReturn(member);
+                when(memberDetailRepository.findByMemberIdWithPlaceHeadDong(2L)).thenReturn(Optional.of(detail));
                 when(memberRelatedKeywordRepository.findAllByMember(member)).thenReturn(List.of(mrk));
 
                 FindUserInfoResponse response = service.execute(2L);
@@ -83,25 +81,9 @@ class FindUserInfoServiceImplTest {
             @Test
             @DisplayName("NotFoundMemberException을 던진다")
             void it_throws_not_found_member_exception() {
-                when(memberRepository.findById(99L)).thenReturn(Optional.empty());
+                when(memberDetailRepository.findByMemberIdWithPlaceHeadDong(99L)).thenReturn(Optional.empty());
 
                 assertThatThrownBy(() -> service.execute(99L))
-                        .isInstanceOf(NotFoundMemberException.class);
-            }
-        }
-
-        @Nested
-        @DisplayName("MemberDetail이 없을 때")
-        class Context_with_detail_not_found {
-
-            @Test
-            @DisplayName("NotFoundMemberException을 던진다")
-            void it_throws_not_found_member_exception() {
-                Member member = mock(Member.class);
-                when(memberRepository.findById(2L)).thenReturn(Optional.of(member));
-                when(memberDetailRepository.findById(2L)).thenReturn(Optional.empty());
-
-                assertThatThrownBy(() -> service.execute(2L))
                         .isInstanceOf(NotFoundMemberException.class);
             }
         }


### PR DESCRIPTION
## 💡 배경 및 개요

`GET /api/member/{id}` 호출 시 HTTP 500 오류가 발생하였습니다.

`FindUserInfoServiceImpl`에서 `memberDetailRepository.findById()`를 사용하여 `MemberDetail`을 조회하면 `Place`가 JOIN FETCH되지 않고 lazy 프록시로만 로드되었습니다. 이후 `detail.getPlace().getName()` 호출 시 Hibernate가 프록시를 초기화하는 과정에서 `EntityNotFoundException`이 발생하였고, 이 예외가 `GlobalExceptionHandler`의 공통 핸들러에 잡혀 HTTP 500으로 반환되었습니다.

Resolves: #322

## 📃 작업내용

- `FindUserInfoServiceImpl`에서 `memberDetailRepository.findById()` 호출을 `findByMemberIdWithPlaceHeadDong()`으로 교체하여 Place를 JOIN FETCH로 안전하게 로드하도록 수정하였습니다
- `FindMyInfoServiceImpl`에서 이미 검증된 쿼리를 재활용하였습니다
- 불필요해진 `MemberRepository` 의존성을 제거하고 `detail.getMember()`로 회원 정보를 가져오도록 단순화하였습니다 (쿼리 횟수 2회 → 1회)
- `FindUserInfoServiceImplTest` 단위 테스트를 변경된 구현에 맞게 업데이트하였습니다

## 🙋‍♂️ 리뷰노트

`findById()`는 `Place`를 lazy 프록시로 처리하기 때문에, DB에 해당 `place_id`에 대응하는 레코드가 없거나 FK 정합성 문제가 있으면 프록시 초기화 시점에 `EntityNotFoundException`이 발생합니다. 이 예외는 `GlobalException`을 상속하지 않으므로 500으로 떨어집니다.

`FindMyInfoServiceImpl`에서 이미 `findByMemberIdWithPlaceHeadDong()`을 통해 동일한 방식으로 Place를 안전하게 조회하고 있었기 때문에, 같은 쿼리를 재활용하는 방향으로 수정하였습니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
