### PR TITLE
예약 상태 응답 필드 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetChatProductDto.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetChatProductDto.java
@@ -12,6 +12,7 @@ public record GetChatProductDto(
         LocalDateTime createdAt,
         boolean isSeller,
         boolean isCompletable,
-        boolean isCompleted
+        boolean isCompleted,
+        boolean isReserved
 )  {
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImpl.java
@@ -67,6 +67,7 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
         Optional<TradeComplete> pendingTradeComplete = tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
                 product, chatRoom.getBuyer(), chatRoom.getSeller(), TradeStatus.PENDING);
         boolean isCompleted = product.getStatus() == ProductStatus.COMPLETED;
+        boolean isReserved = product.getStatus() == ProductStatus.RESERVATION;
         boolean isCompletable = !isCompleted && pendingTradeComplete
                 .map(tc -> tc.isRequestedBySeller() != isSeller)
                 .orElse(true);
@@ -78,7 +79,8 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
                 pendingTradeComplete.map(TradeComplete::getCreatedAt).orElse(null),
                 isSeller,
                 isCompletable,
-                isCompleted
+                isCompleted,
+                isReserved
         );
 
         List<ChatMessage> messages = chatMessageRepository.findChatMessageByRoomIdWithCursorPaging(roomId, lastCreatedAt, lastMessageId, limit);

--- a/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/response/GetProductByIdResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/response/GetProductByIdResponse.java
@@ -17,6 +17,7 @@ public record GetProductByIdResponse(
         List<GetImageResponse> images,
         boolean isMine,
         boolean isCompletable,
-        boolean isCompleted
+        boolean isCompleted,
+        boolean isReserved
 ) {
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImpl.java
@@ -1,8 +1,10 @@
 package team.startup.gwangsan.domain.post.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
@@ -12,7 +14,10 @@ import team.startup.gwangsan.domain.post.exception.ReservationParticipantOnlyExc
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
 import team.startup.gwangsan.domain.post.service.DeleteReservationProductService;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +26,8 @@ public class DeleteReservationProductServiceImpl implements DeleteReservationPro
     private final ProductRepository productRepository;
     private final MemberUtil memberUtil;
     private final ProductReservationRepository productReservationRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     @Transactional
@@ -36,5 +43,15 @@ public class DeleteReservationProductServiceImpl implements DeleteReservationPro
         productReservation.cancel();
 
         product.updateStatus(ProductStatus.ONGOING);
+
+        chatRoomRepository.findByProductIdAndMember(product.getId(), productReservation.getReserver())
+                .ifPresent(chatRoom -> applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                        chatRoom.getId(),
+                        null,
+                        product.getId(),
+                        false,
+                        false,
+                        LocalDateTime.now()
+                )));
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImpl.java
@@ -82,6 +82,7 @@ public class FindProductByIdServiceImpl implements FindProductByIdService {
             isCompletable = chatMessageRepository.existsByRoomAndSenderId(chatRoom, member.getId());
         }
         boolean isCompleted = product.getStatus().equals(ProductStatus.COMPLETED);
+        boolean isReserved = product.getStatus().equals(ProductStatus.RESERVATION);
 
         return new GetProductByIdResponse(
                 product.getId(),
@@ -94,7 +95,8 @@ public class FindProductByIdServiceImpl implements FindProductByIdService {
                 images,
                 isMine,
                 isCompletable,
-                isCompleted
+                isCompleted,
+                isReserved
         );
     }
 

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
@@ -195,6 +195,7 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
                 requester.getId(),
                 product.getId(),
                 true,
+                false,
                 changedAt
         ));
     }
@@ -222,6 +223,7 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
                 requestTarget.getId(),
                 product.getId(),
                 false,
+                product.getStatus() == ProductStatus.RESERVATION,
                 changedAt
         ));
     }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
@@ -1,8 +1,10 @@
 package team.startup.gwangsan.domain.post.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
@@ -14,7 +16,10 @@ import team.startup.gwangsan.domain.post.exception.ProductNotOngoingException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
 import team.startup.gwangsan.domain.post.service.ReservationProductService;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +28,8 @@ public class ReservationProductServiceImpl implements ReservationProductService 
     private final ProductRepository productRepository;
     private final ProductReservationRepository productReservationRepository;
     private final MemberUtil memberUtil;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
     @Transactional
@@ -49,5 +56,15 @@ public class ReservationProductServiceImpl implements ReservationProductService 
         );
 
         product.updateStatus(ProductStatus.RESERVATION);
