### PR TITLE
채팅방 개인별 삭제(숨김) API 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/entity/ChatRoom.java
@@ -42,6 +42,12 @@ public class ChatRoom {
     @JoinColumn(name = "product_id")
     private Product product;
 
+    @Column(name = "hidden_by_buyer_at")
+    private LocalDateTime hiddenByBuyerAt;
+
+    @Column(name = "hidden_by_seller_at")
+    private LocalDateTime hiddenBySellerAt;
+
     @Builder
     public ChatRoom(LocalDateTime createdAt, Boolean isActive, Member buyer, Member seller, Product product) {
         this.createdAt = createdAt;
@@ -49,5 +55,25 @@ public class ChatRoom {
         this.buyer = buyer;
         this.seller = seller;
         this.product = product;
+    }
+
+    public boolean isParticipant(Member member) {
+        return buyer.getId().equals(member.getId()) || seller.getId().equals(member.getId());
+    }
+
+    public void hideFor(Member member, LocalDateTime hiddenAt) {
+        if (buyer.getId().equals(member.getId())) {
+            this.hiddenByBuyerAt = hiddenAt;
+        } else if (seller.getId().equals(member.getId())) {
+            this.hiddenBySellerAt = hiddenAt;
+        }
+    }
+
+    public void unhideFor(Member member) {
+        if (buyer.getId().equals(member.getId())) {
+            this.hiddenByBuyerAt = null;
+        } else if (seller.getId().equals(member.getId())) {
+            this.hiddenBySellerAt = null;
+        }
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/ChatController.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/ChatController.java
@@ -10,6 +10,7 @@ import team.startup.gwangsan.domain.chat.presentation.dto.response.GetChatMessag
 import team.startup.gwangsan.domain.chat.presentation.dto.response.GetRoomIdResponse;
 import team.startup.gwangsan.domain.chat.presentation.dto.response.GetRoomsResponse;
 import team.startup.gwangsan.domain.chat.service.CreateChatRoomService;
+import team.startup.gwangsan.domain.chat.service.DeleteChatRoomService;
 import team.startup.gwangsan.domain.chat.service.FindChatMessageByRoomIdService;
 import team.startup.gwangsan.domain.chat.service.FindRoomsByCurrentUserService;
 import team.startup.gwangsan.domain.chat.service.ReadChatMessageService;
@@ -28,6 +29,7 @@ public class ChatController {
     private final ReadChatMessageService readChatMessageService;
     private final FindRoomsByCurrentUserService findRoomsByCurrentUserService;
     private final FindRoomIdByProductIdService findRoomIdByProductIdService;
+    private final DeleteChatRoomService deleteChatRoomService;
 
     @PostMapping("/room/{product_id}")
     public ResponseEntity<CreateChatRoomResponse> createChatRoom(@PathVariable("product_id") Long productId) {
@@ -62,5 +64,11 @@ public class ChatController {
     public ResponseEntity<GetRoomIdResponse> getRoom(@PathVariable("product_id") Long productId) {
         GetRoomIdResponse response = findRoomIdByProductIdService.execute(productId);
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/room/{room_id}")
+    public ResponseEntity<Void> deleteChatRoom(@PathVariable("room_id") Long roomId) {
+        deleteChatRoomService.execute(roomId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
@@ -84,7 +84,10 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
                 .join(chatRoom.buyer, buyer)
                 .join(chatRoom.seller, seller)
                 .where(chatRoom.isActive.isTrue()
-                        .and(chatRoom.buyer.id.eq(memberId).or(chatRoom.seller.id.eq(memberId))))
+                        .and(
+                                chatRoom.buyer.id.eq(memberId).and(chatRoom.hiddenByBuyerAt.isNull())
+                                        .or(chatRoom.seller.id.eq(memberId).and(chatRoom.hiddenBySellerAt.isNull()))
+                        ))
                 .fetch();
 
         if (rooms.isEmpty()) {

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/DeleteChatRoomService.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/DeleteChatRoomService.java
@@ -1,0 +1,5 @@
+package team.startup.gwangsan.domain.chat.service;
+
+public interface DeleteChatRoomService {
+    void execute(Long roomId);
+}

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/CreateChatRoomServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/CreateChatRoomServiceImpl.java
@@ -51,7 +51,9 @@ public class CreateChatRoomServiceImpl implements CreateChatRoomService {
         Optional<ChatRoom> existsChatRoom = chatRoomRepository.findByProductIdAndBuyerAndSeller(productId, buyer, seller);
 
         if (existsChatRoom.isPresent()) {
-            return new CreateChatRoomResponse(existsChatRoom.get().getId());
+            ChatRoom room = existsChatRoom.get();
+            room.unhideFor(member);
+            return new CreateChatRoomResponse(room.getId());
         }
 
         ChatRoom chatRoom = ChatRoom.builder()

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/DeleteChatRoomServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/DeleteChatRoomServiceImpl.java
@@ -1,0 +1,36 @@
+package team.startup.gwangsan.domain.chat.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.chat.service.DeleteChatRoomService;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteChatRoomServiceImpl implements DeleteChatRoomService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberUtil memberUtil;
+
+    @Override
+    @Transactional
+    public void execute(Long roomId) {
+        Member member = memberUtil.getCurrentMember();
+
+        ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomId(roomId)
+                .orElseThrow(NotFoundChatRoomException::new);
+
+        if (!chatRoom.isParticipant(member)) {
+            throw new NotFoundChatRoomException();
+        }
+
+        chatRoom.hideFor(member, LocalDateTime.now());
+    }
+}

--- a/src/main/resources/db/migration/V4__add_chat_room_hidden_at.sql
+++ b/src/main/resources/db/migration/V4__add_chat_room_hidden_at.sql
@@ -1,0 +1,6 @@
+-- Per-participant chat room hide (soft delete). Non-null means that side
+-- deleted the room from their own list; the room and its messages remain
+-- untouched for the other side and for trade/reservation data.
+ALTER TABLE tbl_chat_room
+    ADD COLUMN hidden_by_buyer_at DATETIME NULL,
+    ADD COLUMN hidden_by_seller_at DATETIME NULL;

--- a/src/test/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImplTest.java
@@ -136,6 +136,36 @@ class ChatRoomCustomRepositoryImplTest {
             assertThat(result.get(0).lastMessage()).isEqualTo("나중에 온 메시지");
         }
 
+        @Test
+        @DisplayName("요청자 쪽에서 숨김 처리한 채팅방은 결과에서 제외한다")
+        void it_excludes_room_hidden_by_requester() {
+            Member buyer = createMember("buyer3", "010-0003-0001");
+            Member seller = createMember("seller3", "010-0003-0002");
+            ChatRoom room = createRoom(buyer, seller, createProduct(seller));
+            room.hideFor(buyer, LocalDateTime.of(2024, 1, 1, 0, 0));
+            em.persist(room);
+
+            em.flush();
+            em.getEntityManager().clear();
+
+            assertThat(repository.findRoomsByMemberId(buyer.getId())).isEmpty();
+        }
+
+        @Test
+        @DisplayName("상대방이 숨김 처리해도 요청자의 결과에는 그대로 노출된다")
+        void it_keeps_room_visible_for_the_other_participant() {
+            Member buyer = createMember("buyer4", "010-0004-0001");
+            Member seller = createMember("seller4", "010-0004-0002");
+            ChatRoom room = createRoom(buyer, seller, createProduct(seller));
+            room.hideFor(buyer, LocalDateTime.of(2024, 1, 1, 0, 0));
+            em.persist(room);
+
+            em.flush();
+            em.getEntityManager().clear();
+
+            assertThat(repository.findRoomsByMemberId(seller.getId())).hasSize(1);
+        }
+
     }
 
     @Nested

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/CreateChatRoomServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/CreateChatRoomServiceImplTest.java
@@ -100,6 +100,21 @@ class CreateChatRoomServiceImplTest {
         }
 
         @Test
+        @DisplayName("이미 채팅방이 존재하면 요청자 쪽의 숨김 상태를 해제한다")
+        void it_unhides_room_for_requester_when_room_already_exists() {
+            arrangeDefaultScenario();
+            when(product.getMode()).thenReturn(Mode.GIVER);
+            ChatRoom existingRoom = mock(ChatRoom.class);
+            when(existingRoom.getId()).thenReturn(100L);
+            when(chatRoomRepository.findByProductIdAndBuyerAndSeller(eq(10L), eq(currentMember), eq(productOwner)))
+                    .thenReturn(Optional.of(existingRoom));
+
+            service.execute(10L);
+
+            verify(existingRoom).unhideFor(currentMember);
+        }
+
+        @Test
         @DisplayName("GIVER 모드이면 현재 사용자가 buyer, 상품주가 seller 로 방을 생성한다")
         void it_creates_room_with_current_user_as_buyer_when_mode_is_giver() {
             arrangeDefaultScenario();

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/DeleteChatRoomServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/DeleteChatRoomServiceImplTest.java
@@ -1,0 +1,78 @@
+package team.startup.gwangsan.domain.chat.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("DeleteChatRoomServiceImpl 단위 테스트")
+class DeleteChatRoomServiceImplTest {
+
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private MemberUtil memberUtil;
+
+    @InjectMocks
+    private DeleteChatRoomServiceImpl service;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("채팅방이 존재하지 않으면 NotFoundChatRoomException 을 던진다")
+        void it_throws_NotFoundChatRoomException_when_room_not_found() {
+            Member member = mock(Member.class);
+            when(memberUtil.getCurrentMember()).thenReturn(member);
+            when(chatRoomRepository.findChatRoomByRoomId(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.execute(1L))
+                    .isInstanceOf(NotFoundChatRoomException.class);
+        }
+
+        @Test
+        @DisplayName("요청자가 채팅방의 참여자가 아니면 NotFoundChatRoomException 을 던지고 숨김 처리하지 않는다")
+        void it_throws_NotFoundChatRoomException_when_member_is_not_participant() {
+            Member member = mock(Member.class);
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.isParticipant(member)).thenReturn(false);
+            when(memberUtil.getCurrentMember()).thenReturn(member);
+            when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
+
+            assertThatThrownBy(() -> service.execute(10L))
+                    .isInstanceOf(NotFoundChatRoomException.class);
+
+            verify(chatRoom, never()).hideFor(any(), any());
+        }
+
+        @Test
+        @DisplayName("요청자가 참여자면 요청자 쪽만 숨김 처리한다")
+        void it_hides_room_only_for_requester() {
+            Member member = mock(Member.class);
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.isParticipant(member)).thenReturn(true);
+            when(memberUtil.getCurrentMember()).thenReturn(member);
+            when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
+
+            service.execute(10L);
+
+            verify(chatRoom).hideFor(eq(member), any(LocalDateTime.class));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- `ChatRoom`에 `hiddenByBuyerAt`/`hiddenBySellerAt` 컬럼을 추가해 참여자별 삭제(숨김) 상태를 관리한다.
- `DELETE /api/chat/room/{room_id}`를 추가해 요청자 쪽만 숨김 처리한다 (row는 삭제하지 않음).
- `GET /api/chat/rooms` 목록 조회 시 요청자 쪽에서 숨긴 채팅방은 결과에서 제외한다.
- 동일 상품(buyer/seller 조합)으로 채팅방을 다시 생성하면 요청자 쪽 숨김이 해제되어 방이 다시 보인다.
- `ChatRoom`은 `Product`만 참조하고 `TradeComplete`/`ProductReservation`은 `ChatRoom`을 참조하지 않으므로, 숨김 처리는 거래/예약 데이터에 어떤 영향도 주지 않는다.
- 기존 `isActive` 필드는 양쪽 모두에 적용되는 room 단위 플래그라 재사용하지 않고 별도 컬럼을 추가했다.
- prod(`ddl-auto: validate`)를 위한 Flyway 마이그레이션(`V4__add_chat_room_hidden_at.sql`) 추가.

Closes #355

## Test plan
- [x] `DeleteChatRoomServiceImplTest`: 존재하지 않는 방 / 비참여자 / 정상 케이스 단위 테스트
- [x] `CreateChatRoomServiceImplTest`: 재진입 시 숨김 해제 검증 테스트 추가
- [x] `ChatRoomCustomRepositoryImplTest`: 요청자가 숨긴 방은 제외되고 상대방에게는 그대로 노출되는지 검증
- [x] `./gradlew test` — Docker 미설치로 실패하는 `ChatStreamConsumerIntegrationTest`(Testcontainers) 1건을 제외한 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)