### PR TITLE
Expo 푸시 알림 발송 실패 원인 파악 로깅 개선

### DIFF
--- a/src/main/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapter.java
+++ b/src/main/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapter.java
@@ -47,9 +47,12 @@ public class ExpoPushAdapter implements NotificationPort {
 
         List<String> expoTokens = expoTokens(deviceTokens);
 
-        if (!expoTokens.isEmpty()) {
-            sendByExpo(expoTokens, title, body, type, sourceId);
+        if (expoTokens.isEmpty()) {
+            log.warn("[Expo] 대상 디바이스 토큰 {}건 중 Expo 형식(ExponentPushToken[...]) 토큰이 없어 전송을 건너뜁니다.", deviceTokens.size());
+            return;
         }
+
+        sendByExpo(expoTokens, title, body, type, sourceId);
     }
 
     boolean isExpoPushToken(String t) {

--- a/src/test/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapterTest.java
+++ b/src/test/java/team/startup/gwangsan/global/thirdparty/expo/ExpoPushAdapterTest.java
@@ -114,6 +114,20 @@ class ExpoPushAdapterTest {
 
             verifyNoInteractions(retryTemplate);
         }
+
+        @Test
+        @DisplayName("Expo 형식이 아닌 토큰만 있으면 전송을 시도하지 않는다")
+        void it_does_not_attempt_to_send_when_no_token_is_expo_format() {
+            DeviceToken nativeToken = DeviceToken.builder()
+                    .deviceId("device-1")
+                    .userId(1L)
+                    .deviceToken("fcm-native-registration-token")
+                    .build();
+
+            adapter.sendNotification(List.of(nativeToken), "title", "body", NotificationType.CHATTING, 1L);
+
+            verifyNoInteractions(retryTemplate);
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 💡 배경 및 개요

채팅 메시지 저장 시 수신자에게 푸시 알림이 도달하지 않는 문제(#340)를 조사하는 과정에서, `ExpoPushAdapter`가 발송 실패 원인을 추적할 수 없게 되어 있는 두 가지 지점을 발견하여 개선하였습니다.

- 대상 디바이스 토큰이 전부 Expo 형식(`ExponentPushToken[...]`)이 아닌 경우, 아무 로그 없이 조용히 발송을 건너뛰고 있었습니다.
- Expo Push API 응답을 원문 문자열로만 로그에 남기고 있어, 토큰별 `status: error`(예: `DeviceNotRegistered`) 원인을 서버 로그만으로 확인할 수 없었습니다.

관련: #340

## 📃 작업내용

- `ExpoPushAdapter.sendNotification()`: Expo 형식 토큰이 하나도 없을 때 대상 토큰 수를 포함한 warn 로그를 남기도록 수정하였습니다.
- `ExpoPushAdapter.sendByExpo()`: Expo 응답을 `String` 대신 구조화된 record(`ExpoPushResponse`, `ExpoPushTicket`, `ExpoPushErrorDetails`)로 파싱하여, 토큰별로 성공/실패를 개별 로그로 남기도록 수정하였습니다.
  - 성공: `[Expo] 전송 성공 - token: ..., id: ...`
  - 실패: `[Expo] 전송 실패 - token: ..., error: ..., message: ...`
- 위 변경에 대한 단위 테스트를 추가하였습니다.

## 🙋‍♂️ 리뷰노트

- 이번 PR은 #340에서 제시한 세 가지 의심 지점 중 "Expo 응답 원문 로그로는 ticket 단위 원인 확인 불가" 항목만 해결합니다. "Redis device token이 userId 단건 조회라 다중 기기/재로그인 시 최신 토큰을 놓칠 수 있는 문제"와 "Expo 토큰 중복 제거"는 이번 작업 범위에 포함하지 않았습니다. 그래서 이슈를 바로 닫지 않고 `관련`으로 연결해두었습니다.
- 실제 운영 환경에 저장된 디바이스 토큰이 Expo 형식인지(혹은 아직 네이티브 FCM 토큰인지)는 로컬 환경에서 확인할 수 없어, 이번 배포 후 서버 로그로 직접 확인이 필요합니다.
- Expo 응답 record 매핑은 실제 Expo API(`https://exp.host/--/api/v2/push/send`) 응답 형식으로 curl 호출해 확인하였습니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

배포 후 채팅 알림 발송 시 서버 로그에 `[Expo] 전송 성공/실패` 로그가 정상적으로 찍히는지 확인 부탁드립니다.
