### PR TITLE
findRoomsByMemberId Java 메모리 필터링 DB 서브쿼리로 전환

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
@@ -123,7 +123,7 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
                 .fetch();
 
         Map<Long, LatestMessageDto> latestMessageMap = latestMessages.stream()
-                .collect(Collectors.toMap(LatestMessageDto::roomId, lm -> lm));
+                .collect(Collectors.toMap(LatestMessageDto::roomId, lm -> lm, (existing, replacement) -> existing));
 
         List<UnreadCountDto> unreadCounts = queryFactory
                 .select(Projections.constructor(UnreadCountDto.class,

--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
@@ -2,12 +2,14 @@ package team.startup.gwangsan.domain.chat.repository.custom.impl;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
-import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import team.startup.gwangsan.domain.chat.entity.ChatRoom;
 import team.startup.gwangsan.domain.chat.entity.QChatMessage;
+import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
 import team.startup.gwangsan.domain.chat.presentation.dto.GetRoomsDto;
 import team.startup.gwangsan.domain.chat.presentation.dto.response.GetRoomMemberResponse;
 import team.startup.gwangsan.domain.chat.repository.custom.ChatRoomCustomRepository;
@@ -17,6 +19,7 @@ import team.startup.gwangsan.domain.chat.repository.projection.UnreadCountDto;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.QMember;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -28,6 +31,7 @@ import static team.startup.gwangsan.domain.chat.entity.QChatRoom.chatRoom;
 public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
 
     private final JPAQueryFactory queryFactory;
+    private final EntityManager entityManager;
 
     @Override
     public Optional<ChatRoom> findChatRoomByRoomId(Long roomId) {
@@ -57,9 +61,6 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
 
     @Override
     public List<GetRoomsDto> findRoomsByMemberId(Long memberId) {
-        QChatMessage message = QChatMessage.chatMessage;
-        QChatMessage subMessage = new QChatMessage("subMessage");
-        QChatMessage subMessage2 = new QChatMessage("subMessage2");
         QChatMessage unreadMessage = new QChatMessage("unreadMessage");
         QMember buyer = new QMember("buyer");
         QMember seller = new QMember("seller");
@@ -95,32 +96,7 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
         Map<Long, ChatRoomDto> roomMap = rooms.stream()
                 .collect(Collectors.toMap(ChatRoomDto::roomId, r -> r));
 
-        List<LatestMessageDto> latestMessages = queryFactory
-                .select(Projections.constructor(LatestMessageDto.class,
-                        message.room.id,
-                        message.id,
-                        message.content,
-                        message.messageType,
-                        message.createdAt
-                ))
-                .from(message)
-                .where(
-                        message.room.id.in(roomIds),
-                        message.createdAt.eq(
-                                JPAExpressions.select(subMessage.createdAt.max())
-                                        .from(subMessage)
-                                        .where(subMessage.room.id.eq(message.room.id))
-                        ),
-                        message.id.eq(
-                                JPAExpressions.select(subMessage2.id.max())
-                                        .from(subMessage2)
-                                        .where(
-                                                subMessage2.room.id.eq(message.room.id),
-                                                subMessage2.createdAt.eq(message.createdAt)
-                                        )
-                        )
-                )
-                .fetch();
+        List<LatestMessageDto> latestMessages = findLatestMessagesByRoomIds(roomIds);
 
         Map<Long, LatestMessageDto> latestMessageMap = latestMessages.stream()
                 .collect(Collectors.toMap(LatestMessageDto::roomId, lm -> lm, (existing, replacement) -> existing));
@@ -187,5 +163,58 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
                         .where(chatRoom.id.eq(roomId))
                         .fetchFirst()
         );
+    }
+
+    private List<LatestMessageDto> findLatestMessagesByRoomIds(List<Long> roomIds) {
+        String placeholders = roomIds.stream()
+                .map(roomId -> "?")
+                .collect(Collectors.joining(", "));
+
+        String sql = """
+                SELECT room_id, message_id, content, message_type, created_at
+                FROM (
+                    SELECT
+                        room_id,
+                        message_id,
+                        content,
+                        message_type,
+                        created_at,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY room_id
+                            ORDER BY created_at DESC, message_id DESC
+                        ) AS row_num
+                    FROM tbl_chat_message
+                    WHERE room_id IN (%s)
+                ) ranked_message
+                WHERE row_num = 1
+                """.formatted(placeholders);
+
+        Query query = entityManager.createNativeQuery(sql);
+        for (int i = 0; i < roomIds.size(); i++) {
+            query.setParameter(i + 1, roomIds.get(i));
+        }
+
+        @SuppressWarnings("unchecked")
+        List<Object[]> rows = query.getResultList();
+
+        return rows.stream()
+                .map(row -> new LatestMessageDto(
+                        ((Number) row[0]).longValue(),
+                        ((Number) row[1]).longValue(),
+                        (String) row[2],
+                        MessageType.valueOf(String.valueOf(row[3])),
+                        toLocalDateTime(row[4])
+                ))
+                .toList();
+    }
+
+    private LocalDateTime toLocalDateTime(Object value) {
+        if (value instanceof LocalDateTime localDateTime) {
+            return localDateTime;
+        }
+        if (value instanceof Timestamp timestamp) {
+            return timestamp.toLocalDateTime();
+        }
+        throw new IllegalArgumentException("Unsupported created_at type: " + value.getClass());
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
@@ -2,6 +2,7 @@ package team.startup.gwangsan.domain.chat.repository.custom.impl;
 
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -57,6 +58,8 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
     @Override
     public List<GetRoomsDto> findRoomsByMemberId(Long memberId) {
         QChatMessage message = QChatMessage.chatMessage;
+        QChatMessage subMessage = new QChatMessage("subMessage");
+        QChatMessage subMessage2 = new QChatMessage("subMessage2");
         QChatMessage unreadMessage = new QChatMessage("unreadMessage");
         QMember buyer = new QMember("buyer");
         QMember seller = new QMember("seller");
@@ -101,16 +104,26 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
                         message.createdAt
                 ))
                 .from(message)
-                .where(message.room.id.in(roomIds))
-                .orderBy(message.room.id.asc(),
-                        message.createdAt.desc(),
-                        message.id.desc())
+                .where(
+                        message.room.id.in(roomIds),
+                        message.createdAt.eq(
+                                JPAExpressions.select(subMessage.createdAt.max())
+                                        .from(subMessage)
+                                        .where(subMessage.room.id.eq(message.room.id))
+                        ),
+                        message.id.eq(
+                                JPAExpressions.select(subMessage2.id.max())
+                                        .from(subMessage2)
+                                        .where(
+                                                subMessage2.room.id.eq(message.room.id),
+                                                subMessage2.createdAt.eq(message.createdAt)
+                                        )
+                        )
+                )
                 .fetch();
 
-        Map<Long, LatestMessageDto> latestMessageMap = new LinkedHashMap<>();
-        for (LatestMessageDto lm : latestMessages) {
-            latestMessageMap.putIfAbsent(lm.roomId(), lm);
-        }
+        Map<Long, LatestMessageDto> latestMessageMap = latestMessages.stream()
+                .collect(Collectors.toMap(LatestMessageDto::roomId, lm -> lm));
 
         List<UnreadCountDto> unreadCounts = queryFactory
                 .select(Projections.constructor(UnreadCountDto.class,

--- a/src/test/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImplTest.java
@@ -39,7 +39,7 @@ class ChatRoomCustomRepositoryImplTest {
 
     @BeforeEach
     void setUp() {
-        repository = new ChatRoomCustomRepositoryImpl(new JPAQueryFactory(em.getEntityManager()));
+        repository = new ChatRoomCustomRepositoryImpl(new JPAQueryFactory(em.getEntityManager()), em.getEntityManager());
     }
 
     private Member createMember(String nickname, String phone) {

--- a/src/test/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImplTest.java
@@ -1,0 +1,138 @@
+package team.startup.gwangsan.domain.chat.repository.custom.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+import team.startup.gwangsan.domain.chat.entity.ChatMessage;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
+import team.startup.gwangsan.domain.chat.presentation.dto.GetRoomsDto;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.Type;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+@DisplayName("ChatRoomCustomRepositoryImpl 통합 테스트")
+class ChatRoomCustomRepositoryImplTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    private ChatRoomCustomRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new ChatRoomCustomRepositoryImpl(new JPAQueryFactory(em.getEntityManager()));
+    }
+
+    private Member createMember(String nickname, String phone) {
+        return em.persist(Member.builder()
+                .name("테스트")
+                .nickname(nickname)
+                .password("pw")
+                .phoneNumber(phone)
+                .role(MemberRole.ROLE_USER)
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    private Product createProduct(Member owner) {
+        return em.persist(Product.builder()
+                .title("상품")
+                .description("설명")
+                .gwangsan(5000)
+                .member(owner)
+                .type(Type.SERVICE)
+                .mode(Mode.GIVER)
+                .status(ProductStatus.ONGOING)
+                .build());
+    }
+
+    private ChatRoom createRoom(Member buyer, Member seller, Product product) {
+        return em.persist(ChatRoom.builder()
+                .isActive(true)
+                .buyer(buyer)
+                .seller(seller)
+                .product(product)
+                .build());
+    }
+
+    private void createMessage(Long id, ChatRoom room, Member sender, String content, LocalDateTime createdAt) {
+        em.persist(ChatMessage.builder()
+                .id(id)
+                .content(content)
+                .messageType(MessageType.TEXT)
+                .checked(false)
+                .room(room)
+                .sender(sender)
+                .createdAt(createdAt)
+                .build());
+    }
+
+    @Nested
+    @DisplayName("findRoomsByMemberId()는")
+    class Describe_findRoomsByMemberId {
+
+        @Test
+        @DisplayName("createdAt이 최신인데 id가 더 작은 메시지를 최신 메시지로 반환한다")
+        void it_selects_message_with_latest_createdAt_even_if_id_is_smaller() {
+            Member buyer = createMember("buyer1", "010-0001-0001");
+            Member seller = createMember("seller1", "010-0001-0002");
+            ChatRoom room = createRoom(buyer, seller, createProduct(seller));
+
+            LocalDateTime older = LocalDateTime.of(2024, 1, 1, 10, 0);
+            LocalDateTime newer = LocalDateTime.of(2024, 1, 1, 10, 1);
+
+            createMessage(100L, room, seller, "오래된 메시지", older);   // id 높음, 시간 오래됨
+            createMessage(90L, room, buyer, "최신 메시지", newer);       // id 낮음, 시간 최신
+
+            em.flush();
+            em.getEntityManager().clear();
+
+            List<GetRoomsDto> result = repository.findRoomsByMemberId(buyer.getId());
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).messageId()).isEqualTo(90L);
+            assertThat(result.get(0).lastMessage()).isEqualTo("최신 메시지");
+        }
+
+        @Test
+        @DisplayName("createdAt이 같을 때 id가 더 큰 메시지를 최신 메시지로 반환한다")
+        void it_selects_message_with_larger_id_when_createdAt_is_same() {
+            Member buyer = createMember("buyer2", "010-0002-0001");
+            Member seller = createMember("seller2", "010-0002-0002");
+            ChatRoom room = createRoom(buyer, seller, createProduct(seller));
+
+            LocalDateTime sameTime = LocalDateTime.of(2024, 1, 1, 10, 0);
+
+            createMessage(10L, room, seller, "먼저 온 메시지", sameTime);
+            createMessage(20L, room, buyer, "나중에 온 메시지", sameTime);
+
+            em.flush();
+            em.getEntityManager().clear();
+
+            List<GetRoomsDto> result = repository.findRoomsByMemberId(buyer.getId());
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).messageId()).isEqualTo(20L);
+            assertThat(result.get(0).lastMessage()).isEqualTo("나중에 온 메시지");
+        }
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

`GET /api/chat/rooms` API에서 채팅방 목록 조회 시, 각 채팅방의 최신 메시지 1건을 구하기 위해 해당 채팅방의 전체 메시지를 Java 메모리로 끌어온 뒤 `putIfAbsent`로 필터링하는 구조적 성능 문제가 존재하였습니다.

채팅방 10개 × 메시지 1,000개 기준으로 DB에서 10,000건을 반환하고 Java에서 9,990건을 즉시 폐기하는 방식으로, 채팅 사용량이 늘어날수록 응답 지연이 선형으로 증가하는 Critical Path 상의 문제였습니다.

Resolves: #334

## 📃 작업내용

- `ChatRoomCustomRepositoryImpl.findRoomsByMemberId()` 최신 메시지 조회 쿼리를 QueryDSL Correlated Subquery 방식으로 교체하였습니다.
  - 기존: 전체 메시지 fetch 후 Java `putIfAbsent`로 필터링
  - 변경: `MAX(createdAt)` + 동률 시 `MAX(id)` 이중 서브쿼리로 DB 레벨에서 채팅방당 1건만 반환
- 기존 정렬 기준(`createdAt DESC, id DESC`)의 의미를 그대로 보존하였습니다.
- 스키마 변경 없이 기존 인덱스 `(room_id, created_at, message_id)` 를 그대로 활용합니다.
- `ChatRoomCustomRepositoryImplTest` Repository 통합 테스트 2케이스를 추가하였습니다.
  - `createdAt`이 최신인데 `id`가 더 작은 메시지를 최신으로 선택하는 케이스
  - 동일 `createdAt`에서 `id`가 더 큰 메시지를 최신으로 선택하는 케이스

## 🙋‍♂️ 리뷰노트

`MAX(id)` 단일 조건으로 먼저 구현하였으나, `SaveChatMessageServiceImpl`에서 `messageId`와 `createdAt`이 외부 입력으로 저장되어 ID가 시간 순서를 보장하지 않는다는 피드백을 반영하여 이중 서브쿼리 방식으로 수정하였습니다.

Native Query(Window Function) 대신 QueryDSL Correlated Subquery를 선택한 이유는 기존 코드베이스의 QueryDSL 패턴을 유지하고 타입 안전성을 확보하기 위함입니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타
