### PR TITLE
게시글 목록 응답에 완료 여부 추가 및 내 게시글 조회 상태 필터 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/admin/service/impl/FindAlertByAlertTypeAndPlaceServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/impl/FindAlertByAlertTypeAndPlaceServiceImpl.java
@@ -22,6 +22,7 @@ import team.startup.gwangsan.domain.place.entity.Place;
 import team.startup.gwangsan.domain.place.repository.PlaceRepository;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductImage;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductMemberResponse;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductResponse;
 import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
@@ -304,7 +305,8 @@ public class FindAlertByAlertTypeAndPlaceServiceImpl implements FindAlertByAlert
                 product.getType(),
                 product.getMode(),
                 memberDto,
-                images
+                images,
+                product.getStatus() == ProductStatus.COMPLETED
         );
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/response/GetProductResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/response/GetProductResponse.java
@@ -14,6 +14,7 @@ public record GetProductResponse(
         Type type,
         Mode mode,
         GetProductMemberResponse member,
-        List<GetImageResponse> images
+        List<GetImageResponse> images,
+        boolean isCompleted
 ) {
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/repository/custom/ProductCustomRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/custom/ProductCustomRepository.java
@@ -14,7 +14,7 @@ import java.util.List;
 public interface ProductCustomRepository {
     List<Product> findProductsByTypeAndModeAndMemberDetailPlaceAndStatus(Type type, Mode mode, Place place, ProductStatus status);
 
-    List<Product> findProductByMemberAndTypeAndModeAndStatus(Member member, Type type, Mode mode, ProductStatus status);
+    List<Product> findProductByMemberAndTypeAndModeAndStatusIn(Member member, Type type, Mode mode, Collection<ProductStatus> statuses);
 
     List<GetRoomProductDto> findRoomProductsWithImagesByIds(Collection<Long> productIds);
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/repository/custom/impl/ProductCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/custom/impl/ProductCustomRepositoryImpl.java
@@ -51,14 +51,14 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
     }
 
     @Override
-    public List<Product> findProductByMemberAndTypeAndModeAndStatus(Member member, Type type, Mode mode, ProductStatus status) {
+    public List<Product> findProductByMemberAndTypeAndModeAndStatusIn(Member member, Type type, Mode mode, Collection<ProductStatus> statuses) {
         return queryFactory
                 .selectFrom(product).distinct()
                 .where(
                         product.member.id.eq(member.getId()),
                         typeEq(type),
                         modeEq(mode),
-                        statusEq(status)
+                        statusIn(statuses)
                 )
                 .fetch()
                 .stream()
@@ -117,5 +117,9 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
 
     private BooleanExpression statusEq(ProductStatus status) {
         return status != null ? product.status.eq(status) : null;
+    }
+
+    private BooleanExpression statusIn(Collection<ProductStatus> statuses) {
+        return (statuses == null || statuses.isEmpty()) ? null : product.status.in(statuses);
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductByCurrentUserAndTypeAndModeServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductByCurrentUserAndTypeAndModeServiceImpl.java
@@ -38,7 +38,8 @@ public class FindProductByCurrentUserAndTypeAndModeServiceImpl implements FindPr
         Member member = memberUtil.getCurrentMember();
         MemberDetail memberDetail = memberDetailRepository.findById(member.getId())
                 .orElseThrow(NotFoundMemberDetailException::new);
-        List<Product> products = productRepository.findProductByMemberAndTypeAndModeAndStatus(member, type, mode, ProductStatus.ONGOING);
+        List<Product> products = productRepository.findProductByMemberAndTypeAndModeAndStatusIn(
+                member, type, mode, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED));
 
         if (products.isEmpty()) {
             return List.of();
@@ -80,7 +81,8 @@ public class FindProductByCurrentUserAndTypeAndModeServiceImpl implements FindPr
                         product.getType(),
                         product.getMode(),
                         memberResponse,
-                        imageMap.getOrDefault(product.getId(), List.of())
+                        imageMap.getOrDefault(product.getId(), List.of()),
+                        product.getStatus() == ProductStatus.COMPLETED
                 ))
                 .toList();
     }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByMemberIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByMemberIdServiceImpl.java
@@ -10,6 +10,7 @@ import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailExcepti
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.Type;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductMemberResponse;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductResponse;
@@ -36,7 +37,7 @@ public class FindProductsByMemberIdServiceImpl implements FindProductsByMemberId
                 .orElseThrow(NotFoundMemberDetailException::new);
         Member member = memberDetail.getMember();
 
-        List<Product> products = productRepository.findProductByMemberAndTypeAndModeAndStatus(member, type, mode, null);
+        List<Product> products = productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, type, mode, null);
 
         if (products.isEmpty()) {
             return List.of();
@@ -78,7 +79,8 @@ public class FindProductsByMemberIdServiceImpl implements FindProductsByMemberId
                         product.getType(),
                         product.getMode(),
                         memberResponse,
-                        imageMap.getOrDefault(product.getId(), List.of())
+                        imageMap.getOrDefault(product.getId(), List.of()),
+                        product.getStatus() == ProductStatus.COMPLETED
                 ))
                 .toList();
     }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByTypeAndModeServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByTypeAndModeServiceImpl.java
