### PR TITLE
리뷰 대상자 오류 및 채팅방 목록 거래 완료 표시 누락 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetRoomProductDto.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetRoomProductDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 public record GetRoomProductDto(
         Long productId,
         String title,
+        boolean isCompleted,
         List<GetImageResponse> images
 ) {
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/repository/custom/impl/ProductCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/custom/impl/ProductCustomRepositoryImpl.java
@@ -75,12 +75,13 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
                 .select(
                         product.id,
                         product.title,
+                        product.status,
                         image.id,
                         image.imageUrl
                 )
-                .from(productImage)
-                .join(productImage.product, product)
-                .join(productImage.image, image)
+                .from(product)
+                .leftJoin(productImage).on(productImage.product.eq(product))
+                .leftJoin(image).on(productImage.image.eq(image))
                 .where(product.id.in(productIds))
                 .fetch();
 
@@ -89,15 +90,18 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
         for (Tuple row : rows) {
             Long productId = row.get(product.id);
             String title = row.get(product.title);
+            ProductStatus status = row.get(product.status);
             Long imageId = row.get(image.id);
             String imageUrl = row.get(image.imageUrl);
 
             GetRoomProductDto dto = resultMap.computeIfAbsent(
                     productId,
-                    id -> new GetRoomProductDto(id, title, new ArrayList<>())
+                    id -> new GetRoomProductDto(id, title, status == ProductStatus.COMPLETED, new ArrayList<>())
             );
 
-            dto.images().add(new GetImageResponse(imageId, imageUrl));
+            if (imageId != null) {
+                dto.images().add(new GetImageResponse(imageId, imageUrl));
+            }
         }
 
         return new ArrayList<>(resultMap.values());

--- a/src/main/java/team/startup/gwangsan/domain/review/exception/CannotReviewSelfException.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/exception/CannotReviewSelfException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangsan.domain.review.exception;
+
+import team.startup.gwangsan.global.exception.ErrorCode;
+import team.startup.gwangsan.global.exception.GlobalException;
+
+public class CannotReviewSelfException extends GlobalException {
+    public CannotReviewSelfException() {
+        super(ErrorCode.CANNOT_REVIEW_SELF);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/review/exception/NotTradeParticipantException.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/exception/NotTradeParticipantException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangsan.domain.review.exception;
+
+import team.startup.gwangsan.global.exception.ErrorCode;
+import team.startup.gwangsan.global.exception.GlobalException;
+
+public class NotTradeParticipantException extends GlobalException {
+    public NotTradeParticipantException() {
+        super(ErrorCode.NOT_TRADE_PARTICIPANT);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/review/presentation/dto/request/CreateReviewRequest.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/presentation/dto/request/CreateReviewRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record CreateReviewRequest(
         @NotNull Long productId,
+        @NotNull Long otherMemberId,
         @NotBlank String content,
         @Min(0) @Max(100) Integer light
 ) {}

--- a/src/main/java/team/startup/gwangsan/domain/review/presentation/dto/response/ReviewResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/presentation/dto/response/ReviewResponse.java
@@ -10,5 +10,6 @@ public record ReviewResponse(
         String content,
         Integer light,
         String reviewerName,
+        String targetName,
         List<GetImageResponse> imageUrls
 ) {}

--- a/src/main/java/team/startup/gwangsan/domain/review/repository/custom/impl/ReviewCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/repository/custom/impl/ReviewCustomRepositoryImpl.java
@@ -26,7 +26,8 @@ public class ReviewCustomRepositoryImpl implements ReviewCustomRepository {
                         review.id,
                         review.product.id,
                         review.content,
-                        review.light
+                        review.light,
+                        review.reviewed.nickname
                 ))
                 .from(review)
                 .where(review.reviewer.id.eq(reviewerId))

--- a/src/main/java/team/startup/gwangsan/domain/review/repository/projection/MyReviewDto.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/repository/projection/MyReviewDto.java
@@ -4,5 +4,6 @@ public record MyReviewDto(
         Long reviewId,
         Long productId,
         String content,
-        Integer light
+        Integer light,
+        String reviewedNickname
 ) {}

--- a/src/main/java/team/startup/gwangsan/domain/review/service/impl/CreateReviewServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/service/impl/CreateReviewServiceImpl.java
@@ -8,7 +8,9 @@ import team.startup.gwangsan.domain.alert.entity.constant.AlertType;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
@@ -16,9 +18,14 @@ import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.review.entity.Review;
 import team.startup.gwangsan.domain.review.exception.AlreadyReviewedException;
 import team.startup.gwangsan.domain.review.exception.CannotReviewBeforeTradeException;
+import team.startup.gwangsan.domain.review.exception.CannotReviewSelfException;
+import team.startup.gwangsan.domain.review.exception.NotTradeParticipantException;
 import team.startup.gwangsan.domain.review.presentation.dto.request.CreateReviewRequest;
 import team.startup.gwangsan.domain.review.repository.ReviewRepository;
 import team.startup.gwangsan.domain.review.service.CreateReviewService;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
 import team.startup.gwangsan.global.util.BlockValidator;
 import team.startup.gwangsan.global.util.MemberUtil;
@@ -29,8 +36,10 @@ public class CreateReviewServiceImpl implements CreateReviewService {
 
     private final ReviewRepository reviewRepository;
     private final MemberUtil memberUtil;
+    private final MemberRepository memberRepository;
     private final ProductRepository productRepository;
     private final MemberDetailRepository memberDetailRepository;
+    private final TradeCompleteRepository tradeCompleteRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final BlockValidator blockValidator;
 
@@ -39,20 +48,40 @@ public class CreateReviewServiceImpl implements CreateReviewService {
     public void execute(CreateReviewRequest request) {
         Member reviewer = memberUtil.getCurrentMember();
 
+        if (reviewer.getId().equals(request.otherMemberId())) {
+            throw new CannotReviewSelfException();
+        }
+
         Product product = productRepository.findById(request.productId())
                 .orElseThrow(NotFoundProductException::new);
 
-        blockValidator.validate(reviewer, product.getMember());
-
         if (product.getStatus() != ProductStatus.COMPLETED) {
             throw new CannotReviewBeforeTradeException();
+        }
+
+        Member reviewed = memberRepository.findById(request.otherMemberId())
+                .orElseThrow(NotFoundMemberException::new);
+
+        blockValidator.validate(reviewer, reviewed);
+
+        TradeComplete completedTrade = tradeCompleteRepository
+                .findByProductAndStatus(product, TradeStatus.COMPLETED)
+                .orElseThrow(CannotReviewBeforeTradeException::new);
+
+        Long buyerId = completedTrade.getBuyer().getId();
+        Long sellerId = completedTrade.getSeller().getId();
+        boolean isTradeParticipants =
+                (buyerId.equals(reviewer.getId()) && sellerId.equals(reviewed.getId()))
+                        || (sellerId.equals(reviewer.getId()) && buyerId.equals(reviewed.getId()));
+
+        if (!isTradeParticipants) {
+            throw new NotTradeParticipantException();
         }
 
         if (reviewRepository.existsByProductAndReviewer(product, reviewer)) {
             throw new AlreadyReviewedException();
         }
 
-        Member reviewed = product.getMember();
         MemberDetail reviewedDetail = memberDetailRepository.findByMember(reviewed)
                 .orElseThrow(NotFoundMemberDetailException::new);
 

--- a/src/main/java/team/startup/gwangsan/domain/review/service/impl/GetMyReviewListServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/service/impl/GetMyReviewListServiceImpl.java
@@ -56,6 +56,7 @@ public class GetMyReviewListServiceImpl implements GetMyReviewListService {
                         r.content(),
                         r.light(),
                         reviewer.getNickname(),
+                        r.reviewedNickname(),
                         imagesByProductId.getOrDefault(r.productId(), List.of())
                 ))
                 .toList();

--- a/src/main/java/team/startup/gwangsan/domain/review/service/impl/GetReceivedReviewListServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/service/impl/GetReceivedReviewListServiceImpl.java
@@ -61,6 +61,7 @@ public class GetReceivedReviewListServiceImpl implements GetReceivedReviewListSe
                         r.content(),
                         r.light(),
                         r.reviewerNickname(),
+                        reviewed.getNickname(),
                         imagesByProductId.getOrDefault(r.productId(), List.of())
                 ))
                 .toList();

--- a/src/main/java/team/startup/gwangsan/domain/review/service/impl/GetReviewByMemberServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/service/impl/GetReviewByMemberServiceImpl.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
+import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
@@ -28,7 +29,7 @@ public class GetReviewByMemberServiceImpl implements GetReviewByMemberService {
     @Transactional(readOnly = true)
     public List<ReviewResponse> execute(Long memberId) {
 
-        memberRepository.findById(memberId)
+        Member target = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
 
         List<ReceivedReviewDto> rows = reviewRepository.findReceivedReviews(memberId);
@@ -59,6 +60,7 @@ public class GetReviewByMemberServiceImpl implements GetReviewByMemberService {
                         r.content(),
                         r.light(),
                         r.reviewerNickname(),
+                        target.getNickname(),
                         imagesByProductId.getOrDefault(r.productId(), List.of())
                 ))
                 .toList();

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/TradeCompleteRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/TradeCompleteRepository.java
@@ -15,6 +15,8 @@ import java.util.Optional;
 public interface TradeCompleteRepository extends JpaRepository<TradeComplete, Long>, TradeCompleteCustomRepository {
     Optional<TradeComplete> findByProductAndBuyerAndSellerAndStatus(Product product, Member buyer, Member seller, TradeStatus tradeStatus);
 
+    Optional<TradeComplete> findByProductAndStatus(Product product, TradeStatus tradeStatus);
+
     void deleteByProductAndStatus(Product product, TradeStatus tradeStatus);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/team/startup/gwangsan/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangsan/global/exception/ErrorCode.java
@@ -86,6 +86,8 @@ public enum ErrorCode {
     // review
     ALREADY_REVIEWED(409, "이미 리뷰를 작성하였습니다."),
     CANNOT_REVIEW_BEFORE_TRADE(403, "거래가 완료되지 않아 리뷰를 작성할 수 없습니다."),
+    CANNOT_REVIEW_SELF(400, "본인에게는 리뷰를 작성할 수 없습니다."),
+    NOT_TRADE_PARTICIPANT(403, "거래 당사자만 리뷰를 작성할 수 있습니다."),
     NOT_FOUND_REVIEW(404, "해당하는 후기를 찾을 수 없습니다."),
 
     // chat

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindRoomsByCurrentUserServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindRoomsByCurrentUserServiceImplTest.java
@@ -66,7 +66,7 @@ class FindRoomsByCurrentUserServiceImplTest {
                     10L, null, 1L, "마지막 메시지", MessageType.TEXT,
                     LocalDateTime.now(), 0L, 100L
             );
-            GetRoomProductDto productDto = new GetRoomProductDto(100L, "상품명", List.of());
+            GetRoomProductDto productDto = new GetRoomProductDto(100L, "상품명", false, List.of());
 
             when(chatRoomRepository.findRoomsByMemberId(1L)).thenReturn(List.of(roomDto));
             when(productRepository.findRoomProductsWithImagesByIds(Set.of(100L))).thenReturn(List.of(productDto));
@@ -84,8 +84,8 @@ class FindRoomsByCurrentUserServiceImplTest {
         void it_maps_each_room_to_correct_product() {
             GetRoomsDto room1 = new GetRoomsDto(1L, null, 1L, "msg1", MessageType.TEXT, LocalDateTime.now(), 0L, 100L);
             GetRoomsDto room2 = new GetRoomsDto(2L, null, 2L, "msg2", MessageType.TEXT, LocalDateTime.now(), 1L, 200L);
-            GetRoomProductDto product1 = new GetRoomProductDto(100L, "상품1", List.of());
-            GetRoomProductDto product2 = new GetRoomProductDto(200L, "상품2", List.of());
+            GetRoomProductDto product1 = new GetRoomProductDto(100L, "상품1", false, List.of());
+            GetRoomProductDto product2 = new GetRoomProductDto(200L, "상품2", true, List.of());
 
             when(chatRoomRepository.findRoomsByMemberId(1L)).thenReturn(List.of(room1, room2));
             when(productRepository.findRoomProductsWithImagesByIds(Set.of(100L, 200L)))

--- a/src/test/java/team/startup/gwangsan/domain/review/service/impl/CreateReviewServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/review/service/impl/CreateReviewServiceImplTest.java
@@ -10,15 +10,22 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.review.exception.AlreadyReviewedException;
 import team.startup.gwangsan.domain.review.exception.CannotReviewBeforeTradeException;
+import team.startup.gwangsan.domain.review.exception.CannotReviewSelfException;
+import team.startup.gwangsan.domain.review.exception.NotTradeParticipantException;
 import team.startup.gwangsan.domain.review.presentation.dto.request.CreateReviewRequest;
 import team.startup.gwangsan.domain.review.repository.ReviewRepository;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 import team.startup.gwangsan.global.util.BlockValidator;
 import team.startup.gwangsan.global.util.MemberUtil;
 
@@ -36,10 +43,25 @@ class CreateReviewServiceImplTest {
 
     @Mock private ReviewRepository reviewRepository;
     @Mock private MemberUtil memberUtil;
+    @Mock private MemberRepository memberRepository;
     @Mock private ProductRepository productRepository;
     @Mock private MemberDetailRepository memberDetailRepository;
+    @Mock private TradeCompleteRepository tradeCompleteRepository;
     @Mock private org.springframework.context.ApplicationEventPublisher applicationEventPublisher;
     @Mock private BlockValidator blockValidator;
+
+    private Member mockMember(Long id) {
+        Member member = mock(Member.class);
+        lenient().when(member.getId()).thenReturn(id);
+        return member;
+    }
+
+    private TradeComplete mockCompletedTrade(Member buyer, Member seller) {
+        TradeComplete tradeComplete = mock(TradeComplete.class);
+        lenient().when(tradeComplete.getBuyer()).thenReturn(buyer);
+        lenient().when(tradeComplete.getSeller()).thenReturn(seller);
+        return tradeComplete;
+    }
 
     @Nested
     @DisplayName("execute() 메서드는")
@@ -52,27 +74,44 @@ class CreateReviewServiceImplTest {
             @Test
             @DisplayName("리뷰를 저장하고 이벤트를 발행한다")
             void it_saves_review_and_publishes_event() {
-                Member reviewer = mock(Member.class);
-                Member reviewed = mock(Member.class);
-                when(reviewed.getId()).thenReturn(2L);
+                Member reviewer = mockMember(1L);
+                Member reviewed = mockMember(2L);
 
                 Product product = mock(Product.class);
                 when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
-                when(product.getMember()).thenReturn(reviewed);
 
                 MemberDetail reviewedDetail = mock(MemberDetail.class);
+                TradeComplete completedTrade = mockCompletedTrade(reviewer, reviewed);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
                 when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
+                when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(completedTrade));
                 when(reviewRepository.existsByProductAndReviewer(product, reviewer)).thenReturn(false);
                 when(memberDetailRepository.findByMember(reviewed)).thenReturn(Optional.of(reviewedDetail));
 
-                CreateReviewRequest request = new CreateReviewRequest(1L, "좋았어요", 80);
+                CreateReviewRequest request = new CreateReviewRequest(1L, 2L, "좋았어요", 80);
                 service.execute(request);
 
                 verify(reviewedDetail).plusLight(80);
                 verify(reviewRepository).save(any());
                 verify(applicationEventPublisher).publishEvent(any(Object.class));
+            }
+        }
+
+        @Nested
+        @DisplayName("본인을 리뷰 대상으로 지정했을 때")
+        class Context_with_self_review {
+
+            @Test
+            @DisplayName("CannotReviewSelfException을 던진다")
+            void it_throws_cannot_review_self_exception() {
+                Member reviewer = mockMember(1L);
+                when(memberUtil.getCurrentMember()).thenReturn(reviewer);
+
+                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 1L, "내용", 50)))
+                        .isInstanceOf(CannotReviewSelfException.class);
             }
         }
 
@@ -83,11 +122,11 @@ class CreateReviewServiceImplTest {
             @Test
             @DisplayName("NotFoundProductException을 던진다")
             void it_throws_not_found_product_exception() {
-                Member reviewer = mock(Member.class);
+                Member reviewer = mockMember(1L);
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
                 when(productRepository.findById(99L)).thenReturn(Optional.empty());
 
-                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(99L, "내용", 50)))
+                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(99L, 2L, "내용", 50)))
                         .isInstanceOf(NotFoundProductException.class);
             }
         }
@@ -99,18 +138,88 @@ class CreateReviewServiceImplTest {
             @Test
             @DisplayName("CannotReviewBeforeTradeException을 던진다")
             void it_throws_cannot_review_before_trade_exception() {
-                Member reviewer = mock(Member.class);
-                Member owner = mock(Member.class);
+                Member reviewer = mockMember(1L);
 
                 Product product = mock(Product.class);
                 when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
-                when(product.getMember()).thenReturn(owner);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
                 when(productRepository.findById(1L)).thenReturn(Optional.of(product));
 
-                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, "내용", 50)))
+                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 2L, "내용", 50)))
                         .isInstanceOf(CannotReviewBeforeTradeException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("리뷰 대상 회원이 없을 때")
+        class Context_with_target_member_not_found {
+
+            @Test
+            @DisplayName("NotFoundMemberException을 던진다")
+            void it_throws_not_found_member_exception() {
+                Member reviewer = mockMember(1L);
+
+                Product product = mock(Product.class);
+                when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
+
+                when(memberUtil.getCurrentMember()).thenReturn(reviewer);
+                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(memberRepository.findById(2L)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 2L, "내용", 50)))
+                        .isInstanceOf(NotFoundMemberException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("완료된 거래 내역을 찾을 수 없을 때")
+        class Context_with_completed_trade_not_found {
+
+            @Test
+            @DisplayName("CannotReviewBeforeTradeException을 던진다")
+            void it_throws_cannot_review_before_trade_exception() {
+                Member reviewer = mockMember(1L);
+                Member reviewed = mockMember(2L);
+
+                Product product = mock(Product.class);
+                when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
+
+                when(memberUtil.getCurrentMember()).thenReturn(reviewer);
+                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
+                when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 2L, "내용", 50)))
+                        .isInstanceOf(CannotReviewBeforeTradeException.class);
+            }
+        }
+
+        @Nested
+        @DisplayName("지정한 대상이 거래 당사자가 아닐 때")
+        class Context_with_not_trade_participant {
+
+            @Test
+            @DisplayName("NotTradeParticipantException을 던진다")
+            void it_throws_not_trade_participant_exception() {
+                Member reviewer = mockMember(1L);
+                Member reviewed = mockMember(2L);
+                Member thirdParty = mockMember(3L);
+
+                Product product = mock(Product.class);
+                when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
+
+                TradeComplete completedTrade = mockCompletedTrade(reviewer, thirdParty);
+
+                when(memberUtil.getCurrentMember()).thenReturn(reviewer);
+                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
+                when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(completedTrade));
+
+                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 2L, "내용", 50)))
+                        .isInstanceOf(NotTradeParticipantException.class);
             }
         }
 
