### PR TITLE
채팅 푸시 알림 미수신 개선

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
@@ -20,6 +20,7 @@ import team.startup.gwangsan.domain.image.repository.ImageRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.repository.MemberRepository;
+import team.startup.gwangsan.domain.notification.entity.DeviceToken;
 import team.startup.gwangsan.domain.notification.entity.constant.NotificationType;
 import team.startup.gwangsan.domain.notification.repository.DeviceTokenRepository;
 import team.startup.gwangsan.global.event.SendNotificationEvent;
@@ -68,10 +69,12 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
 
         Member otherMember = member.getId().equals(chatRoom.getBuyer().getId()) ? chatRoom.getSeller() : chatRoom.getBuyer();
 
-        deviceTokenRepository.findByUserId(otherMember.getId())
-                .ifPresent(token -> applicationEventPublisher.publishEvent(
-                        new SendNotificationEvent(List.of(token), NotificationType.CHATTING, roomId)
-                ));
+        List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserId(otherMember.getId());
+        if (!deviceTokens.isEmpty()) {
+            applicationEventPublisher.publishEvent(
+                    new SendNotificationEvent(deviceTokens, NotificationType.CHATTING, roomId)
+            );
+        }
 
         return new SaveChatMessageResponse(
                 chatMessage.getId(),

--- a/src/main/java/team/startup/gwangsan/domain/notice/service/impl/CreateNoticeServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/notice/service/impl/CreateNoticeServiceImpl.java
@@ -85,8 +85,7 @@ public class CreateNoticeServiceImpl implements CreateNoticeService {
 
         List<DeviceToken> deviceTokens = new ArrayList<>();
         for (Long memberId : memberIds) {
-            deviceTokenRepository.findByUserId(memberId)
-                    .ifPresent(deviceTokens::add);
+            deviceTokens.addAll(deviceTokenRepository.findAllByUserId(memberId));
         }
 
         applicationEventPublisher.publishEvent(new SendNotificationEvent(

--- a/src/main/java/team/startup/gwangsan/domain/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/notification/repository/DeviceTokenRepository.java
@@ -3,8 +3,8 @@ package team.startup.gwangsan.domain.notification.repository;
 import org.springframework.data.repository.CrudRepository;
 import team.startup.gwangsan.domain.notification.entity.DeviceToken;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface DeviceTokenRepository extends CrudRepository<DeviceToken, String> {
-    Optional<DeviceToken> findByUserId(Long userId);
+    List<DeviceToken> findAllByUserId(Long userId);
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
@@ -167,8 +167,7 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
         List<DeviceToken> deviceTokens = new ArrayList<>();
 
         for (Long memberId : memberIds) {
-            deviceTokenRepository.findByUserId(memberId)
-                    .ifPresent(deviceTokens::add);
+            deviceTokens.addAll(deviceTokenRepository.findAllByUserId(memberId));
         }
 
         tradeCompleteRepository.deleteByProductAndStatus(product, TradeStatus.PENDING);

--- a/src/main/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapter.java
+++ b/src/main/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapter.java
@@ -113,6 +113,7 @@ public class ExpoPushAdapter implements NotificationPort {
 
     List<String> expoTokens(List<DeviceToken> deviceTokens) {
         return deviceTokens.stream()
+                .filter(Objects::nonNull)
                 .map(DeviceToken::getDeviceToken)
                 .filter(Objects::nonNull)
                 .filter(this::isExpoPushToken)

--- a/src/main/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapter.java
+++ b/src/main/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapter.java
@@ -1,5 +1,9 @@
 package team.startup.gwangsan.global.thirdparty.expo;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -22,9 +26,11 @@ public class ExpoPushAdapter implements NotificationPort {
 
     private final RetryTemplate retryTemplate;
     private final WebClient expoClient;
+    private final Gson gson;
 
-    public ExpoPushAdapter(RetryTemplate retryTemplate, WebClient.Builder webClientBuilder) {
+    public ExpoPushAdapter(RetryTemplate retryTemplate, WebClient.Builder webClientBuilder, Gson gson) {
         this.retryTemplate = retryTemplate;
+        this.gson = gson;
         this.expoClient = webClientBuilder
                 .baseUrl("https://exp.host")
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -39,11 +45,7 @@ public class ExpoPushAdapter implements NotificationPort {
             return;
         }
 
-        List<String> expoTokens = deviceTokens.stream()
-                .map(DeviceToken::getDeviceToken)
-                .filter(Objects::nonNull)
-                .filter(this::isExpoPushToken)
-                .toList();
+        List<String> expoTokens = expoTokens(deviceTokens);
 
         if (!expoTokens.isEmpty()) {
             sendByExpo(expoTokens, title, body, type, sourceId);
@@ -100,11 +102,56 @@ public class ExpoPushAdapter implements NotificationPort {
                             .block(Duration.ofSeconds(5));
 
                     log.info("[Expo] 응답: {}", resp);
+                    logExpoErrors(resp);
                     return null;
                 });
             } catch (Exception e) {
                 log.error("[Expo] 전송 실패: {}", e.getMessage(), e);
             }
         }
+    }
+
+    List<String> expoTokens(List<DeviceToken> deviceTokens) {
+        return deviceTokens.stream()
+                .map(DeviceToken::getDeviceToken)
+                .filter(Objects::nonNull)
+                .filter(this::isExpoPushToken)
+                .distinct()
+                .toList();
+    }
+
+    int logExpoErrors(String response) {
+        if (response == null || response.isBlank()) return 0;
+        try {
+            JsonObject root = gson.fromJson(response, JsonObject.class);
+            if (root == null || !root.has("data") || !root.get("data").isJsonArray()) return 0;
+
+            JsonArray data = root.getAsJsonArray("data");
+            int errors = 0;
+            for (JsonElement element : data) {
+                if (!element.isJsonObject()) continue;
+                JsonObject ticket = element.getAsJsonObject();
+                if (!"error".equals(asString(ticket, "status"))) continue;
+                errors++;
+
+                JsonObject details = ticket.has("details") && ticket.get("details").isJsonObject()
+                        ? ticket.getAsJsonObject("details")
+                        : null;
+                log.warn(
+                        "[Expo] ticket error: message={}, error={}, details={}",
+                        asString(ticket, "message"),
+                        details == null ? null : asString(details, "error"),
+                        details
+                );
+            }
+            return errors;
+        } catch (Exception e) {
+            log.warn("[Expo] 응답 파싱 실패: {}", e.getMessage());
+            return 0;
+        }
+    }
+
+    private String asString(JsonObject object, String key) {
+        return object.has(key) && !object.get(key).isJsonNull() ? object.get(key).getAsString() : null;
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImplTest.java
@@ -76,7 +76,7 @@ class SaveChatMessageServiceImplTest {
             when(memberRepository.findById(1L)).thenReturn(Optional.of(sender));
             when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
             when(chatMessageRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-            when(deviceTokenRepository.findByUserId(any())).thenReturn(Optional.empty());
+            when(deviceTokenRepository.findAllByUserId(any())).thenReturn(List.of());
         }
 
         @Test
@@ -176,8 +176,9 @@ class SaveChatMessageServiceImplTest {
         @DisplayName("상대방 디바이스 토큰이 있으면 CHATTING 타입 알림 이벤트를 발행한다")
         void it_publishes_notification_event_when_device_token_exists() {
             arrangeDefaultScenario();
-            DeviceToken token = mock(DeviceToken.class);
-            when(deviceTokenRepository.findByUserId(2L)).thenReturn(Optional.of(token));
+            DeviceToken token1 = mock(DeviceToken.class);
+            DeviceToken token2 = mock(DeviceToken.class);
+            when(deviceTokenRepository.findAllByUserId(2L)).thenReturn(List.of(token1, token2));
 
             service.execute(1L, 10L, "안녕", null, MessageType.TEXT, 1L, now);
 
@@ -185,7 +186,7 @@ class SaveChatMessageServiceImplTest {
             verify(applicationEventPublisher).publishEvent(captor.capture());
             assertThat(captor.getValue().type()).isEqualTo(NotificationType.CHATTING);
             assertThat(captor.getValue().sourceId()).isEqualTo(10L);
-            assertThat(captor.getValue().deviceTokens()).containsExactly(token);
+            assertThat(captor.getValue().deviceTokens()).containsExactly(token1, token2);
         }
 
         @Test
@@ -205,7 +206,7 @@ class SaveChatMessageServiceImplTest {
 
             service.execute(1L, 10L, "안녕", null, MessageType.TEXT, 1L, now);
 
-            verify(deviceTokenRepository).findByUserId(2L);
+            verify(deviceTokenRepository).findAllByUserId(2L);
         }
 
         @Test
@@ -221,11 +222,11 @@ class SaveChatMessageServiceImplTest {
             when(memberRepository.findById(3L)).thenReturn(Optional.of(sellerMember));
             when(chatRoomRepository.findChatRoomByRoomId(20L)).thenReturn(Optional.of(room));
             when(chatMessageRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
-            when(deviceTokenRepository.findByUserId(any())).thenReturn(Optional.empty());
+            when(deviceTokenRepository.findAllByUserId(any())).thenReturn(List.of());
 
             service.execute(1L, 20L, "안녕", null, MessageType.TEXT, 3L, now);
 
-            verify(deviceTokenRepository).findByUserId(4L);
+            verify(deviceTokenRepository).findAllByUserId(4L);
         }
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/notice/service/impl/CreateNoticeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/notice/service/impl/CreateNoticeServiceImplTest.java
@@ -71,7 +71,7 @@ class CreateNoticeServiceImplTest {
                 when(imageRepository.findAllById(List.of(10L))).thenReturn(List.of(image));
                 when(memberDetailRepository.findAllByPlace(place)).thenReturn(List.of(memberDetail));
                 when(memberDetail.getId()).thenReturn(1L);
-                when(deviceTokenRepository.findByUserId(1L)).thenReturn(Optional.empty());
+                when(deviceTokenRepository.findAllByUserId(1L)).thenReturn(List.of());
 
                 CreateNoticeRequest request = new CreateNoticeRequest("제목", "내용", 1, List.of(10L));
                 service.execute(request);
@@ -99,7 +99,7 @@ class CreateNoticeServiceImplTest {
                 when(noticeRepository.save(any())).thenReturn(mock(Notice.class));
                 when(memberDetailRepository.findAllByPlace(place)).thenReturn(List.of(memberDetail));
                 when(memberDetail.getId()).thenReturn(1L);
-                when(deviceTokenRepository.findByUserId(1L)).thenReturn(Optional.empty());
+                when(deviceTokenRepository.findAllByUserId(1L)).thenReturn(List.of());
 
                 CreateNoticeRequest request = new CreateNoticeRequest("제목", "내용", 1, Collections.emptyList());
                 service.execute(request);

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
@@ -36,6 +36,7 @@ import team.startup.gwangsan.domain.trade.exception.*;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -337,10 +338,10 @@ class RequestTradeCompleteServiceImplTest {
                     TradeStatus.PENDING
             )).thenReturn(Optional.of(pending));
 
-            when(deviceTokenRepository.findByUserId(buyerId))
-                    .thenReturn(Optional.of(mock(DeviceToken.class)));
-            when(deviceTokenRepository.findByUserId(sellerId))
-                    .thenReturn(Optional.empty());
+            when(deviceTokenRepository.findAllByUserId(buyerId))
+                    .thenReturn(List.of(mock(DeviceToken.class)));
+            when(deviceTokenRepository.findAllByUserId(sellerId))
+                    .thenReturn(List.of());
 
             // when
             assertDoesNotThrow(() -> service.execute(productId, sellerId));
@@ -522,10 +523,10 @@ class RequestTradeCompleteServiceImplTest {
                     TradeStatus.PENDING
             )).thenReturn(Optional.of(pending));
 
-            when(deviceTokenRepository.findByUserId(buyerId))
-                    .thenReturn(Optional.of(mock(DeviceToken.class)));
-            when(deviceTokenRepository.findByUserId(sellerId))
-                    .thenReturn(Optional.empty());
+            when(deviceTokenRepository.findAllByUserId(buyerId))
+                    .thenReturn(List.of(mock(DeviceToken.class)));
+            when(deviceTokenRepository.findAllByUserId(sellerId))
+                    .thenReturn(List.of());
 
             // when
             assertDoesNotThrow(() -> service.execute(productId, sellerId));

--- a/src/test/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapterTest.java
+++ b/src/test/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapterTest.java
@@ -13,6 +13,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import team.startup.gwangsan.domain.notification.entity.DeviceToken;
 import team.startup.gwangsan.domain.notification.entity.constant.NotificationType;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -122,11 +123,12 @@ class ExpoPushAdapterTest {
         @Test
         @DisplayName("Expo 토큰만 중복 없이 반환한다")
         void it_returns_distinct_expo_tokens() {
-            List<DeviceToken> tokens = List.of(
+            List<DeviceToken> tokens = Arrays.asList(
                     DeviceToken.builder().deviceToken("ExponentPushToken[abc]").build(),
                     DeviceToken.builder().deviceToken("ExponentPushToken[abc]").build(),
                     DeviceToken.builder().deviceToken("fcm-token").build(),
-                    DeviceToken.builder().deviceToken(null).build()
+                    DeviceToken.builder().deviceToken(null).build(),
+                    null
             );
 
             assertThat(adapter.expoTokens(tokens)).containsExactly("ExponentPushToken[abc]");

--- a/src/test/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapterTest.java
+++ b/src/test/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapterTest.java
@@ -1,11 +1,12 @@
 package team.startup.gwangsan.global.thirdparty.expo;
 
+import com.google.gson.Gson;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -18,12 +19,12 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ExpoPushAdapter 단위 테스트")
 class ExpoPushAdapterTest {
 
-    @InjectMocks
     private ExpoPushAdapter adapter;
 
     @Mock
@@ -31,6 +32,12 @@ class ExpoPushAdapterTest {
 
     @Mock(answer = Answers.RETURNS_SELF)
     private WebClient.Builder webClientBuilder;
+
+    @BeforeEach
+    void setUp() {
+        when(webClientBuilder.build()).thenReturn(mock(WebClient.class));
+        adapter = new ExpoPushAdapter(retryTemplate, webClientBuilder, new Gson());
+    }
 
     @Nested
     @DisplayName("isExpoPushToken() 메서드는")
@@ -105,6 +112,42 @@ class ExpoPushAdapterTest {
             adapter.sendNotification(tokens, "title", "body", null, 1L);
 
             verifyNoInteractions(retryTemplate);
+        }
+    }
+
+    @Nested
+    @DisplayName("expoTokens() 메서드는")
+    class Describe_expoTokens {
+
+        @Test
+        @DisplayName("Expo 토큰만 중복 없이 반환한다")
+        void it_returns_distinct_expo_tokens() {
+            List<DeviceToken> tokens = List.of(
+                    DeviceToken.builder().deviceToken("ExponentPushToken[abc]").build(),
+                    DeviceToken.builder().deviceToken("ExponentPushToken[abc]").build(),
+                    DeviceToken.builder().deviceToken("fcm-token").build(),
+                    DeviceToken.builder().deviceToken(null).build()
+            );
+
+            assertThat(adapter.expoTokens(tokens)).containsExactly("ExponentPushToken[abc]");
+        }
+    }
+
+    @Nested
+    @DisplayName("logExpoErrors() 메서드는")
+    class Describe_logExpoErrors {
+
+        @Test
+        @DisplayName("Expo error ticket 개수를 반환한다")
+        void it_returns_error_ticket_count() {
+            String response = """
+                    {"data":[
+                      {"status":"ok","id":"ticket-id"},
+                      {"status":"error","message":"DeviceNotRegistered","details":{"error":"DeviceNotRegistered"}}
+                    ]}
+                    """;
+
+            assertThat(adapter.logExpoErrors(response)).isEqualTo(1);
         }
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

채팅 메시지 저장 시 수신자에게 푸시 알림이 도달하지 않는 문제가 있어 서버 측 알림 전송 흐름을 개선하였습니다.

기존에는 Redis device token을 `userId` 기준 단건으로 조회하여 여러 기기 또는 재로그인 상황에서 최신 Expo 토큰을 놓칠 수 있었습니다. 또한 Expo Push API 응답은 원문만 로그로 남아 ticket 단위 에러 원인을 확인하기 어려웠습니다.

Resolves: #340

## 📃 작업내용

- `DeviceTokenRepository`의 `userId` 조회를 단건 조회에서 다건 조회로 변경하였습니다.
- 채팅, 공지, 거래 완료 알림에서 대상 사용자의 device token을 모두 수집하여 푸시 이벤트에 전달하도록 변경하였습니다.
- Expo Push 전송 시 Expo 토큰만 필터링하고 중복 토큰을 제거하도록 변경하였습니다.
- Expo 응답의 ticket 단위 `status: error`를 경고 로그로 남기도록 추가하였습니다.
- 변경된 토큰 조회 방식과 Expo 응답 파싱을 검증하는 테스트를 수정 및 추가하였습니다.

## 🙋‍♂️ 리뷰노트

Redis 저장 구조는 변경하지 않고 기존 `deviceId` 키와 `userId` 인덱스를 그대로 사용하였습니다. 이번 PR은 채팅 푸시 미수신 원인 개선에 필요한 최소 범위로 제한하였습니다.

Expo 응답 파싱 실패는 푸시 전송 실패로 처리하지 않고 로그만 남기도록 하였습니다. 외부 응답 형식 변화가 실제 알림 전송 흐름을 막지 않도록 하기 위함입니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

Focused test를 통과하였습니다.

```bash
./gradlew test --tests '*ExpoPushAdapterTest' --tests '*SaveChatMessageServiceImplTest' --tests '*CreateNoticeServiceImplTest' --tests '*RequestTradeCompleteServiceImplTest'
```