@@ -91,7 +91,8 @@ public class FindProductsByTypeAndModeServiceImpl implements FindProductsByTypeA
                             product.getType(),
                             product.getMode(),
                             memberResponse,
-                            imageMap.getOrDefault(product.getId(), List.of())
+                            imageMap.getOrDefault(product.getId(), List.of()),
+                            product.getStatus() == ProductStatus.COMPLETED
                     );
                 })
                 .toList();

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductByCurrentUserAndTypeAndModeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductByCurrentUserAndTypeAndModeServiceImplTest.java
@@ -77,7 +77,8 @@ class FindProductByCurrentUserAndTypeAndModeServiceImplTest {
             when(member.getId()).thenReturn(1L);
             MemberDetail memberDetail = mock(MemberDetail.class);
             when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(memberDetail));
-            when(productRepository.findProductByMemberAndTypeAndModeAndStatus(member, Type.SERVICE, Mode.GIVER, ProductStatus.ONGOING))
+            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(
+                    member, Type.SERVICE, Mode.GIVER, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED)))
                     .thenReturn(List.of());
 
             var result = service.execute(Type.SERVICE, Mode.GIVER);
@@ -111,6 +112,7 @@ class FindProductByCurrentUserAndTypeAndModeServiceImplTest {
             when(product1.getGwangsan()).thenReturn(3);
             when(product1.getType()).thenReturn(Type.SERVICE);
             when(product1.getMode()).thenReturn(Mode.GIVER);
+            when(product1.getStatus()).thenReturn(ProductStatus.ONGOING);
 
             when(product2.getId()).thenReturn(102L);
             when(product2.getTitle()).thenReturn("상품2");
@@ -118,9 +120,10 @@ class FindProductByCurrentUserAndTypeAndModeServiceImplTest {
             when(product2.getGwangsan()).thenReturn(5);
             when(product2.getType()).thenReturn(Type.SERVICE);
             when(product2.getMode()).thenReturn(Mode.GIVER);
+            when(product2.getStatus()).thenReturn(ProductStatus.COMPLETED);
 
-            when(productRepository.findProductByMemberAndTypeAndModeAndStatus(
-                    member, Type.SERVICE, Mode.GIVER, ProductStatus.ONGOING
+            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(
+                    member, Type.SERVICE, Mode.GIVER, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED)
             )).thenReturn(List.of(product1, product2));
 
             Image img1 = mock(Image.class);
@@ -154,17 +157,20 @@ class FindProductByCurrentUserAndTypeAndModeServiceImplTest {
             assertThat(result.get(0).images()).containsExactly(
                     new GetImageResponse(201L, "url1")
             );
+            assertThat(result.get(0).isCompleted()).isFalse();
 
             assertThat(result.get(1).id()).isEqualTo(102L);
             assertThat(result.get(1).images()).containsExactly(
                     new GetImageResponse(202L, "url2")
             );
+            assertThat(result.get(1).isCompleted()).isTrue();
 
             assertThat(result.get(0).member().light()).isEqualTo(3);
 
             verify(memberUtil).getCurrentMember();
             verify(memberDetailRepository).findById(1L);
-            verify(productRepository).findProductByMemberAndTypeAndModeAndStatus(member, Type.SERVICE, Mode.GIVER, ProductStatus.ONGOING);
+            verify(productRepository).findProductByMemberAndTypeAndModeAndStatusIn(
+                    member, Type.SERVICE, Mode.GIVER, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED));
             verify(productImageRepository).findAllByProductIdIn(List.of(101L, 102L));
         }
     }

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByMemberIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByMemberIdServiceImplTest.java
@@ -20,6 +20,7 @@ import team.startup.gwangsan.domain.place.entity.Place;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductImage;
 import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.Type;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductResponse;
 import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