@@ -121,18 +230,22 @@ class CreateReviewServiceImplTest {
             @Test
             @DisplayName("AlreadyReviewedException을 던진다")
             void it_throws_already_reviewed_exception() {
-                Member reviewer = mock(Member.class);
-                Member owner = mock(Member.class);
+                Member reviewer = mockMember(1L);
+                Member reviewed = mockMember(2L);
 
                 Product product = mock(Product.class);
                 when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
-                when(product.getMember()).thenReturn(owner);
+
+                TradeComplete completedTrade = mockCompletedTrade(reviewer, reviewed);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
                 when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
+                when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(completedTrade));
                 when(reviewRepository.existsByProductAndReviewer(product, reviewer)).thenReturn(true);
 
-                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, "내용", 50)))
+                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 2L, "내용", 50)))
                         .isInstanceOf(AlreadyReviewedException.class);
             }
         }
@@ -144,19 +257,23 @@ class CreateReviewServiceImplTest {
             @Test
             @DisplayName("NotFoundMemberDetailException을 던진다")
             void it_throws_not_found_member_detail_exception() {
-                Member reviewer = mock(Member.class);
-                Member reviewed = mock(Member.class);
+                Member reviewer = mockMember(1L);
+                Member reviewed = mockMember(2L);
 
                 Product product = mock(Product.class);
                 when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
-                when(product.getMember()).thenReturn(reviewed);
+
+                TradeComplete completedTrade = mockCompletedTrade(reviewer, reviewed);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
                 when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
+                when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
+                        .thenReturn(Optional.of(completedTrade));
                 when(reviewRepository.existsByProductAndReviewer(product, reviewer)).thenReturn(false);
                 when(memberDetailRepository.findByMember(reviewed)).thenReturn(Optional.empty());
 
-                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, "내용", 50)))
+                assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 2L, "내용", 50)))
                         .isInstanceOf(NotFoundMemberDetailException.class);
             }
         }

