### PR TITLE
기간별 거래 통계 API 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/trade/exception/InvalidTradeStatisticsPeriodException.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/exception/InvalidTradeStatisticsPeriodException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangsan.domain.trade.exception;
+
+import team.startup.gwangsan.global.exception.ErrorCode;
+import team.startup.gwangsan.global.exception.GlobalException;
+
+public class InvalidTradeStatisticsPeriodException extends GlobalException {
+    public InvalidTradeStatisticsPeriodException() {
+        super(ErrorCode.INVALID_TRADE_STATISTICS_PERIOD);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/TradeController.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/TradeController.java
@@ -1,6 +1,7 @@
 package team.startup.gwangsan.domain.trade.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,7 @@ import team.startup.gwangsan.domain.trade.service.TradeCancelWithdrawService;
 import team.startup.gwangsan.domain.trade.service.TradeHistoryByHeadService;
 import team.startup.gwangsan.domain.trade.service.TradeHistoryByPlaceService;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @RestController
@@ -40,6 +42,26 @@ public class TradeController {
             @RequestParam(name = "place_id") Integer placeId
     ) {
         PlaceTradeHistoryResponse response = tradeHistoryByPlaceService.execute(period, placeId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/statistics/head")
+    public ResponseEntity<List<HeadTradeHistoryResponse>> getHeadStatistics(
+            @RequestParam(name = "head_id") Integer headId,
+            @RequestParam(name = "start_date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(name = "end_date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        List<HeadTradeHistoryResponse> response = tradeHistoryByHeadService.execute(headId, startDate, endDate);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/statistics/place")
+    public ResponseEntity<PlaceTradeHistoryResponse> getPlaceStatistics(
+            @RequestParam(name = "place_id") Integer placeId,
+            @RequestParam(name = "start_date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+            @RequestParam(name = "end_date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate
+    ) {
+        PlaceTradeHistoryResponse response = tradeHistoryByPlaceService.execute(placeId, startDate, endDate);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/TradeCompleteCustomRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/TradeCompleteCustomRepository.java
@@ -12,6 +12,10 @@ public interface TradeCompleteCustomRepository {
 
     Long countByPlaceId(int period, LocalDateTime now, Integer placeId);
 
+    Map<Integer, Long> countByHeadIdBetween(Integer headId, LocalDateTime start, LocalDateTime end);
+
+    Long countByPlaceIdBetween(Integer placeId, LocalDateTime start, LocalDateTime end);
+
     Optional<TradeComplete> findByProductIdAndStatus(Long productId, TradeStatus status);
 
     Optional<TradeComplete> findByIdWithProductAndMember(Long id);

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/impl/TradeCompleteCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/impl/TradeCompleteCustomRepositoryImpl.java
@@ -55,7 +55,7 @@ public class TradeCompleteCustomRepositoryImpl implements TradeCompleteCustomRep
                 .leftJoin(memberDetail).on(memberDetail.place.eq(place))
                 .leftJoin(memberDetail.member, member)
                 .leftJoin(tradeComplete).on(
-                        tradeComplete.product.member.eq(member),
+                        tradeComplete.seller.eq(member),
                         tradeComplete.completedAt.goe(start),
                         tradeComplete.completedAt.lt(end),
                         tradeComplete.status.eq(TradeStatus.COMPLETED))
@@ -80,7 +80,7 @@ public class TradeCompleteCustomRepositoryImpl implements TradeCompleteCustomRep
                 .leftJoin(memberDetail).on(memberDetail.place.eq(place))
                 .leftJoin(memberDetail.member, member)
                 .leftJoin(tradeComplete).on(
-                        tradeComplete.product.member.eq(member),
+                        tradeComplete.seller.eq(member),
                         tradeComplete.completedAt.goe(start),
                         tradeComplete.completedAt.lt(end),
                         tradeComplete.status.eq(TradeStatus.COMPLETED))

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/impl/TradeCompleteCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/impl/TradeCompleteCustomRepositoryImpl.java
@@ -9,6 +9,7 @@ import team.startup.gwangsan.domain.trade.repository.custom.TradeCompleteCustomR
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -27,11 +28,25 @@ public class TradeCompleteCustomRepositoryImpl implements TradeCompleteCustomRep
 
     @Override
     public Map<Integer, Long> countByHeadId(int period, LocalDateTime now, Integer headId) {
-        var cnt = tradeComplete.id.count();
-
         LocalDate today = now.toLocalDate();
         LocalDateTime start = today.minusDays(period - 1L).atStartOfDay();
         LocalDateTime nextDayStart = today.plusDays(1L).atStartOfDay();
+
+        return countByHeadIdBetween(headId, start, nextDayStart);
+    }
+
+    @Override
+    public Long countByPlaceId(int period, LocalDateTime now, Integer placeId) {
+        LocalDate today = now.toLocalDate();
+        LocalDateTime start = today.minusDays(period - 1L).atStartOfDay();
+        LocalDateTime nextDayStart = today.plusDays(1L).atStartOfDay();
+
+        return countByPlaceIdBetween(placeId, start, nextDayStart);
+    }
+
+    @Override
+    public Map<Integer, Long> countByHeadIdBetween(Integer headId, LocalDateTime start, LocalDateTime end) {
+        var cnt = tradeComplete.id.count();
 
         return queryFactory
                 .select(place.id, cnt)
@@ -42,23 +57,23 @@ public class TradeCompleteCustomRepositoryImpl implements TradeCompleteCustomRep
                 .leftJoin(tradeComplete).on(
                         tradeComplete.product.member.eq(member),
                         tradeComplete.completedAt.goe(start),
-                        tradeComplete.completedAt.lt(nextDayStart))
+                        tradeComplete.completedAt.lt(end),
+                        tradeComplete.status.eq(TradeStatus.COMPLETED))
                 .where(head.id.eq(headId))
                 .groupBy(place.id)
+                .orderBy(place.id.asc())
                 .fetch()
                 .stream()
                 .collect(Collectors.toMap(
                         t -> t.get(place.id),
-                        t -> t.get(cnt)
+                        t -> t.get(cnt),
+                        (left, right) -> left,
+                        LinkedHashMap::new
                 ));
     }
 
     @Override
-    public Long countByPlaceId(int period, LocalDateTime now, Integer placeId) {
-        LocalDate today = now.toLocalDate();
-        LocalDateTime start = today.minusDays(period - 1L).atStartOfDay();
-        LocalDateTime nextDayStart = today.plusDays(1L).atStartOfDay();
-
+    public Long countByPlaceIdBetween(Integer placeId, LocalDateTime start, LocalDateTime end) {
         Long count = queryFactory
                 .select(tradeComplete.id.count())
                 .from(place)
@@ -67,7 +82,8 @@ public class TradeCompleteCustomRepositoryImpl implements TradeCompleteCustomRep
                 .leftJoin(tradeComplete).on(
                         tradeComplete.product.member.eq(member),
                         tradeComplete.completedAt.goe(start),
-                        tradeComplete.completedAt.lt(nextDayStart))
+                        tradeComplete.completedAt.lt(end),
+                        tradeComplete.status.eq(TradeStatus.COMPLETED))
                 .where(place.id.eq(placeId))
                 .fetchOne();
 

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/TradeHistoryByHeadService.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/TradeHistoryByHeadService.java
@@ -3,8 +3,11 @@ package team.startup.gwangsan.domain.trade.service;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.HeadTradeHistoryResponse;
 
+import java.time.LocalDate;
 import java.util.List;
 
 public interface TradeHistoryByHeadService {
     List<HeadTradeHistoryResponse> execute(Period period, Integer headId);
+
+    List<HeadTradeHistoryResponse> execute(Integer headId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/TradeHistoryByPlaceService.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/TradeHistoryByPlaceService.java
@@ -3,6 +3,10 @@ package team.startup.gwangsan.domain.trade.service;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.PlaceTradeHistoryResponse;
 
+import java.time.LocalDate;
+
 public interface TradeHistoryByPlaceService {
     PlaceTradeHistoryResponse execute(Period period, Integer placeId);
+
+    PlaceTradeHistoryResponse execute(Integer placeId, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImpl.java
@@ -5,11 +5,13 @@ import org.springframework.stereotype.Service;
 import team.startup.gwangsan.domain.place.entity.Place;
 import team.startup.gwangsan.domain.place.presentation.dto.PlaceDto;
 import team.startup.gwangsan.domain.place.repository.PlaceRepository;
-import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.exception.InvalidTradeStatisticsPeriodException;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.HeadTradeHistoryResponse;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 import team.startup.gwangsan.domain.trade.service.TradeHistoryByHeadService;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
@@ -28,6 +30,23 @@ public class TradeHistoryByHeadServiceImpl implements TradeHistoryByHeadService 
         LocalDateTime now = LocalDateTime.now();
         Map<Integer, Long> history = tradeCompleteRepository.countByHeadId(periodValue, now, headId);
 
+        return toResponse(history);
+    }
+
+    @Override
+    public List<HeadTradeHistoryResponse> execute(Integer headId, LocalDate startDate, LocalDate endDate) {
+        validatePeriod(startDate, endDate);
+
+        Map<Integer, Long> history = tradeCompleteRepository.countByHeadIdBetween(
+                headId,
+                startDate.atStartOfDay(),
+                endDate.plusDays(1).atStartOfDay()
+        );
+
+        return toResponse(history);
+    }
+
+    private List<HeadTradeHistoryResponse> toResponse(Map<Integer, Long> history) {
         List<Place> places = placeRepository.findAllById(history.keySet());
         Map<Integer, PlaceDto> placeMap = places.stream()
                 .collect(Collectors.toMap(
@@ -41,5 +60,11 @@ public class TradeHistoryByHeadServiceImpl implements TradeHistoryByHeadService 
                         e.getValue()
                 ))
                 .toList();
+    }
+
+    private void validatePeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new InvalidTradeStatisticsPeriodException();
+        }
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImpl.java
@@ -63,6 +63,9 @@ public class TradeHistoryByHeadServiceImpl implements TradeHistoryByHeadService 
     }
 
     private void validatePeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            throw new InvalidTradeStatisticsPeriodException();
+        }
         if (startDate.isAfter(endDate)) {
             throw new InvalidTradeStatisticsPeriodException();
         }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImpl.java
@@ -39,6 +39,9 @@ public class TradeHistoryByPlaceServiceImpl implements TradeHistoryByPlaceServic
     }
 
     private void validatePeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate == null || endDate == null) {
+            throw new InvalidTradeStatisticsPeriodException();
+        }
         if (startDate.isAfter(endDate)) {
             throw new InvalidTradeStatisticsPeriodException();
         }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImpl.java
@@ -3,10 +3,12 @@ package team.startup.gwangsan.domain.trade.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.exception.InvalidTradeStatisticsPeriodException;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.PlaceTradeHistoryResponse;
 import team.startup.gwangsan.domain.trade.service.TradeHistoryByPlaceService;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Service
@@ -21,5 +23,24 @@ public class TradeHistoryByPlaceServiceImpl implements TradeHistoryByPlaceServic
                 tradeCompleteRepository.countByPlaceId(
                         period.getValue(), LocalDateTime.now(), placeId)
         );
+    }
+
+    @Override
+    public PlaceTradeHistoryResponse execute(Integer placeId, LocalDate startDate, LocalDate endDate) {
+        validatePeriod(startDate, endDate);
+
+        return new PlaceTradeHistoryResponse(
+                tradeCompleteRepository.countByPlaceIdBetween(
+                        placeId,
+                        startDate.atStartOfDay(),
+                        endDate.plusDays(1).atStartOfDay()
+                )
+        );
+    }
+
+    private void validatePeriod(LocalDate startDate, LocalDate endDate) {
+        if (startDate.isAfter(endDate)) {
+            throw new InvalidTradeStatisticsPeriodException();
+        }
     }
 }

--- a/src/main/java/team/startup/gwangsan/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangsan/global/exception/ErrorCode.java
@@ -106,6 +106,7 @@ public enum ErrorCode {
     TRADE_PARTICIPANT_ONLY(403, "거래 당사자만 요청할 수 있습니다."),
     NOT_TRADE_CANCEL_REQUESTER(403, "거래 철회 요청자가 아닙니다."),
     CANNOT_PENDING_TRADE_CANCEL(400, "거래 철회가 대기중이 아닙니다."),
+    INVALID_TRADE_STATISTICS_PERIOD(400, "거래 통계 조회 기간이 올바르지 않습니다."),
 
     // suspend
     NOT_FOUND_SUSPEND(404, "해당하는 정지 내역을 찾을 수 없습니다."),

--- a/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
+++ b/src/main/java/team/startup/gwangsan/global/security/config/SecurityConfig.java
@@ -137,6 +137,8 @@ public class SecurityConfig {
                                 // trade
                                 .requestMatchers(HttpMethod.GET, "/api/trade/graph/head").hasAnyAuthority(MemberRole.ROLE_HEAD_ADMIN.name())
                                 .requestMatchers(HttpMethod.GET, "/api/trade/graph/place").hasAnyAuthority(MemberRole.ROLE_HEAD_ADMIN.name(), MemberRole.ROLE_PLACE_ADMIN.name())
+                                .requestMatchers(HttpMethod.GET, "/api/trade/statistics/head").hasAnyAuthority(MemberRole.ROLE_HEAD_ADMIN.name())
+                                .requestMatchers(HttpMethod.GET, "/api/trade/statistics/place").hasAnyAuthority(MemberRole.ROLE_HEAD_ADMIN.name(), MemberRole.ROLE_PLACE_ADMIN.name())
 
                                 .anyRequest().hasAnyAuthority(
                                         MemberRole.ROLE_USER.name(),

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
@@ -135,5 +135,28 @@ class TradeHistoryByHeadServiceImplTest {
                 verify(tradeCompleteRepository, never()).countByHeadIdBetween(any(), any(), any());
             }
         }
+
+        @Nested
+        @DisplayName("기간이 null일 때")
+        class Context_with_null_period {
+
+            @Test
+            @DisplayName("InvalidTradeStatisticsPeriodException을 던진다")
+            void it_throws_invalid_trade_statistics_period_exception() {
+                assertThatThrownBy(() -> service.execute(
+                        1,
+                        null,
+                        LocalDate.of(2026, 6, 8)
+                )).isInstanceOf(InvalidTradeStatisticsPeriodException.class);
+
+                assertThatThrownBy(() -> service.execute(
+                        1,
+                        LocalDate.of(2026, 6, 1),
+                        null
+                )).isInstanceOf(InvalidTradeStatisticsPeriodException.class);
+
+                verify(tradeCompleteRepository, never()).countByHeadIdBetween(any(), any(), any());
+            }
+        }
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByHeadServiceImplTest.java
@@ -9,13 +9,16 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangsan.domain.place.entity.Place;
 import team.startup.gwangsan.domain.place.repository.PlaceRepository;
+import team.startup.gwangsan.domain.trade.exception.InvalidTradeStatisticsPeriodException;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.HeadTradeHistoryResponse;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -73,6 +76,63 @@ class TradeHistoryByHeadServiceImplTest {
                 List<HeadTradeHistoryResponse> result = service.execute(Period.DAY, 1);
 
                 assertThat(result).isEmpty();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("execute(headId, startDate, endDate) 메서드는")
+    class Describe_execute_with_period {
+
+        @Nested
+        @DisplayName("정상 기간일 때")
+        class Context_with_valid_period {
+
+            @Test
+            @DisplayName("기간 내 지점별 거래 건수를 반환한다")
+            void it_returns_trade_history_by_head_between_dates() {
+                LocalDate startDate = LocalDate.of(2026, 6, 1);
+                LocalDate endDate = LocalDate.of(2026, 6, 8);
+
+                when(tradeCompleteRepository.countByHeadIdBetween(
+                        eq(1),
+                        eq(startDate.atStartOfDay()),
+                        eq(endDate.plusDays(1).atStartOfDay())
+                )).thenReturn(Map.of(10, 5L, 11, 0L));
+
+                Place place1 = mock(Place.class);
+                when(place1.getId()).thenReturn(10);
+                when(place1.getName()).thenReturn("수완지점");
+
+                Place place2 = mock(Place.class);
+                when(place2.getId()).thenReturn(11);
+                when(place2.getName()).thenReturn("하남지점");
+
+                when(placeRepository.findAllById(any())).thenReturn(List.of(place1, place2));
+
+                List<HeadTradeHistoryResponse> result = service.execute(1, startDate, endDate);
+
+                assertThat(result).hasSize(2);
+                assertThat(result)
+                        .extracting(HeadTradeHistoryResponse::tradeCount)
+                        .containsExactlyInAnyOrder(5L, 0L);
+            }
+        }
+
+        @Nested
+        @DisplayName("시작일이 종료일보다 늦을 때")
+        class Context_with_invalid_period {
+
+            @Test
+            @DisplayName("InvalidTradeStatisticsPeriodException을 던진다")
+            void it_throws_invalid_trade_statistics_period_exception() {
+                assertThatThrownBy(() -> service.execute(
+                        1,
+                        LocalDate.of(2026, 6, 9),
+                        LocalDate.of(2026, 6, 8)
+                )).isInstanceOf(InvalidTradeStatisticsPeriodException.class);
+
+                verify(tradeCompleteRepository, never()).countByHeadIdBetween(any(), any(), any());
             }
         }
     }

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
@@ -104,5 +104,28 @@ class TradeHistoryByPlaceServiceImplTest {
                 verify(tradeCompleteRepository, never()).countByPlaceIdBetween(any(), any(), any());
             }
         }
+
+        @Nested
+        @DisplayName("기간이 null일 때")
+        class Context_with_null_period {
+
+            @Test
+            @DisplayName("InvalidTradeStatisticsPeriodException을 던진다")
+            void it_throws_invalid_trade_statistics_period_exception() {
+                assertThatThrownBy(() -> service.execute(
+                        5,
+                        null,
+                        LocalDate.of(2026, 6, 8)
+                )).isInstanceOf(InvalidTradeStatisticsPeriodException.class);
+
+                assertThatThrownBy(() -> service.execute(
+                        5,
+                        LocalDate.of(2026, 6, 1),
+                        null
+                )).isInstanceOf(InvalidTradeStatisticsPeriodException.class);
+
+                verify(tradeCompleteRepository, never()).countByPlaceIdBetween(any(), any(), any());
+            }
+        }
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeHistoryByPlaceServiceImplTest.java
@@ -7,10 +7,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.trade.exception.InvalidTradeStatisticsPeriodException;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.PlaceTradeHistoryResponse;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -54,6 +58,50 @@ class TradeHistoryByPlaceServiceImplTest {
                 PlaceTradeHistoryResponse result = service.execute(Period.WEEK, 5);
 
                 assertThat(result.count()).isEqualTo(0L);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("execute(placeId, startDate, endDate) 메서드는")
+    class Describe_execute_with_period {
+
+        @Nested
+        @DisplayName("정상 기간일 때")
+        class Context_with_valid_period {
+
+            @Test
+            @DisplayName("기간 내 지점 거래 건수를 반환한다")
+            void it_returns_trade_count_by_place_between_dates() {
+                LocalDate startDate = LocalDate.of(2026, 6, 1);
+                LocalDate endDate = LocalDate.of(2026, 6, 8);
+
+                when(tradeCompleteRepository.countByPlaceIdBetween(
+                        eq(5),
+                        eq(startDate.atStartOfDay()),
+                        eq(endDate.plusDays(1).atStartOfDay())
+                )).thenReturn(7L);
+
+                PlaceTradeHistoryResponse result = service.execute(5, startDate, endDate);
+
+                assertThat(result.count()).isEqualTo(7L);
+            }
+        }
+
+        @Nested
+        @DisplayName("시작일이 종료일보다 늦을 때")
+        class Context_with_invalid_period {
+
+            @Test
+            @DisplayName("InvalidTradeStatisticsPeriodException을 던진다")
+            void it_throws_invalid_trade_statistics_period_exception() {
+                assertThatThrownBy(() -> service.execute(
+                        5,
+                        LocalDate.of(2026, 6, 9),
+                        LocalDate.of(2026, 6, 8)
+                )).isInstanceOf(InvalidTradeStatisticsPeriodException.class);
+
+                verify(tradeCompleteRepository, never()).countByPlaceIdBetween(any(), any(), any());
             }
         }
     }


### PR DESCRIPTION
## 배경 및 개요

본점과 지점의 거래 통계를 기존 고정 기간이 아닌 사용자가 지정한 기간 기준으로 조회할 수 있도록 API를 추가하였습니다.

Resolves: #327

## 작업내용

- 본점 기간 거래 통계 조회 API를 추가하였습니다.
  - `GET /api/trade/statistics/head`
  - `head_id`, `start_date`, `end_date` 기준 산하 지점별 거래 건수를 반환합니다.
- 지점 기간 거래 통계 조회 API를 추가하였습니다.
  - `GET /api/trade/statistics/place`
  - `place_id`, `start_date`, `end_date` 기준 거래 건수를 반환합니다.
- 거래 통계 조회 기준을 `COMPLETED` 상태와 `completedAt` 기간 조건으로 명확히 하였습니다.
- 시작일이 종료일보다 늦은 경우 400 예외가 반환되도록 검증을 추가하였습니다.
- 신규 통계 API 권한 설정을 추가하였습니다.

## 리뷰노트

기간 조건은 `start_date`의 시작 시각 이상, `end_date` 다음 날 시작 시각 미만으로 처리하여 종료일 데이터가 포함되도록 하였습니다.

기존 `/api/trade/graph/*` API는 유지하였고, 내부 조회 로직만 신규 기간 조회 메서드를 재사용하도록 정리하였습니다.

## PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 기타

- 통과: `./gradlew test --tests 'team.startup.gwangsan.domain.trade.service.impl.TradeHistoryByHeadServiceImplTest' --tests 'team.startup.gwangsan.domain.trade.service.impl.TradeHistoryByPlaceServiceImplTest'`
- 전체 `./gradlew test`는 Docker 의존 통합 테스트의 Docker 초기화 실패로 완료되지 않았습니다.
