### PR TITLE
Flyway 도입 및 조회 경로 복합 인덱스 마이그레이션 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.flywaydb:flyway-mysql'
 
 	// aop
 	implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-database-mariadb'
+	implementation 'org.flywaydb:flyway-mysql'
 
 	// aop
 	implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.flywaydb:flyway-core'
-	implementation 'org.flywaydb:flyway-mysql'
+	implementation 'org.flywaydb:flyway-database-mariadb'
 
 	// aop
 	implementation 'org.springframework.boot:spring-boot-starter-aop'

--- a/src/main/java/team/startup/gwangsan/domain/alert/repository/custom/AlertReceiptCustomRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/alert/repository/custom/AlertReceiptCustomRepository.java
@@ -6,7 +6,7 @@ import team.startup.gwangsan.domain.alert.entity.AlertReceipt;
 import java.util.List;
 
 public interface AlertReceiptCustomRepository {
-    List<AlertReceipt> findByMemberIdAndCheckedAndAlertId(Long memberId, boolean check, Long alertId);
+    List<AlertReceipt> findByMemberIdAndCheckedUpToAlertId(Long memberId, boolean check, Long alertId);
 
     List<Alert> findByMemberId(Long memberId);
 }

--- a/src/main/java/team/startup/gwangsan/domain/alert/repository/custom/impl/AlertReceiptCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/alert/repository/custom/impl/AlertReceiptCustomRepositoryImpl.java
@@ -19,7 +19,7 @@ public class AlertReceiptCustomRepositoryImpl implements AlertReceiptCustomRepos
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public List<AlertReceipt> findByMemberIdAndCheckedAndAlertId(Long memberId, boolean check, Long alertId) {
+    public List<AlertReceipt> findByMemberIdAndCheckedUpToAlertId(Long memberId, boolean check, Long alertId) {
         return queryFactory
                 .selectFrom(alertReceipt)
                 .where(

--- a/src/main/java/team/startup/gwangsan/domain/alert/service/impl/ReadAlertServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/alert/service/impl/ReadAlertServiceImpl.java
@@ -22,7 +22,7 @@ public class ReadAlertServiceImpl implements ReadAlertService {
     @Transactional
     public void execute(Long alertId) {
         Member member = memberUtil.getCurrentMember();
-        List<AlertReceipt> alertReceipts = alertReceiptRepository.findByMemberIdAndCheckedAndAlertId(member.getId(), false, alertId);
+        List<AlertReceipt> alertReceipts = alertReceiptRepository.findByMemberIdAndCheckedUpToAlertId(member.getId(), false, alertId);
 
         for (AlertReceipt alert : alertReceipts) {
             alert.markChecked();

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,16 @@
+spring:
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+    baseline-version: 1
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: false
+  sql:
+    init:
+      mode: never

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,8 @@ spring:
     url: jdbc:${RDB_TYPE:mariadb}://${RDB_HOST:localhost}:${RDB_PORT:3306}/${RDB_SCHEMA:gwangsan_db}
     username: ${DB_USER:root}
     password: ${DB_PASSWORD:12345678}
+  flyway:
+    enabled: false
   jpa:
     hibernate:
       dialect: ${DB_DIALECT:org.hibernate.dialect.MariaDBDialect}
@@ -21,7 +23,7 @@ spring:
     show-sql: true
   sql:
     init:
-      mode: always
+      mode: never
   servlet:
     multipart:
       max-file-size: 10MB

--- a/src/main/resources/db/migration/V2__add_query_path_indexes.sql
+++ b/src/main/resources/db/migration/V2__add_query_path_indexes.sql
@@ -1,0 +1,18 @@
+-- V1 is the Flyway baseline: the schema created by Hibernate before Flyway was introduced.
+-- V2+ contains all DDL changes managed by Flyway.
+
+-- Supports chat message cursor pagination by room.
+CREATE INDEX idx_chat_message_room_created_message
+    ON tbl_chat_message (room_id, created_at, message_id);
+
+-- Supports marking unread messages as read within a room.
+CREATE INDEX idx_chat_message_room_checked_message
+    ON tbl_chat_message (room_id, checked, message_id);
+
+-- Supports member alert lookups and unread alert checks.
+CREATE INDEX idx_alert_receipt_member_checked_alert
+    ON tbl_alert_receipt (member_id, checked, alert_id);
+
+-- Supports completed trade statistics joined by seller and filtered by status/date.
+CREATE INDEX idx_trade_complete_seller_status_completed
+    ON tbl_trade_complete (seller_id, status, completed_at);

--- a/src/test/java/team/startup/gwangsan/domain/alert/service/impl/ReadAlertServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/alert/service/impl/ReadAlertServiceImplTest.java
@@ -48,7 +48,7 @@ class ReadAlertServiceImplTest {
         void it_marks_all_unchecked_receipts_as_checked() {
             AlertReceipt receipt1 = mock(AlertReceipt.class);
             AlertReceipt receipt2 = mock(AlertReceipt.class);
-            when(alertReceiptRepository.findByMemberIdAndCheckedAndAlertId(1L, false, 10L))
+            when(alertReceiptRepository.findByMemberIdAndCheckedUpToAlertId(1L, false, 10L))
                     .thenReturn(List.of(receipt1, receipt2));
 
             service.execute(10L);
@@ -60,12 +60,12 @@ class ReadAlertServiceImplTest {
         @Test
         @DisplayName("해당 알림에 읽지 않은 receipt 가 없으면 markChecked() 를 호출하지 않는다")
         void it_does_nothing_when_no_unchecked_receipts() {
-            when(alertReceiptRepository.findByMemberIdAndCheckedAndAlertId(1L, false, 10L))
+            when(alertReceiptRepository.findByMemberIdAndCheckedUpToAlertId(1L, false, 10L))
                     .thenReturn(List.of());
 
             service.execute(10L);
 
-            verify(alertReceiptRepository).findByMemberIdAndCheckedAndAlertId(1L, false, 10L);
+            verify(alertReceiptRepository).findByMemberIdAndCheckedUpToAlertId(1L, false, 10L);
             verifyNoMoreInteractions(alertReceiptRepository);
         }
     }


### PR DESCRIPTION
## 💡 배경 및 개요

기존 개발 환경에서는 Hibernate `ddl-auto: update`로 스키마를 관리하고 있었으나, 프로덕션 환경에서는 자동 DDL 변경이 위험하므로 Flyway를 도입하여 스키마 변경 이력을 버전으로 관리하도록 하였습니다.

또한 채팅 메시지 커서 페이지네이션, 앱 알림 조회, 거래 통계 등 실제 쿼리 경로를 분석하여 성능 개선이 필요한 테이블에 복합 인덱스를 추가하는 첫 번째 마이그레이션 스크립트를 작성하였습니다.

Resolves: #332

## 📃 작업내용

**Flyway 도입**
- `build.gradle`에 `flyway-core`, `flyway-mysql` 의존성을 추가하였습니다
- 개발 환경(`application.yml`)에서는 `flyway.enabled: false`로 비활성화하고 Hibernate `ddl-auto: update`를 유지하였습니다
- 프로덕션 환경(`application-prod.yml`)을 신규 추가하여 Flyway 활성화 및 `ddl-auto: validate`로 설정하였습니다
- `baseline-on-migrate: true`, `baseline-version: 1`로 기존 Hibernate 생성 스키마를 V1 베이스라인으로 처리하였습니다

**V2 마이그레이션 — 조회 경로 복합 인덱스 4개 추가**

| 인덱스명 | 테이블 | 컬럼 | 용도 |
|---------|--------|------|------|
| `idx_chat_message_room_created_message` | tbl_chat_message | (room_id, created_at, message_id) | 채팅 메시지 커서 페이지네이션 |
| `idx_chat_message_room_checked_message` | tbl_chat_message | (room_id, checked, message_id) | 메시지 읽음 처리 UPDATE |
| `idx_alert_receipt_member_checked_alert` | tbl_alert_receipt | (member_id, checked, alert_id) | 앱 알림 조회 및 읽지 않은 알림 확인 |
| `idx_trade_complete_seller_status_completed` | tbl_trade_complete | (seller_id, status, completed_at) | 거래 통계 집계 |

**메서드명 정합성 개선**
- `findByMemberIdAndCheckedAndAlertId` → `findByMemberIdAndCheckedUpToAlertId`로 변경하였습니다 (내부 구현이 alertId 이하 범위 조회이므로 명칭을 동작에 맞게 수정)

## 🙋‍♂️ 리뷰노트

- Flyway를 기존 서비스에 늦게 도입하는 경우 `baseline-on-migrate: true`가 필수입니다. 이 옵션 없이 활성화하면 V1 스크립트가 없다는 오류가 발생합니다
- `tbl_chat_message`에 인덱스를 2개 추가하였습니다. 페이지네이션 쿼리(`created_at` 범위)와 읽음 처리 UPDATE 쿼리(`checked`, `message_id` 범위)의 WHERE 조건이 달라 단일 인덱스로 두 쿼리를 모두 커버할 수 없어 분리하였습니다
- `tbl_trade_complete` 인덱스 컬럼 순서를 `(seller_id, status, completed_at)`으로 결정하였습니다. `status`는 카디널리티가 낮으므로 JOIN 조건인 `seller_id`를 선두 컬럼으로 배치하였습니다

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

프로덕션 배포 시 `spring.profiles.active=prod` 환경변수가 설정되어 있어야 Flyway가 활성화됩니다.