--- a/src/test/java/team/startup/gwangsan/domain/review/service/impl/GetMyReviewListServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/review/service/impl/GetMyReviewListServiceImplTest.java
@@ -67,7 +67,7 @@ class GetMyReviewListServiceImplTest {
                 when(member.getNickname()).thenReturn("리뷰어");
                 when(memberUtil.getCurrentMember()).thenReturn(member);
 
-                MyReviewDto dto = new MyReviewDto(10L, 100L, "좋았어요", 8);
+                MyReviewDto dto = new MyReviewDto(10L, 100L, "좋았어요", 8, "대상자");
                 when(reviewRepository.findMyReviews(1L)).thenReturn(List.of(dto));
 
                 ProductImage pi = mock(ProductImage.class);
@@ -87,6 +87,7 @@ class GetMyReviewListServiceImplTest {
                 assertThat(result.get(0).reviewId()).isEqualTo(10L);
                 assertThat(result.get(0).content()).isEqualTo("좋았어요");
                 assertThat(result.get(0).reviewerName()).isEqualTo("리뷰어");
+                assertThat(result.get(0).targetName()).isEqualTo("대상자");
                 assertThat(result.get(0).imageUrls()).hasSize(1);
             }
         }


### PR DESCRIPTION
## Summary
- `/api/review` POST 시 대상자를 항상 게시글 작성자로 고정하던 로직을 제거하고, `otherMemberId`를 body로 받아 실제 완료된 거래의 상대방인지 검증하도록 변경 (구매자/판매자 모두 작성 가능, 본인 대상 리뷰 방지)
- `GET /api/review`, `/api/review/current`, `/api/review/{memberId}` 응답에 `targetName`(리뷰 대상자 닉네임) 추가 — `reviewerName`만 있어 누가 준 후기인지 구분이 안 되던 문제 해결
- `GET /api/chat/rooms` 응답의 상품 정보에서 이미지가 없는 상품이 통째로 빠지던 INNER JOIN 버그를 LEFT JOIN으로 수정하고, `isCompleted` 필드를 추가하여 거래 요청 존재 여부와 무관하게 항상 거래 완료 여부를 내려주도록 개선

## Test plan
- [x] `CreateReviewServiceImplTest` — 본인 리뷰 방지, 거래 미완료, 대상 회원 없음, 완료된 거래 없음, 거래 당사자 아님, 중복 리뷰, MemberDetail 없음, 정상 케이스 단위 테스트 추가/보강
- [x] `GetMyReviewListServiceImplTest` — `targetName` 반영 확인
- [x] `FindRoomsByCurrentUserServiceImplTest` — `isCompleted` 필드 반영 확인
- [x] `./gradlew test` 전체 실행 (Docker 미설치로 인한 무관한 통합 테스트 1건 제외 380개 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)