@@ -80,7 +81,7 @@ class FindProductsByMemberIdServiceImplTest {
             Member member = mock(Member.class);
             when(memberDetailRepository.findById(MEMBER_ID)).thenReturn(Optional.of(memberDetail));
             when(memberDetail.getMember()).thenReturn(member);
-            when(productRepository.findProductByMemberAndTypeAndModeAndStatus(member, TYPE, MODE, null))
+            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, null))
                     .thenReturn(List.of());
 
             List<GetProductResponse> result = service.execute(MEMBER_ID, TYPE, MODE);
@@ -115,6 +116,7 @@ class FindProductsByMemberIdServiceImplTest {
             when(product1.getGwangsan()).thenReturn(10);
             when(product1.getType()).thenReturn(TYPE);
             when(product1.getMode()).thenReturn(MODE);
+            when(product1.getStatus()).thenReturn(ProductStatus.ONGOING);
 
             when(product2.getId()).thenReturn(101L);
             when(product2.getTitle()).thenReturn("제목2");
@@ -122,8 +124,9 @@ class FindProductsByMemberIdServiceImplTest {
             when(product2.getGwangsan()).thenReturn(20);
             when(product2.getType()).thenReturn(TYPE);
             when(product2.getMode()).thenReturn(MODE);
+            when(product2.getStatus()).thenReturn(ProductStatus.COMPLETED);
 
-            when(productRepository.findProductByMemberAndTypeAndModeAndStatus(member, TYPE, MODE, null))
+            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, null))
                     .thenReturn(List.of(product1, product2));
 
             Image image1 = mock(Image.class);
@@ -165,6 +168,7 @@ class FindProductsByMemberIdServiceImplTest {
             assertThat(r1.images())
                     .extracting(GetImageResponse::imageId)
                     .containsExactly(1000L);
+            assertThat(r1.isCompleted()).isFalse();
 
             GetProductResponse r2 = responses.get(1);
             assertThat(r2.id()).isEqualTo(101L);
@@ -177,12 +181,13 @@ class FindProductsByMemberIdServiceImplTest {
             assertThat(r2.images())
                     .extracting(GetImageResponse::imageId)
                     .containsExactly(1001L);
+            assertThat(r2.isCompleted()).isTrue();
 
             ArgumentCaptor<List<Long>> productIdsCaptor = ArgumentCaptor.forClass(List.class);
             verify(productImageRepository).findAllByProductIdIn(productIdsCaptor.capture());
             assertThat(productIdsCaptor.getValue()).containsExactlyInAnyOrder(100L, 101L);
 
-            verify(productRepository).findProductByMemberAndTypeAndModeAndStatus(member, TYPE, MODE, null);
+            verify(productRepository).findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, null);
         }
 
         @Test