+
+        chatRoomRepository.findByProductIdAndMember(productId, reserver)
+                .ifPresent(chatRoom -> applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                        chatRoom.getId(),
+                        null,
+                        productId,
+                        false,
+                        true,
+                        LocalDateTime.now()
+                )));
     }
 }

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
@@ -36,6 +36,7 @@ public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTrad
                         event.targetMemberId(),
                         event.productId(),
                         event.completed(),
+                        event.reserved(),
                         event.changedAt()
                 ))
                 .retrieve()
@@ -47,6 +48,7 @@ public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTrad
             Long targetMemberId,
             Long productId,
             boolean isCompleted,
+            boolean isReserved,
             LocalDateTime createdAt
     ) {
     }

--- a/src/main/java/team/startup/gwangsan/global/event/TradeStatusChangedEvent.java
+++ b/src/main/java/team/startup/gwangsan/global/event/TradeStatusChangedEvent.java
@@ -7,6 +7,7 @@ public record TradeStatusChangedEvent(
         Long targetMemberId,
         Long productId,
         boolean completed,
+        boolean reserved,
         LocalDateTime changedAt
 ) {
 }

--- a/src/main/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListener.java
+++ b/src/main/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListener.java
@@ -23,10 +23,11 @@ public class TradeStatusChangedEventListener {
             notifier.notifyTradeStatusChanged(event);
         } catch (Exception e) {
             log.warn(
-                    "Failed to notify chatting server of trade status change. roomId={}, productId={}, completed={}",
+                    "Failed to notify chatting server of trade status change. roomId={}, productId={}, completed={}, reserved={}",
                     event.roomId(),
                     event.productId(),
                     event.completed(),
+                    event.reserved(),
                     e
             );
         }

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImplTest.java
@@ -296,6 +296,18 @@ class FindChatMessageByRoomIdServiceImplTest {
         }
 
         @Test
