### PR TITLE
채팅방 목록 조회 시 손상된 메시지 데이터로 인한 조회 실패 방지

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import team.startup.gwangsan.domain.chat.entity.ChatRoom;
 import team.startup.gwangsan.domain.chat.entity.QChatMessage;
@@ -26,6 +27,7 @@ import java.util.stream.Collectors;
 
 import static team.startup.gwangsan.domain.chat.entity.QChatRoom.chatRoom;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
@@ -198,14 +200,37 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
         List<Object[]> rows = query.getResultList();
 
         return rows.stream()
-                .map(row -> new LatestMessageDto(
-                        ((Number) row[0]).longValue(),
-                        ((Number) row[1]).longValue(),
-                        (String) row[2],
-                        MessageType.valueOf(String.valueOf(row[3])),
-                        toLocalDateTime(row[4])
-                ))
+                .map(this::toLatestMessageDto)
+                .filter(Objects::nonNull)
                 .toList();
+    }
+
+    LatestMessageDto toLatestMessageDto(Object[] row) {
+        Long roomId = ((Number) row[0]).longValue();
+        MessageType messageType = toMessageType(row[3]);
+        LocalDateTime createdAt = toLocalDateTime(row[4]);
+
+        if (messageType == null || createdAt == null) {
+            log.warn("Skipping malformed chat message row for room {} (message_type={}, created_at={})",
+                    roomId, row[3], row[4]);
+            return null;
+        }
+
+        return new LatestMessageDto(
+                roomId,
+                ((Number) row[1]).longValue(),
+                (String) row[2],
+                messageType,
+                createdAt
+        );
+    }
+
+    private MessageType toMessageType(Object value) {
+        try {
+            return MessageType.valueOf(String.valueOf(value));
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
     }
 
     private LocalDateTime toLocalDateTime(Object value) {
@@ -215,6 +240,6 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
         if (value instanceof Timestamp timestamp) {
             return timestamp.toLocalDateTime();
         }
-        throw new IllegalArgumentException("Unsupported created_at type: " + value.getClass());
+        return null;
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImplTest.java
@@ -14,6 +14,7 @@ import team.startup.gwangsan.domain.chat.entity.ChatMessage;
 import team.startup.gwangsan.domain.chat.entity.ChatRoom;
 import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
 import team.startup.gwangsan.domain.chat.presentation.dto.GetRoomsDto;
+import team.startup.gwangsan.domain.chat.repository.projection.LatestMessageDto;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
 import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
@@ -133,6 +134,47 @@ class ChatRoomCustomRepositoryImplTest {
             assertThat(result).hasSize(1);
             assertThat(result.get(0).messageId()).isEqualTo(20L);
             assertThat(result.get(0).lastMessage()).isEqualTo("나중에 온 메시지");
+        }
+
+    }
+
+    @Nested
+    @DisplayName("toLatestMessageDto()는")
+    class Describe_toLatestMessageDto {
+
+        @Test
+        @DisplayName("message_type이 알 수 없는 값이면 예외 대신 null을 반환한다")
+        void it_returns_null_when_message_type_is_unknown() {
+            Object[] row = {1L, 100L, "손상된 메시지", "CORRUPTED_TYPE", LocalDateTime.of(2024, 1, 1, 10, 0)};
+
+            LatestMessageDto result = repository.toLatestMessageDto(row);
+
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("created_at이 지원하지 않는 타입이면 예외 대신 null을 반환한다")
+        void it_returns_null_when_created_at_type_is_unsupported() {
+            Object[] row = {1L, 100L, "메시지", "TEXT", "2024-01-01"};
+
+            LatestMessageDto result = repository.toLatestMessageDto(row);
+
+            assertThat(result).isNull();
+        }
+
+        @Test
+        @DisplayName("정상적인 데이터면 LatestMessageDto를 반환한다")
+        void it_returns_dto_when_row_is_valid() {
+            LocalDateTime createdAt = LocalDateTime.of(2024, 1, 1, 10, 0);
+            Object[] row = {1L, 100L, "정상 메시지", "TEXT", createdAt};
+
+            LatestMessageDto result = repository.toLatestMessageDto(row);
+
+            assertThat(result.roomId()).isEqualTo(1L);
+            assertThat(result.messageId()).isEqualTo(100L);
+            assertThat(result.content()).isEqualTo("정상 메시지");
+            assertThat(result.messageType()).isEqualTo(MessageType.TEXT);
+            assertThat(result.createdAt()).isEqualTo(createdAt);
         }
     }
 }


### PR DESCRIPTION
## Summary
- `GET /api/chat/rooms` 조회가 간헐적으로 500 에러로 실패하는 문제를 수정
- 원인: `ChatRoomCustomRepositoryImpl.findLatestMessagesByRoomIds`의 네이티브 쿼리 결과 매핑에서 `MessageType.valueOf(...)`, `created_at` 타입 변환 실패 시 `IllegalArgumentException`이 그대로 던져지고, 이 예외가 `GlobalExceptionHandler`의 catch-all로 떨어져 목록 조회 API 전체가 500으로 실패했음
- 최신 메시지 한 건의 데이터가 손상되어 있어도 해당 채팅방까지 조회가 실패하지 않도록, 예외 대신 해당 메시지를 스킵(마지막 메시지 정보 없이 반환)하고 경고 로그를 남기도록 수정

## Test plan
- [x] `ChatRoomCustomRepositoryImplTest` — `message_type`이 알 수 없는 값이거나 `created_at` 타입이 예상과 다를 때 예외 대신 null을 반환하는지 단위 테스트 추가
- [x] 기존 `findRoomsByMemberId` 정렬 관련 테스트 통과 확인
- [x] `./gradlew test --tests "team.startup.gwangsan.domain.chat.*"` 전체 통과 확인

