### PR TITLE
게시글 삭제를 soft delete로 전환

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/alert/service/impl/CreateAlertServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/alert/service/impl/CreateAlertServiceImpl.java
@@ -215,7 +215,7 @@ public class CreateAlertServiceImpl implements CreateAlertService {
     }
 
     private Product getProduct(Long id) {
-        return productRepository.findById(id)
+        return productRepository.findActiveById(id)
                 .orElseThrow(NotFoundProductException::new);
     }
 

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/CreateChatRoomServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/CreateChatRoomServiceImpl.java
@@ -31,7 +31,7 @@ public class CreateChatRoomServiceImpl implements CreateChatRoomService {
     public CreateChatRoomResponse execute(Long productId) {
         Member member = memberUtil.getCurrentMember();
 
-        Product product = productRepository.findById(productId)
+        Product product = productRepository.findActiveById(productId)
                 .orElseThrow(NotFoundProductException::new);
         Member productMember = product.getMember();
 

--- a/src/main/java/team/startup/gwangsan/domain/post/entity/constant/ProductStatus.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/entity/constant/ProductStatus.java
@@ -3,5 +3,6 @@ package team.startup.gwangsan.domain.post.entity.constant;
 public enum ProductStatus {
     ONGOING,
     COMPLETED,
-    RESERVATION
+    RESERVATION,
+    DELETED
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/repository/ProductRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/ProductRepository.java
@@ -14,10 +14,17 @@ import team.startup.gwangsan.domain.post.repository.custom.ProductCustomReposito
 import java.util.Optional;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, ProductCustomRepository {
-    Optional<Product> findByIdAndStatus(Long id, ProductStatus status);
+    Optional<Product> findByIdAndStatusNot(Long id, ProductStatus status);
+
+    /**
+     * 삭제되지 않은 게시글만 조회한다. 단건 조회는 이 메서드를 사용한다.
+     */
+    default Optional<Product> findActiveById(Long id) {
+        return findByIdAndStatusNot(id, ProductStatus.DELETED);
+    }
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("select p from Product p where p.id = :id")
+    @Query("select p from Product p where p.id = :id and p.status <> team.startup.gwangsan.domain.post.entity.constant.ProductStatus.DELETED")
     Optional<Product> findByIdWithLock(Long id);
 
     @Modifying(clearAutomatically = true)

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/DeleteProductByIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/DeleteProductByIdServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.exception.ForbiddenProductException;
 import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
@@ -23,12 +24,13 @@ public class DeleteProductByIdServiceImpl implements DeleteProductByIdService {
     public void execute(Long id) {
         Member member = memberUtil.getCurrentMember();
 
-        Product product = productRepository.findById(id)
+        Product product = productRepository.findActiveById(id)
                 .orElseThrow(NotFoundProductException::new);
 
         validateProductMember(member, product.getMember());
 
-        productRepository.delete(product);
+        // 거래·리뷰 이력이 게시글을 참조하므로 물리 삭제하지 않고 상태만 변경한다
+        product.updateStatus(ProductStatus.DELETED);
     }
 
     private void validateProductMember(Member member, Member productMember) {

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImpl.java
@@ -44,7 +44,7 @@ public class FindProductByIdServiceImpl implements FindProductByIdService {
         Member member = memberUtil.getCurrentMember();
         Place myPlace = memberDetailRepository.findPlaceByMemberId(member.getId());
 
-        Product product = productRepository.findById(id)
+        Product product = productRepository.findActiveById(id)
                 .orElseThrow(NotFoundProductException::new);
 
         blockValidator.validate(member, product.getMember());

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByMemberIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByMemberIdServiceImpl.java
@@ -37,7 +37,8 @@ public class FindProductsByMemberIdServiceImpl implements FindProductsByMemberId
                 .orElseThrow(NotFoundMemberDetailException::new);
         Member member = memberDetail.getMember();
 
-        List<Product> products = productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, type, mode, null);
+        List<Product> products = productRepository.findProductByMemberAndTypeAndModeAndStatusIn(
+                member, type, mode, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED, ProductStatus.RESERVATION));
 
         if (products.isEmpty()) {
             return List.of();

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
@@ -36,7 +36,7 @@ public class ReservationProductServiceImpl implements ReservationProductService 
     public void execute(Long productId) {
         Member reserver = memberUtil.getCurrentMember();
 
-        Product product = productRepository.findById(productId)
+        Product product = productRepository.findActiveById(productId)
                 .orElseThrow(NotFoundProductException::new);
 
         if (product.getStatus() == ProductStatus.RESERVATION) {

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/UpdateProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/UpdateProductServiceImpl.java
@@ -41,7 +41,7 @@ public class UpdateProductServiceImpl implements UpdateProductService {
     public void execute(Long productId, Type type, Mode mode, String title, String description, Integer gwangsan, List<Long> imageIds) {
         Member member = memberUtil.getCurrentMember();
 
-        Product product = productRepository.findById(productId)
+        Product product = productRepository.findActiveById(productId)
                 .orElseThrow(NotFoundProductException::new);
 
         validateProductMember(member, product);

--- a/src/main/java/team/startup/gwangsan/domain/review/service/impl/CreateReviewServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/review/service/impl/CreateReviewServiceImpl.java
@@ -52,7 +52,7 @@ public class CreateReviewServiceImpl implements CreateReviewService {
             throw new CannotReviewSelfException();
         }
 
-        Product product = productRepository.findById(request.productId())
+        Product product = productRepository.findActiveById(request.productId())
                 .orElseThrow(NotFoundProductException::new);
 
         if (product.getStatus() != ProductStatus.COMPLETED) {

--- a/src/test/java/team/startup/gwangsan/domain/alert/service/impl/CreateAlertServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/alert/service/impl/CreateAlertServiceImplTest.java
@@ -144,7 +144,7 @@ class CreateAlertServiceImplTest {
         void it_saves_receipt_for_trade_complete_reject() {
             Product product = mock(Product.class);
             when(product.getTitle()).thenReturn("상품명");
-            when(productRepository.findById(100L)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(100L)).thenReturn(Optional.of(product));
 
             when(alertRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
@@ -163,7 +163,7 @@ class CreateAlertServiceImplTest {
         @Test
         @DisplayName("TRADE_COMPLETE_REJECT 타입인데 상품이 없으면 NotFoundProductException 을 던진다")
         void it_throws_NotFoundProductException_for_trade_complete_reject() {
-            when(productRepository.findById(99L)).thenReturn(Optional.empty());
+            when(productRepository.findActiveById(99L)).thenReturn(Optional.empty());
 
             assertThrows(NotFoundProductException.class,
                     () -> service.execute(99L, 1L, AlertType.TRADE_COMPLETE_REJECT, null));

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/CreateChatRoomServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/CreateChatRoomServiceImplTest.java
@@ -59,14 +59,14 @@ class CreateChatRoomServiceImplTest {
 
         private void arrangeDefaultScenario() {
             when(product.getMember()).thenReturn(productOwner);
-            when(productRepository.findById(10L)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(10L)).thenReturn(Optional.of(product));
             doNothing().when(blockValidator).validate(any(Member.class), any(Member.class));
         }
 
         @Test
         @DisplayName("상품이 존재하지 않으면 NotFoundProductException 을 던진다")
         void it_throws_NotFoundProductException_when_product_not_found() {
-            when(productRepository.findById(99L)).thenReturn(Optional.empty());
+            when(productRepository.findActiveById(99L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> service.execute(99L))
                     .isInstanceOf(NotFoundProductException.class);
@@ -76,7 +76,7 @@ class CreateChatRoomServiceImplTest {
         @DisplayName("차단 관계이면 BlockedMemberException 을 던진다")
         void it_throws_BlockedMemberException_when_blocked() {
             when(product.getMember()).thenReturn(productOwner);
-            when(productRepository.findById(10L)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(10L)).thenReturn(Optional.of(product));
             doThrow(new BlockedMemberException()).when(blockValidator).validate(any(Member.class), any(Member.class));
 
             assertThatThrownBy(() -> service.execute(10L))
@@ -143,7 +143,7 @@ class CreateChatRoomServiceImplTest {
         @DisplayName("현재 사용자가 상품 등록자와 동일하면 buyer 와 seller 가 같은 채팅방이 생성된다")
         void it_creates_room_where_buyer_and_seller_are_same_when_self_product() {
             when(product.getMember()).thenReturn(currentMember);
-            when(productRepository.findById(10L)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(10L)).thenReturn(Optional.of(product));
             doNothing().when(blockValidator).validate(any(Member.class), any(Member.class));
             when(product.getMode()).thenReturn(Mode.GIVER);
             when(chatRoomRepository.findByProductIdAndBuyerAndSeller(eq(10L), eq(currentMember), eq(currentMember)))

--- a/src/test/java/team/startup/gwangsan/domain/post/repository/ProductRepositoryTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/repository/ProductRepositoryTest.java
@@ -1,0 +1,98 @@
+package team.startup.gwangsan.domain.post.repository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.Type;
+import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+@DisplayName("ProductRepository 통합 테스트")
+class ProductRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = em.persist(Member.builder()
+                .name("홍길동")
+                .nickname("길동")
+                .phoneNumber("01000000000")
+                .password("password")
+                .role(MemberRole.ROLE_USER)
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    private Product persistProduct(ProductStatus status) {
+        return em.persist(Product.builder()
+                .title("제목")
+                .description("설명")
+                .gwangsan(5000)
+                .member(member)
+                .status(status)
+                .type(Type.SERVICE)
+                .mode(Mode.GIVER)
+                .build());
+    }
+
+    @Nested
+    @DisplayName("findActiveById 메서드는")
+    class Describe_findActiveById {
+
+        @Test
+        @DisplayName("삭제되지 않은 게시글을 반환한다")
+        void it_returns_product_when_not_deleted() {
+            Product product = persistProduct(ProductStatus.ONGOING);
+            em.flush();
+            em.clear();
+
+            assertThat(productRepository.findActiveById(product.getId())).isPresent();
+        }
+
+        @Test
+        @DisplayName("DELETED 상태의 게시글은 반환하지 않는다")
+        void it_returns_empty_when_deleted() {
+            Product product = persistProduct(ProductStatus.DELETED);
+            em.flush();
+            em.clear();
+
+            assertThat(productRepository.findActiveById(product.getId())).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("findByIdWithLock 메서드는")
+    class Describe_findByIdWithLock {
+
+        @Test
+        @DisplayName("DELETED 상태의 게시글은 반환하지 않는다")
+        void it_returns_empty_when_deleted() {
+            Product product = persistProduct(ProductStatus.DELETED);
+            em.flush();
+            em.clear();
+
+            assertThat(productRepository.findByIdWithLock(product.getId())).isEmpty();
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/DeleteProductByIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/DeleteProductByIdServiceImplTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.exception.ForbiddenProductException;
 import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
@@ -57,18 +58,19 @@ class DeleteProductByIdServiceImplTest {
         class Context_with_author {
 
             @Test
-            @DisplayName("정상적으로 상품을 삭제한다")
-            void it_deletes_product() {
+            @DisplayName("물리 삭제하지 않고 상태를 DELETED 로 변경한다")
+            void it_marks_product_as_deleted() {
                 // given
                 Long productId = 1L;
                 when(memberUtil.getCurrentMember()).thenReturn(author);
-                when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
                 // when
                 deleteProductByIdService.execute(productId);
 
                 // then
-                verify(productRepository).delete(product);
+                verify(product).updateStatus(ProductStatus.DELETED);
+                verify(productRepository, never()).delete(any());
             }
         }
 
@@ -82,13 +84,13 @@ class DeleteProductByIdServiceImplTest {
                 // given
                 Long productId = 1L;
                 when(memberUtil.getCurrentMember()).thenReturn(otherUser);
-                when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
                 // when & then
                 assertThrows(ForbiddenProductException.class,
                         () -> deleteProductByIdService.execute(productId));
 
-                verify(productRepository, never()).delete(any());
+                verify(product, never()).updateStatus(any());
             }
         }
 
@@ -102,13 +104,13 @@ class DeleteProductByIdServiceImplTest {
                 // given
                 Long productId = 99L;
                 when(memberUtil.getCurrentMember()).thenReturn(author);
-                when(productRepository.findById(productId)).thenReturn(Optional.empty());
+                when(productRepository.findActiveById(productId)).thenReturn(Optional.empty());
 
                 // when & then
                 assertThrows(NotFoundProductException.class,
                         () -> deleteProductByIdService.execute(productId));
 
-                verify(productRepository, never()).delete(any());
+                verify(product, never()).updateStatus(any());
             }
         }
     }

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductByIdServiceImplTest.java
@@ -105,7 +105,7 @@ class FindProductByIdServiceImplTest {
             when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
             when(product.getMember()).thenReturn(owner);
 
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             Place productPlace = mock(Place.class);
             when(productPlace.getName()).thenReturn("광산구");
@@ -165,7 +165,7 @@ class FindProductByIdServiceImplTest {
             assertThat(result.isCompleted()).isFalse();
             assertThat(result.isReserved()).isTrue();
 
-            verify(productRepository).findById(productId);
+            verify(productRepository).findActiveById(productId);
             verify(productImageRepository).findAllByProductId(productId);
             verify(chatRoomRepository).findByProductIdAndMember(productId, currentMember);
             verify(chatMessageRepository).existsByRoomAndSenderId(chatRoom, currentMember.getId());
@@ -185,13 +185,13 @@ class FindProductByIdServiceImplTest {
             when(memberDetailRepository.findPlaceByMemberId(currentMember.getId()))
                     .thenReturn(myPlace);
 
-            when(productRepository.findById(productId)).thenReturn(Optional.empty());
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.empty());
 
             // when & then
             assertThrows(NotFoundProductException.class,
                     () -> service.execute(productId));
 
-            verify(productRepository).findById(productId);
+            verify(productRepository).findActiveById(productId);
             verifyNoMoreInteractions(productImageRepository, chatRoomRepository, chatMessageRepository);
         }
 
@@ -215,7 +215,7 @@ class FindProductByIdServiceImplTest {
             Product product = mock(Product.class);
             when(product.getId()).thenReturn(productId);
             when(product.getMember()).thenReturn(owner);
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             Place productPlace = mock(Place.class);
             when(memberDetailRepository.findPlaceByMemberId(owner.getId()))
@@ -233,7 +233,7 @@ class FindProductByIdServiceImplTest {
             assertThrows(PlaceMismatchException.class,
                     () -> service.execute(productId));
 
-            verify(productRepository).findById(productId);
+            verify(productRepository).findActiveById(productId);
         }
 
         @Test
@@ -264,7 +264,7 @@ class FindProductByIdServiceImplTest {
             when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
             when(product.getMember()).thenReturn(owner);
 
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             MemberDetail ownerDetail = mock(MemberDetail.class);
             when(ownerDetail.getId()).thenReturn(10L);
@@ -313,7 +313,7 @@ class FindProductByIdServiceImplTest {
             Product product = mock(Product.class);
             when(product.getId()).thenReturn(productId);
             when(product.getMember()).thenReturn(owner);
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             doThrow(new BlockedMemberException())
                     .when(blockValidator).validate(currentMember, owner);
@@ -346,7 +346,7 @@ class FindProductByIdServiceImplTest {
             Product product = mock(Product.class);
             when(product.getId()).thenReturn(productId);
             when(product.getMember()).thenReturn(owner);
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             Place productPlace = mock(Place.class);
             when(memberDetailRepository.findPlaceByMemberId(owner.getId()))

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByMemberIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/FindProductsByMemberIdServiceImplTest.java
@@ -81,7 +81,7 @@ class FindProductsByMemberIdServiceImplTest {
             Member member = mock(Member.class);
             when(memberDetailRepository.findById(MEMBER_ID)).thenReturn(Optional.of(memberDetail));
             when(memberDetail.getMember()).thenReturn(member);
-            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, null))
+            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED, ProductStatus.RESERVATION)))
                     .thenReturn(List.of());
 
             List<GetProductResponse> result = service.execute(MEMBER_ID, TYPE, MODE);
@@ -135,7 +135,7 @@ class FindProductsByMemberIdServiceImplTest {
             when(product3.getMode()).thenReturn(MODE);
             when(product3.getStatus()).thenReturn(ProductStatus.RESERVATION);
 
-            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, null))
+            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED, ProductStatus.RESERVATION)))
                     .thenReturn(List.of(product1, product2, product3));
 
             Image image1 = mock(Image.class);
@@ -204,7 +204,7 @@ class FindProductsByMemberIdServiceImplTest {
             verify(productImageRepository).findAllByProductIdIn(productIdsCaptor.capture());
             assertThat(productIdsCaptor.getValue()).containsExactlyInAnyOrder(100L, 101L, 102L);
 
-            verify(productRepository).findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, null);
+            verify(productRepository).findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED, ProductStatus.RESERVATION));
         }
 
         @Test
@@ -232,7 +232,7 @@ class FindProductsByMemberIdServiceImplTest {
             when(product.getType()).thenReturn(TYPE);
             when(product.getMode()).thenReturn(MODE);
 
-            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, null))
+            when(productRepository.findProductByMemberAndTypeAndModeAndStatusIn(member, TYPE, MODE, List.of(ProductStatus.ONGOING, ProductStatus.COMPLETED, ProductStatus.RESERVATION)))
                     .thenReturn(List.of(product));
 
             when(productImageRepository.findAllByProductIdIn(anyList()))

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
@@ -65,13 +65,13 @@ class ReservationProductServiceImplTest {
             Long productId = 1L;
 
             // given
-            when(productRepository.findById(productId)).thenReturn(Optional.empty());
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.empty());
 
             // when & then
             assertThrows(NotFoundProductException.class,
                     () -> service.execute(productId));
 
-            verify(productRepository).findById(productId);
+            verify(productRepository).findActiveById(productId);
         }
 
         @Test
@@ -83,7 +83,7 @@ class ReservationProductServiceImplTest {
             Product product = mock(Product.class);
             when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
 
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             // when & then
             assertThrows(ProductAlreadyReservationException.class,
@@ -99,7 +99,7 @@ class ReservationProductServiceImplTest {
             Product product = mock(Product.class);
             when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
 
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             // when & then
             assertThrows(ProductNotOngoingException.class,
@@ -118,7 +118,7 @@ class ReservationProductServiceImplTest {
             Product product = mock(Product.class);
             when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
 
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             ChatRoom chatRoom = mock(ChatRoom.class);
             when(chatRoom.getId()).thenReturn(10L);

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/UpdateProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/UpdateProductServiceImplTest.java
@@ -76,7 +76,7 @@ class UpdateProductServiceImplTest {
         void givenObjectGiverWithNoImages_whenUpdateProduct_thenThrowsObjectRequiredException() {
             Long productId = 1L;
             when(memberUtil.getCurrentMember()).thenReturn(author);
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             assertThrows(ObjectRequiredImageException.class, () ->
                     updateProductService.execute(productId, Type.OBJECT, Mode.GIVER, "T", "D", 100, Collections.emptyList()));
@@ -88,7 +88,7 @@ class UpdateProductServiceImplTest {
             // given
             Long productId = 1L;
             when(memberUtil.getCurrentMember()).thenReturn(author);
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             ProductImage pi1 = mock(ProductImage.class);
             ProductImage pi2 = mock(ProductImage.class);
@@ -136,7 +136,7 @@ class UpdateProductServiceImplTest {
             Long productId = 1L;
 
             when(memberUtil.getCurrentMember()).thenReturn(otherUser);
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             // when & then
             assertThrows(ForbiddenProductException.class, () ->
@@ -158,7 +158,7 @@ class UpdateProductServiceImplTest {
             Long productId = 99L;
 
             when(memberUtil.getCurrentMember()).thenReturn(author);
-            when(productRepository.findById(productId)).thenReturn(Optional.empty());
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.empty());
 
             // when & then
             assertThrows(NotFoundProductException.class, () ->
@@ -179,7 +179,7 @@ class UpdateProductServiceImplTest {
             // given
             Long productId = 1L;
             when(memberUtil.getCurrentMember()).thenReturn(author);
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             ProductImage pi = mock(ProductImage.class);
             Image img = mock(Image.class);
@@ -216,7 +216,7 @@ class UpdateProductServiceImplTest {
             Long productId = 1L;
 
             when(memberUtil.getCurrentMember()).thenReturn(author);
-            when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             ProductImage pi = mock(ProductImage.class);
             Image existing = mock(Image.class);
@@ -252,7 +252,7 @@ class UpdateProductServiceImplTest {
         Long productId = 1L;
 
         when(memberUtil.getCurrentMember()).thenReturn(author);
-        when(productRepository.findById(productId)).thenReturn(Optional.of(product));
+        when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
         ProductImage pi = mock(ProductImage.class);
         Image existingImg = mock(Image.class);

--- a/src/test/java/team/startup/gwangsan/domain/review/service/impl/CreateReviewServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/review/service/impl/CreateReviewServiceImplTest.java
@@ -84,7 +84,7 @@ class CreateReviewServiceImplTest {
                 TradeComplete completedTrade = mockCompletedTrade(reviewer, reviewed);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
-                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(1L)).thenReturn(Optional.of(product));
                 when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
                 when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(completedTrade));
@@ -124,7 +124,7 @@ class CreateReviewServiceImplTest {
             void it_throws_not_found_product_exception() {
                 Member reviewer = mockMember(1L);
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
-                when(productRepository.findById(99L)).thenReturn(Optional.empty());
+                when(productRepository.findActiveById(99L)).thenReturn(Optional.empty());
 
                 assertThatThrownBy(() -> service.execute(new CreateReviewRequest(99L, 2L, "내용", 50)))
                         .isInstanceOf(NotFoundProductException.class);
@@ -144,7 +144,7 @@ class CreateReviewServiceImplTest {
                 when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
-                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(1L)).thenReturn(Optional.of(product));
 
                 assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 2L, "내용", 50)))
                         .isInstanceOf(CannotReviewBeforeTradeException.class);
@@ -164,7 +164,7 @@ class CreateReviewServiceImplTest {
                 when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
-                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(1L)).thenReturn(Optional.of(product));
                 when(memberRepository.findById(2L)).thenReturn(Optional.empty());
 
                 assertThatThrownBy(() -> service.execute(new CreateReviewRequest(1L, 2L, "내용", 50)))
@@ -186,7 +186,7 @@ class CreateReviewServiceImplTest {
                 when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
-                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(1L)).thenReturn(Optional.of(product));
                 when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
                 when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
                         .thenReturn(Optional.empty());
@@ -213,7 +213,7 @@ class CreateReviewServiceImplTest {
                 TradeComplete completedTrade = mockCompletedTrade(reviewer, thirdParty);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
-                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(1L)).thenReturn(Optional.of(product));
                 when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
                 when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(completedTrade));
@@ -239,7 +239,7 @@ class CreateReviewServiceImplTest {
                 TradeComplete completedTrade = mockCompletedTrade(reviewer, reviewed);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
-                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(1L)).thenReturn(Optional.of(product));
                 when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
                 when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(completedTrade));
@@ -266,7 +266,7 @@ class CreateReviewServiceImplTest {
                 TradeComplete completedTrade = mockCompletedTrade(reviewer, reviewed);
 
                 when(memberUtil.getCurrentMember()).thenReturn(reviewer);
-                when(productRepository.findById(1L)).thenReturn(Optional.of(product));
+                when(productRepository.findActiveById(1L)).thenReturn(Optional.of(product));
                 when(memberRepository.findById(2L)).thenReturn(Optional.of(reviewed));
                 when(tradeCompleteRepository.findByProductAndStatus(product, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(completedTrade));


### PR DESCRIPTION
## 💡 배경 및 개요

`DELETE /api/post/{post_id}` 호출 시 연관 데이터가 있는 게시글은 FK 제약 위반으로 500이 발생했습니다.

```
Cannot delete or update a parent row: a foreign key constraint fails
(`tbl_trade_complete`, CONSTRAINT `tbl_trade_complete_ibfk_1` ...)
```

`tbl_product`를 참조하는 테이블이 5개(`tbl_product_image`, `tbl_product_reservation`, `tbl_chat_room`, `tbl_trade_complete`, `tbl_review`)라, 이미지가 한 장이라도 붙은 게시글은 사실상 전부 삭제 불가 상태였습니다.

Resolves: #353

## 📃 작업내용

- `ProductStatus`에 `DELETED` 추가
- `DeleteProductByIdServiceImpl` — `productRepository.delete()` → `product.updateStatus(DELETED)`
- `ProductRepository.findActiveById()` 추가 (`findByIdAndStatusNot` 위임), 단건 조회 7곳을 이걸로 통일
  - 게시글 상세 / 수정 / 삭제 / 예약, 채팅방 생성, 리뷰 생성, 알림 생성
- `findByIdWithLock` JPQL에 DELETED 제외 조건 추가 (거래 완료 요청 경로)
- `/post/member/{member_id}` — status 필터가 `null`(전체 조회)이라 DELETED가 노출되므로 `ONGOING, COMPLETED, RESERVATION` 명시
- 미사용이 된 `findByIdAndStatus` 삭제
- `ProductRepositoryTest` 추가 — DELETED가 실제로 걸러지는지 H2로 검증

## 🙋‍♂️ 리뷰노트

**왜 soft delete인가**

거래 이력(`tbl_trade_complete`)은 정산 기록이고 리뷰는 상대방 light 점수의 근거라 물리 삭제하면 안 되는 데이터입니다. 회원 탈퇴 시 게시글을 지우지 않고 더미 회원에게 넘기는 `ProductRepository.reassignMember()` 선례와도 일관됩니다.

**의도적으로 남겨둔 것**

채팅방 목록(`findRoomProductsWithImagesByIds`)은 DELETED를 거르지 않았습니다. 이미 열려 있는 대화방이 게시글 삭제로 사라지면 상대방이 맥락을 잃기 때문에, 방은 유지하고 게시글 정보만 그대로 보여줍니다. 관리자 알림 조회도 같은 이유로 그대로 뒀습니다.

**응답 스펙 변화 없음**

`DELETED`는 목록·상세 응답에서 제외되기만 하고 프론트로 내려가지 않습니다. 삭제된 게시글 접근 시 기존과 동일하게 `NotFoundProductException`(404)이 나갑니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (해당 없음)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요?
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요? (`develop`)
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

`./gradlew test` — 388개 중 387개 통과.
`ChatStreamConsumerIntegrationTest` 1건은 로컬에 Docker가 없어 Testcontainers가 기동하지 못한 것으로, 이번 변경과 무관합니다.

이미 삭제를 시도했다가 실패한 게시글들은 그대로 남아 있습니다. 기존 데이터 정리가 필요하면 별도로 논의가 필요합니다.

