### PR TITLE
light 누적값 상한 미처리 버그 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
@@ -66,7 +66,7 @@ public class MemberDetail {
     }
 
     public void plusLight(Integer light) {
-        this.light = Math.max(0, this.light + light);
+        this.light = Math.min(100, Math.max(0, this.light + light));
     }
 
     public void updatePlace(Place place) {

--- a/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
@@ -66,7 +66,7 @@ public class MemberDetail {
     }
 
     public void plusLight(Integer light) {
-        this.light = Math.min(100, Math.max(0, this.light + light));
+        this.light = Math.min(100, Math.max(0, (this.light != null ? this.light : 0) + (light != null ? light : 0)));
     }
 
     public void updatePlace(Place place) {


### PR DESCRIPTION
## 💡 배경 및 개요

리뷰 저장 시 회원의 누적 `light` 값이 DB constraint 상한(100)을 초과하면 `CONSTRAINT_1` 위반이 발생하여 리뷰 저장이 실패하는 문제가 있었습니다.

`MemberDetail.plusLight()` 메서드가 하한(0)만 처리하고 상한을 막지 않아, `this.light + light`가 100을 초과한 값이 그대로 대입되어 INSERT/UPDATE 시 제약조건을 위반하였습니다.

Resolves: #329

## 📃 작업내용

- `MemberDetail.plusLight()`에 `Math.min(100, ...)`을 추가하여 누적 `light` 값의 상한(100)을 처리하도록 수정하였습니다.

```java
// before
this.light = Math.max(0, this.light + light);
// after
this.light = Math.min(100, Math.max(0, this.light + light));
```

## 🙋‍♂️ 리뷰노트

- `light` 컬럼은 DB constraint상 0~100 범위를 가지므로, 하한과 상한을 모두 clamp하도록 수정하였습니다.
- 같은 클래스의 `adjustGwangsan()`도 하한만 처리하고 있으나, `gwangsan` 컬럼에는 상한 constraint가 없어 이번 작업 범위에서는 제외하였습니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
