### PR TITLE
리뷰 상세 조회 시 productId 누락 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/review/presentation/dto/response/ReviewDetailResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/presentation/dto/response/ReviewDetailResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public record ReviewDetailResponse(
         Long reviewId,
+        Long productId,
         String title,
         String content,
         Integer light,

--- a/src/main/java/team/startup/gwangsan/domain/review/service/impl/GetReviewDetailServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/service/impl/GetReviewDetailServiceImpl.java
@@ -35,6 +35,7 @@ public class GetReviewDetailServiceImpl implements GetReviewDetailService {
 
         return new ReviewDetailResponse(
                 review.getId(),
+                review.getProduct().getId(),
                 review.getProduct().getTitle(),
                 review.getContent(),
                 review.getLight(),

--- a/src/test/java/team/startup/gwangsan/domain/review/service/impl/GetReviewDetailServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/review/service/impl/GetReviewDetailServiceImplTest.java
@@ -79,6 +79,7 @@ class GetReviewDetailServiceImplTest {
                 ReviewDetailResponse response = service.execute(1L);
 
                 assertThat(response.reviewId()).isEqualTo(1L);
+                assertThat(response.productId()).isEqualTo(100L);
                 assertThat(response.title()).isEqualTo("상품명");
                 assertThat(response.content()).isEqualTo("좋았어요");
                 assertThat(response.light()).isEqualTo(8);


### PR DESCRIPTION
## 💡 배경 및 개요

`GET /api/review/detail/{reviewId}` 응답인 `ReviewDetailResponse`에 `productId` 필드가 빠져있어, 같은 도메인의 목록 조회 응답(`ReviewResponse`)과 달리 프론트에서 리뷰 상세 화면에서 상품 id를 알 수 없는 상태였습니다.

## 📃 작업내용

- `ReviewDetailResponse`에 `productId` 필드 추가
- `GetReviewDetailServiceImpl`에서 `review.getProduct().getId()`를 채워 반환하도록 수정
- `GetReviewDetailServiceImplTest`에 `productId` 검증 케이스 추가

## 🙋‍♂️ 리뷰노트

`ReviewResponse`와 필드 구성을 맞추기 위해 `reviewId` 다음 순서에 `productId`를 배치했습니다.

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

관련 이슈를 찾지 못해 `Resolves` 라인은 생략했습니다.