+        @DisplayName("상품이 예약 상태이면 isReserved 가 true 이다")
+        void it_sets_isReserved_true_when_product_is_reserved() {
+            arrangeRoomAsSellerView();
+            arrangeEmptyMessages();
+            when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
+
+            GetChatMessagesResponse response = service.execute(5L, null, null, 20);
+
+            assertThat(response.product().isReserved()).isTrue();
+        }
+
+        @Test
         @DisplayName("메시지가 있으면 가장 최근 메시지 id 까지 읽음 처리한다")
         void it_marks_messages_as_read_using_latest_message_id_when_messages_exist() {
             arrangeRoomAsSellerView();

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImplTest.java
@@ -4,9 +4,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
@@ -15,11 +19,15 @@ import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
 import team.startup.gwangsan.domain.post.exception.ReservationParticipantOnlyException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
@@ -36,6 +44,12 @@ class DeleteReservationProductServiceImplTest {
     @Mock
     private ProductReservationRepository productReservationRepository;
 
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
     @InjectMocks
     private DeleteReservationProductServiceImpl service;
 
@@ -50,6 +64,7 @@ class DeleteReservationProductServiceImplTest {
             Long productId = 1L;
 
             Member currentMember = mock(Member.class);
+            Member reserver = mock(Member.class);
             ProductReservation reservation = mock(ProductReservation.class);
             Product product = mock(Product.class);
 
@@ -60,6 +75,13 @@ class DeleteReservationProductServiceImplTest {
                     ReservationStatus.PENDING
             )).thenReturn(Optional.of(reservation));
             when(reservation.getProduct()).thenReturn(product);
+            when(reservation.getReserver()).thenReturn(reserver);
+            when(product.getId()).thenReturn(productId);
+
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.getId()).thenReturn(10L);
+            when(chatRoomRepository.findByProductIdAndMember(productId, reserver))
+                    .thenReturn(Optional.of(chatRoom));
 
             // when & then
             assertDoesNotThrow(() -> service.execute(productId));
@@ -72,6 +94,15 @@ class DeleteReservationProductServiceImplTest {
             );
             verify(reservation).cancel();
             verify(product).updateStatus(ProductStatus.ONGOING);
+
+            ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+            TradeStatusChangedEvent event = (TradeStatusChangedEvent) eventCaptor.getValue();
+            assertEquals(10L, event.roomId());
+            assertNull(event.targetMemberId());
+            assertEquals(productId, event.productId());
+            assertFalse(event.completed());
+            assertFalse(event.reserved());
 
             verifyNoInteractions(productRepository);
         }

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImplTest.java
@@ -76,8 +76,8 @@ class FindProductByIdServiceImplTest {
     class Describe_execute {
 
         @Test
-        @DisplayName("정상 케이스에서 상품 상세 정보를 반환하고 isMine=false, isCompletable=true, isCompleted=false 를 설정한다")
-        void it_returns_product_detail_with_flags_for_normal_case() {
+        @DisplayName("예약 상품 상세 정보를 반환하고 isReserved=true 를 설정한다")
+        void it_returns_reserved_product_detail_with_flags() {
             // given
             Long productId = 1L;
 
@@ -102,7 +102,7 @@ class FindProductByIdServiceImplTest {
             when(product.getGwangsan()).thenReturn(10);
             when(product.getType()).thenReturn(Type.SERVICE);
             when(product.getMode()).thenReturn(Mode.GIVER);
-            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
+            when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
             when(product.getMember()).thenReturn(owner);
 
             when(productRepository.findById(productId)).thenReturn(Optional.of(product));
@@ -163,6 +163,7 @@ class FindProductByIdServiceImplTest {
             assertThat(result.isMine()).isFalse();
             assertThat(result.isCompletable()).isTrue();
             assertThat(result.isCompleted()).isFalse();
+            assertThat(result.isReserved()).isTrue();
 
             verify(productRepository).findById(productId);
             verify(productImageRepository).findAllByProductId(productId);
@@ -286,6 +287,7 @@ class FindProductByIdServiceImplTest {
             assertThat(result.isMine()).isTrue();
             assertThat(result.isCompleted()).isTrue();
             assertThat(result.isCompletable()).isFalse();
+            assertThat(result.isReserved()).isFalse();
 
             GetProductMemberResponse memberResponse = result.member();
             assertThat(memberResponse.light()).isEqualTo(1);

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
@@ -353,7 +353,7 @@ class RequestTradeCompleteServiceImplTest {
             verify(pending).updateStatus(TradeStatus.COMPLETED);
             verify(pending).updateCompletedAt();
             verify(reservation).complete();
-            verifyTradeStatusChangedEvent(roomId, sellerId, productId, true);
+            verifyTradeStatusChangedEvent(roomId, sellerId, productId, true, false);
         }
 
         @Test
@@ -416,7 +416,7 @@ class RequestTradeCompleteServiceImplTest {
             ArgumentCaptor<TradeComplete> savedCaptor = ArgumentCaptor.forClass(TradeComplete.class);
             verify(tradeCompleteRepository).save(savedCaptor.capture());
             assertTrue(savedCaptor.getValue().isRequestedBySeller());
-            verifyTradeStatusChangedEvent(roomId, buyerId, productId, false);
+            verifyTradeStatusChangedEvent(roomId, buyerId, productId, false, false);
         }
 
         @Test
@@ -481,7 +481,7 @@ class RequestTradeCompleteServiceImplTest {
             ArgumentCaptor<TradeComplete> savedCaptor = ArgumentCaptor.forClass(TradeComplete.class);
             verify(tradeCompleteRepository).save(savedCaptor.capture());
             assertTrue(!savedCaptor.getValue().isRequestedBySeller());
-            verifyTradeStatusChangedEvent(roomId, sellerId, productId, false);
+            verifyTradeStatusChangedEvent(roomId, sellerId, productId, false, false);
         }
 
         @Test
@@ -609,11 +609,17 @@ class RequestTradeCompleteServiceImplTest {
             verify(pending).updateStatus(TradeStatus.COMPLETED);
             verify(pending).updateCompletedAt();
             verifyNoInteractions(productReservationRepository);
-            verifyTradeStatusChangedEvent(roomId, sellerId, productId, true);
+            verifyTradeStatusChangedEvent(roomId, sellerId, productId, true, false);
         }
     }
 
-    private void verifyTradeStatusChangedEvent(Long roomId, Long targetMemberId, Long productId, boolean completed) {
+    private void verifyTradeStatusChangedEvent(
+            Long roomId,
+            Long targetMemberId,
+            Long productId,
+            boolean completed,
+            boolean reserved
+    ) {
         ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
         verify(applicationEventPublisher, atLeastOnce()).publishEvent(eventCaptor.capture());
 
@@ -627,6 +633,7 @@ class RequestTradeCompleteServiceImplTest {
         assertEquals(targetMemberId, event.targetMemberId());
         assertEquals(productId, event.productId());
         assertEquals(completed, event.completed());
+        assertEquals(reserved, event.reserved());
         assertTrue(event.changedAt() != null);
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
@@ -4,9 +4,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
@@ -16,12 +20,17 @@ import team.startup.gwangsan.domain.post.exception.ProductAlreadyReservationExce
 import team.startup.gwangsan.domain.post.exception.ProductNotOngoingException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
@@ -36,6 +45,12 @@ class ReservationProductServiceImplTest {
 
     @Mock
     private MemberUtil memberUtil;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
 
     @InjectMocks
     private ReservationProductServiceImpl service;
@@ -105,12 +120,26 @@ class ReservationProductServiceImplTest {
 
             when(productRepository.findById(productId)).thenReturn(Optional.of(product));
 
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.getId()).thenReturn(10L);
+            when(chatRoomRepository.findByProductIdAndMember(productId, reserver))
+                    .thenReturn(Optional.of(chatRoom));
+
             // when
             assertDoesNotThrow(() -> service.execute(productId));
 
             // then
             verify(productReservationRepository).save(any(ProductReservation.class));
             verify(product).updateStatus(ProductStatus.RESERVATION);
+
+            ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+            TradeStatusChangedEvent event = (TradeStatusChangedEvent) eventCaptor.getValue();
+            assertEquals(10L, event.roomId());
+            assertNull(event.targetMemberId());
+            assertEquals(productId, event.productId());
+            assertFalse(event.completed());
+            assertTrue(event.reserved());
         }
     }
 }

--- a/src/test/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImplTest.java
+++ b/src/test/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImplTest.java
@@ -1,0 +1,60 @@
+package team.startup.gwangsan.global.chat.notification;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+@DisplayName("ChattingServerTradeStatusNotifierImpl 단위 테스트")
+class ChattingServerTradeStatusNotifierImplTest {
+
+    private MockRestServiceServer server;
+    private ChattingServerTradeStatusNotifierImpl notifier;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        notifier = new ChattingServerTradeStatusNotifierImpl(
+                new ChattingServerProperties("http://chatting-server", "test-secret"),
+                builder
+        );
+    }
+
+    @Test
+    @DisplayName("예약 여부를 포함한 거래 상태를 채팅 서버에 전달한다")
+    void it_sends_trade_status_with_reservation_state() {
+        server.expect(once(), requestTo("http://chatting-server/api/internal/chat/transaction-state"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header("x-internal-secret", "test-secret"))
+                .andExpect(jsonPath("$.roomId").value(1))
+                .andExpect(jsonPath("$.targetMemberId").value(2))
+                .andExpect(jsonPath("$.productId").value(3))
+                .andExpect(jsonPath("$.isCompleted").value(false))
+                .andExpect(jsonPath("$.isReserved").value(true))
+                .andRespond(withSuccess());
+
+        notifier.notifyTradeStatusChanged(new TradeStatusChangedEvent(
+                1L,
+                2L,
+                3L,
+                false,
+                true,
+                LocalDateTime.of(2026, 8, 24, 13, 15)
+        ));
+
+        server.verify();
+    }
+}

--- a/src/test/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListenerTest.java
+++ b/src/test/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListenerTest.java
@@ -20,7 +20,7 @@ class TradeStatusChangedEventListenerTest {
     void it_does_not_propagate_exception_when_chatting_server_notification_fails() {
         ChattingServerTradeStatusNotifier notifier = mock(ChattingServerTradeStatusNotifier.class);
         TradeStatusChangedEventListener listener = new TradeStatusChangedEventListener(notifier);
-        TradeStatusChangedEvent event = new TradeStatusChangedEvent(1L, 2L, 10L, false, LocalDateTime.now());
+        TradeStatusChangedEvent event = new TradeStatusChangedEvent(1L, 2L, 10L, false, false, LocalDateTime.now());
 
         doThrow(new RuntimeException("chatting server unavailable"))
                 .when(notifier)


### PR DESCRIPTION
## 💡 배경 및 개요

Resolves: #348

## 📃 작업내용

- GET /chat/{roomId}의 product에 isReserved 추가
- GET /post/{postId} 응답에도 isReserved 추가

## ✅ PR 체크리스트

> 템플릿 체크리스트 말고도 추가적으로 필요한 체크리스트는 추가해주세요!

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [ ] 작업한 코드가 정상적으로 동작하나요?
- [ ] Merge 대상 브랜치가 올바른가요?
- [ ] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타