### PR TITLE
관리자 광산 지급/차감 API 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/admin/presentation/AdminController.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/presentation/AdminController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.startup.gwangsan.domain.admin.entity.constant.AlertType;
+import team.startup.gwangsan.domain.admin.presentation.dto.request.AdjustGwangsanRequest;
 import team.startup.gwangsan.domain.admin.presentation.dto.request.AdminSignInRequest;
 import team.startup.gwangsan.domain.admin.presentation.dto.request.UpdateMemberRoleRequest;
 import team.startup.gwangsan.domain.admin.presentation.dto.request.UpdateMemberStatusRequest;
@@ -26,6 +27,7 @@ public class AdminController {
     private final VerificationSignUpService verificationSignUpService;
     private final DeleteAdminAlertService deleteAdminAlertService;
     private final ApproveTradeCancelService approveTradeCancelService;
+    private final AdjustGwangsanService adjustGwangsanService;
 
     @GetMapping("/alert")
     public ResponseEntity<GetAdminAlertResponse> getAdminAlert(
@@ -52,6 +54,15 @@ public class AdminController {
     ) {
         updateMemberStatusService.execute(memberId, request.status());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PatchMapping("/gwangsan/{member_id}")
+    public ResponseEntity<Void> adjustGwangsan(
+            @PathVariable("member_id") Long memberId,
+            @RequestBody @Valid AdjustGwangsanRequest request
+    ) {
+        adjustGwangsanService.execute(memberId, request.gwangsan());
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/signin")

--- a/src/main/java/team/startup/gwangsan/domain/admin/presentation/dto/request/AdjustGwangsanRequest.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/presentation/dto/request/AdjustGwangsanRequest.java
@@ -1,0 +1,8 @@
+package team.startup.gwangsan.domain.admin.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record AdjustGwangsanRequest(
+        @NotNull Integer gwangsan
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/admin/service/AdjustGwangsanService.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/AdjustGwangsanService.java
@@ -1,0 +1,5 @@
+package team.startup.gwangsan.domain.admin.service;
+
+public interface AdjustGwangsanService {
+    void execute(Long memberId, Integer gwangsan);
+}

--- a/src/main/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImpl.java
@@ -10,7 +10,6 @@ import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
-import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 @Service
@@ -28,10 +27,8 @@ public class AdjustGwangsanServiceImpl implements AdjustGwangsanService {
         MemberDetail adminDetail = memberDetailRepository.findById(admin.getId())
                 .orElseThrow(NotFoundMemberDetailException::new);
 
-        Member targetMember = memberRepository.findById(memberId)
+        MemberDetail targetMemberDetail = memberDetailRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
-        MemberDetail targetMemberDetail = memberDetailRepository.findById(targetMember.getId())
-                .orElseThrow(NotFoundMemberDetailException::new);
 
         validatePlaceUtil.validateSamePlace(admin, adminDetail, targetMemberDetail);
         targetMemberDetail.adjustGwangsan(gwangsan);

--- a/src/main/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImpl.java
@@ -17,7 +17,6 @@ import team.startup.gwangsan.global.util.MemberUtil;
 @RequiredArgsConstructor
 public class AdjustGwangsanServiceImpl implements AdjustGwangsanService {
 
-    private final MemberRepository memberRepository;
     private final MemberDetailRepository memberDetailRepository;
     private final MemberUtil memberUtil;
     private final ValidatePlaceUtil validatePlaceUtil;

--- a/src/main/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImpl.java
@@ -1,0 +1,40 @@
+package team.startup.gwangsan.domain.admin.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.admin.service.AdjustGwangsanService;
+import team.startup.gwangsan.domain.admin.util.ValidatePlaceUtil;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+@Service
+@RequiredArgsConstructor
+public class AdjustGwangsanServiceImpl implements AdjustGwangsanService {
+
+    private final MemberRepository memberRepository;
+    private final MemberDetailRepository memberDetailRepository;
+    private final MemberUtil memberUtil;
+    private final ValidatePlaceUtil validatePlaceUtil;
+
+    @Override
+    @Transactional
+    public void execute(Long memberId, Integer gwangsan) {
+        Member admin = memberUtil.getCurrentMember();
+        MemberDetail adminDetail = memberDetailRepository.findById(admin.getId())
+                .orElseThrow(NotFoundMemberDetailException::new);
+
+        Member targetMember = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+        MemberDetail targetMemberDetail = memberDetailRepository.findById(targetMember.getId())
+                .orElseThrow(NotFoundMemberDetailException::new);
+
+        validatePlaceUtil.validateSamePlace(admin, adminDetail, targetMemberDetail);
+        targetMemberDetail.adjustGwangsan(gwangsan);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
@@ -62,7 +62,7 @@ public class MemberDetail {
     }
 
     public void adjustGwangsan(Integer gwangsan) {
-        this.gwangsan = this.gwangsan + gwangsan;
+        this.gwangsan = Math.max(0, this.gwangsan + gwangsan);
     }
 
     public void plusLight(Integer light) {

--- a/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
@@ -61,6 +61,10 @@ public class MemberDetail {
         this.gwangsan = this.gwangsan + gwangsan;
     }
 
+    public void adjustGwangsan(Integer gwangsan) {
+        this.gwangsan = this.gwangsan + gwangsan;
+    }
+
     public void plusLight(Integer light) {
         this.light = Math.max(0, this.light + light);
     }

--- a/src/main/java/team/startup/gwangsan/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team/startup/gwangsan/global/exception/GlobalExceptionHandler.java
@@ -2,9 +2,12 @@ package team.startup.gwangsan.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -18,6 +21,16 @@ public class GlobalExceptionHandler {
                 .build();
 
         return ResponseEntity.status(response.getStatus()).body(response);
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            MethodArgumentTypeMismatchException.class,
+            HttpMessageNotReadableException.class
+    })
+    public ResponseEntity<ErrorResponse> handleBadRequest(Exception ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(400, "잘못된 요청입니다."));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
@@ -109,6 +109,8 @@ public class SecurityConfig {
                                 .requestMatchers(HttpMethod.POST, "/api/admin/signin").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/admin/**")
                                 .hasAnyAuthority(MemberRole.ROLE_PLACE_ADMIN.name(), MemberRole.ROLE_HEAD_ADMIN.name() )
+                                .requestMatchers(HttpMethod.PATCH, "/api/admin/**")
+                                .hasAnyAuthority(MemberRole.ROLE_PLACE_ADMIN.name(), MemberRole.ROLE_HEAD_ADMIN.name())
 
                                 // review
                                 .requestMatchers(HttpMethod.POST, "/api/review").authenticated()

--- a/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
@@ -107,9 +107,7 @@ public class SecurityConfig {
 
                                 // admin
                                 .requestMatchers(HttpMethod.POST, "/api/admin/signin").permitAll()
-                                .requestMatchers(HttpMethod.POST, "/api/admin/**")
-                                .hasAnyAuthority(MemberRole.ROLE_PLACE_ADMIN.name(), MemberRole.ROLE_HEAD_ADMIN.name() )
-                                .requestMatchers(HttpMethod.PATCH, "/api/admin/**")
+                                .requestMatchers("/api/admin/**")
                                 .hasAnyAuthority(MemberRole.ROLE_PLACE_ADMIN.name(), MemberRole.ROLE_HEAD_ADMIN.name())
 
                                 // review

--- a/src/test/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImplTest.java
@@ -12,7 +12,6 @@ import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
-import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.Optional;
@@ -28,9 +27,6 @@ class AdjustGwangsanServiceImplTest {
 
     @InjectMocks
     private AdjustGwangsanServiceImpl service;
-
-    @Mock
-    private MemberRepository memberRepository;
 
     @Mock
     private MemberDetailRepository memberDetailRepository;
@@ -56,13 +52,10 @@ class AdjustGwangsanServiceImplTest {
                 when(admin.getId()).thenReturn(1L);
                 MemberDetail adminDetail = mock(MemberDetail.class);
 
-                Member target = mock(Member.class);
-                when(target.getId()).thenReturn(2L);
                 MemberDetail targetDetail = mock(MemberDetail.class);
 
                 when(memberUtil.getCurrentMember()).thenReturn(admin);
                 when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
-                when(memberRepository.findById(2L)).thenReturn(Optional.of(target));
                 when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(targetDetail));
 
                 service.execute(2L, 1000);
@@ -83,13 +76,10 @@ class AdjustGwangsanServiceImplTest {
                 when(admin.getId()).thenReturn(1L);
                 MemberDetail adminDetail = mock(MemberDetail.class);
 
-                Member target = mock(Member.class);
-                when(target.getId()).thenReturn(2L);
                 MemberDetail targetDetail = mock(MemberDetail.class);
 
                 when(memberUtil.getCurrentMember()).thenReturn(admin);
                 when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
-                when(memberRepository.findById(2L)).thenReturn(Optional.of(target));
                 when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(targetDetail));
 
                 service.execute(2L, -1000);
@@ -111,7 +101,7 @@ class AdjustGwangsanServiceImplTest {
 
                 when(memberUtil.getCurrentMember()).thenReturn(admin);
                 when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
-                when(memberRepository.findById(2L)).thenReturn(Optional.empty());
+                when(memberDetailRepository.findById(2L)).thenReturn(Optional.empty());
 
                 assertThatThrownBy(() -> service.execute(2L, 1000))
                         .isInstanceOf(NotFoundMemberException.class);

--- a/src/test/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/admin/service/impl/AdjustGwangsanServiceImplTest.java
@@ -1,0 +1,121 @@
+package team.startup.gwangsan.domain.admin.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.admin.util.ValidatePlaceUtil;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AdjustGwangsanServiceImpl 단위 테스트")
+class AdjustGwangsanServiceImplTest {
+
+    @InjectMocks
+    private AdjustGwangsanServiceImpl service;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private MemberDetailRepository memberDetailRepository;
+
+    @Mock
+    private MemberUtil memberUtil;
+
+    @Mock
+    private ValidatePlaceUtil validatePlaceUtil;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Nested
+        @DisplayName("정상적인 요청일 때")
+        class Context_with_valid_request {
+
+            @Test
+            @DisplayName("대상 회원의 광산을 조정한다")
+            void it_adjusts_member_gwangsan() {
+                Member admin = mock(Member.class);
+                when(admin.getId()).thenReturn(1L);
+                MemberDetail adminDetail = mock(MemberDetail.class);
+
+                Member target = mock(Member.class);
+                when(target.getId()).thenReturn(2L);
+                MemberDetail targetDetail = mock(MemberDetail.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(admin);
+                when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
+                when(memberRepository.findById(2L)).thenReturn(Optional.of(target));
+                when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(targetDetail));
+
+                service.execute(2L, 1000);
+
+                verify(validatePlaceUtil).validateSamePlace(admin, adminDetail, targetDetail);
+                verify(targetDetail).adjustGwangsan(1000);
+            }
+        }
+
+        @Nested
+        @DisplayName("음수 광산이 요청될 때")
+        class Context_with_negative_gwangsan {
+
+            @Test
+            @DisplayName("음수 값을 그대로 반영한다")
+            void it_applies_negative_gwangsan() {
+                Member admin = mock(Member.class);
+                when(admin.getId()).thenReturn(1L);
+                MemberDetail adminDetail = mock(MemberDetail.class);
+
+                Member target = mock(Member.class);
+                when(target.getId()).thenReturn(2L);
+                MemberDetail targetDetail = mock(MemberDetail.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(admin);
+                when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
+                when(memberRepository.findById(2L)).thenReturn(Optional.of(target));
+                when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(targetDetail));
+
+                service.execute(2L, -1000);
+
+                verify(targetDetail).adjustGwangsan(-1000);
+            }
+        }
+
+        @Nested
+        @DisplayName("대상 회원이 없을 때")
+        class Context_with_target_not_found {
+
+            @Test
+            @DisplayName("NotFoundMemberException을 던진다")
+            void it_throws_not_found_member_exception() {
+                Member admin = mock(Member.class);
+                when(admin.getId()).thenReturn(1L);
+                MemberDetail adminDetail = mock(MemberDetail.class);
+
+                when(memberUtil.getCurrentMember()).thenReturn(admin);
+                when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
+                when(memberRepository.findById(2L)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(2L, 1000))
+                        .isInstanceOf(NotFoundMemberException.class);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

관리자 클라이언트에서 회원 광산 지급/차감을 위해 `PATCH /api/admin/gwangsan/{member_id}`를 호출하고 있었지만, 서버에 해당 매핑이 존재하지 않아 정적 리소스 요청으로 처리된 뒤 HTTP 500 오류가 반환되었습니다.

관리자 페이지에서 양수 광산은 지급, 음수 광산은 차감으로 처리할 수 있도록 API를 추가하였습니다.

Resolves: #324

## 📃 작업내용

- `PATCH /api/admin/gwangsan/{member_id}` API를 추가하였습니다.
- 요청 body의 `gwangsan` 값을 그대로 더해 양수는 지급, 음수는 차감으로 처리하도록 구현하였습니다.
- 기존 관리자 회원 관리 기능과 동일하게 관리자와 대상 회원의 장소 권한을 검증하도록 하였습니다.
- 관리자 `PATCH /api/admin/**` 요청은 PLACE/HEAD 관리자만 접근할 수 있도록 보안 설정을 보강하였습니다.
- 요청 body/path 형식 오류가 HTTP 400 Bad Request로 응답되도록 공통 예외 처리를 추가하였습니다.
- 광산 지급/차감 서비스 단위 테스트를 추가하였습니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?