@@ -210,7 +215,7 @@ class FindProductsByMemberIdServiceImplTest {
             when(product.getType()).thenReturn(TYPE);
             when(product.getMode()).thenReturn(MODE);
 
-            when(productRepository.findProductByMemberAndTypeAndModeAndStatus(member, TYPE, MODE, null))
+            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, null))
                     .thenReturn(List.of(product));
 
             when(productImageRepository.findAllByProductIdIn(anyList()))

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByTypeAndModeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByTypeAndModeServiceImplTest.java
@@ -81,6 +81,7 @@ class FindProductsByTypeAndModeServiceImplTest {
             when(product1.getType()).thenReturn(TYPE);
             when(product1.getMode()).thenReturn(MODE);
             when(product1.getMember()).thenReturn(member1);
+            when(product1.getStatus()).thenReturn(ProductStatus.ONGOING);
 
             when(product2.getId()).thenReturn(101L);
             when(product2.getTitle()).thenReturn("상품2");
@@ -89,6 +90,7 @@ class FindProductsByTypeAndModeServiceImplTest {
             when(product2.getType()).thenReturn(TYPE);
             when(product2.getMode()).thenReturn(MODE);
             when(product2.getMember()).thenReturn(member2);
+            when(product2.getStatus()).thenReturn(ProductStatus.COMPLETED);
 
             when(productRepository.findProductsByTypeAndModeAndMemberDetailPlaceAndStatus(
                     TYPE, MODE, myPlace, ProductStatus.ONGOING
@@ -140,11 +142,13 @@ class FindProductsByTypeAndModeServiceImplTest {
             assertThat(r1.id()).isEqualTo(100L);
             assertThat(r1.member().light()).isEqualTo(3);
             assertThat(r1.images().get(0).imageId()).isEqualTo(1000L);
+            assertThat(r1.isCompleted()).isFalse();
 
             GetProductResponse r2 = result.get(1);
             assertThat(r2.id()).isEqualTo(101L);
             assertThat(r2.member().light()).isEqualTo(1);
             assertThat(r2.images().get(0).imageId()).isEqualTo(1001L);
+            assertThat(r2.isCompleted()).isTrue();
 
             verify(productRepository).findProductsByTypeAndModeAndMemberDetailPlaceAndStatus(
                     TYPE, MODE, myPlace, ProductStatus.ONGOING


### PR DESCRIPTION
## Summary
- `GetProductResponse` (게시글 목록 응답 DTO)에 `isCompleted` 필드를 추가해 `/post`, `/post/current`, `/post/member/{member_id}` 세 목록 API에서도 거래 완료 여부를 내려주도록 수정
- `/post/current` (내 게시글 조회)가 `ONGOING` 상태만 조회하도록 하드코딩되어 있던 필터를 `ONGOING` + `COMPLETED` 로 확장하여, 거래 완료된 내 게시글도 목록에서 사라지지 않도록 수정
- 위 두 가지 문제로 인해 프론트엔드 프로필 화면의 "거래 완료 품목" 섹션이 항상 비어 있던 버그 해결

## Changes
- `GetProductResponse`에 `isCompleted` 필드 추가
- `FindProductByCurrentUserAndTypeAndModeServiceImpl`, `FindProductsByMemberIdServiceImpl`, `FindProductsByTypeAndModeServiceImpl`, `FindAlertByAlertTypeAndPlaceServiceImpl`에서 `isCompleted` 값 채우도록 수정
- `ProductCustomRepository.findProductByMemberAndTypeAndModeAndStatus` → `findProductByMemberAndTypeAndModeAndStatusIn`으로 변경해 복수 상태(`ONGOING`, `COMPLETED`) 필터링 지원
- 관련 단위 테스트 갱신 및 `isCompleted` 검증 케이스 추가

Closes #346

## Test plan
- [x] `./gradlew test` — 관련 단위 테스트(FindProductByCurrentUserAndTypeAndModeServiceImplTest, FindProductsByMemberIdServiceImplTest, FindProductsByTypeAndModeServiceImplTest, FindAlertByAlertTypeAndPlaceServiceImplTest) 통과 확인
- [x] 전체 테스트 스위트 실행 (Docker 미설치로 인한 Testcontainers 통합 테스트 1건 제외 나머지 전부 통과, 기존에도 로컬 환경 문제로 실패하던 것으로 본 변경과 무관)

🤖 Generated with [Claude Code](https://claude.com/claude-code)