### PR TITLE
채팅방 예약 기능에 날짜/시간/장소 및 작성자 권한 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetChatProductDto.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetChatProductDto.java
@@ -13,6 +13,8 @@ public record GetChatProductDto(
         boolean isSeller,
         boolean isCompletable,
         boolean isCompleted,
-        boolean isReserved
+        boolean isReserved,
+        LocalDateTime reservationScheduledAt,
+        String reservationLocation
 )  {
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetChatProductDto.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetChatProductDto.java
@@ -15,6 +15,9 @@ public record GetChatProductDto(
         boolean isCompleted,
         boolean isReserved,
         LocalDateTime reservationScheduledAt,
-        String reservationLocation
+        String reservationPlaceName,
+        String reservationAddress,
+        Double reservationLatitude,
+        Double reservationLongitude
 )  {
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImpl.java
@@ -17,9 +17,12 @@ import team.startup.gwangsan.domain.chat.service.FindChatMessageByRoomIdService;
 import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductImage;
+import team.startup.gwangsan.domain.post.entity.ProductReservation;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
 import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
+import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 import team.startup.gwangsan.global.util.MemberUtil;
@@ -40,6 +43,7 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
     private final ChatMessageImageRepository chatMessageImageRepository;
     private final ProductImageRepository productImageRepository;
     private final TradeCompleteRepository tradeCompleteRepository;
+    private final ProductReservationRepository productReservationRepository;
 
     @Override
     @Transactional
@@ -72,6 +76,10 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
                 .map(tc -> tc.isRequestedBySeller() != isSeller)
                 .orElse(true);
 
+        Optional<ProductReservation> reservation = isReserved
+                ? productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING)
+                : Optional.empty();
+
         GetChatProductDto productDto = new GetChatProductDto(
                 product.getId(),
                 product.getTitle(),
@@ -80,7 +88,9 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
                 isSeller,
                 isCompletable,
                 isCompleted,
-                isReserved
+                isReserved,
+                reservation.map(ProductReservation::getScheduledAt).orElse(null),
+                reservation.map(ProductReservation::getLocation).orElse(null)
         );
 
         List<ChatMessage> messages = chatMessageRepository.findChatMessageByRoomIdWithCursorPaging(roomId, lastCreatedAt, lastMessageId, limit);

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImpl.java
@@ -90,7 +90,10 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
                 isCompleted,
                 isReserved,
                 reservation.map(ProductReservation::getScheduledAt).orElse(null),
-                reservation.map(ProductReservation::getLocation).orElse(null)
+                reservation.map(ProductReservation::getPlaceName).orElse(null),
+                reservation.map(ProductReservation::getAddress).orElse(null),
+                reservation.map(ProductReservation::getLatitude).orElse(null),
+                reservation.map(ProductReservation::getLongitude).orElse(null)
         );
 
         List<ChatMessage> messages = chatMessageRepository.findChatMessageByRoomIdWithCursorPaging(roomId, lastCreatedAt, lastMessageId, limit);

--- a/src/main/java/team/startup/gwangsan/domain/post/entity/ProductReservation.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/entity/ProductReservation.java
@@ -41,8 +41,17 @@ public class ProductReservation {
     @Column(name = "scheduled_at")
     private LocalDateTime scheduledAt;
 
-    @Column(name = "location", length = 100)
-    private String location;
+    @Column(name = "place_name", length = 100)
+    private String placeName;
+
+    @Column(name = "address", length = 255)
+    private String address;
+
+    @Column(name = "latitude")
+    private Double latitude;
+
+    @Column(name = "longitude")
+    private Double longitude;
 
     @CreatedDate
     @Column(name = "created_at", updatable = false)
@@ -52,12 +61,16 @@ public class ProductReservation {
     private LocalDateTime cancelledAt;
 
     @Builder
-    public ProductReservation(Product product, Member reserver, ReservationStatus status, LocalDateTime scheduledAt, String location) {
+    public ProductReservation(Product product, Member reserver, ReservationStatus status, LocalDateTime scheduledAt,
+                               String placeName, String address, Double latitude, Double longitude) {
         this.product = product;
         this.reserver = reserver;
         this.status = status == null ? ReservationStatus.PENDING : status;
         this.scheduledAt = scheduledAt;
-        this.location = location;
+        this.placeName = placeName;
+        this.address = address;
+        this.latitude = latitude;
+        this.longitude = longitude;
     }
 
     public void cancel() {

--- a/src/main/java/team/startup/gwangsan/domain/post/entity/ProductReservation.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/entity/ProductReservation.java
@@ -38,6 +38,12 @@ public class ProductReservation {
     @Column(name = "status", nullable = false)
     private ReservationStatus status;
 
+    @Column(name = "scheduled_at")
+    private LocalDateTime scheduledAt;
+
+    @Column(name = "location", length = 100)
+    private String location;
+
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
@@ -46,10 +52,12 @@ public class ProductReservation {
     private LocalDateTime cancelledAt;
 
     @Builder
-    public ProductReservation(Product product, Member reserver, ReservationStatus status) {
+    public ProductReservation(Product product, Member reserver, ReservationStatus status, LocalDateTime scheduledAt, String location) {
         this.product = product;
         this.reserver = reserver;
         this.status = status == null ? ReservationStatus.PENDING : status;
+        this.scheduledAt = scheduledAt;
+        this.location = location;
     }
 
     public void cancel() {

--- a/src/main/java/team/startup/gwangsan/domain/post/presentation/PostController.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/presentation/PostController.java
@@ -10,6 +10,7 @@ import team.startup.gwangsan.domain.post.entity.constant.Type;
 import team.startup.gwangsan.domain.post.presentation.dto.request.CreateProductRequest;
 import team.startup.gwangsan.domain.post.presentation.dto.request.PatchProductRequest;
 import team.startup.gwangsan.domain.post.presentation.dto.request.RequestTradeCompleteRequest;
+import team.startup.gwangsan.domain.post.presentation.dto.request.ReservationRequest;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductByIdResponse;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductResponse;
 import team.startup.gwangsan.domain.post.service.*;
@@ -111,8 +112,11 @@ public class PostController {
     }
 
     @PatchMapping("/reservation/{product_id}")
-    public ResponseEntity<Void> reservation(@PathVariable("product_id") Long productId) {
-        reservationProductService.execute(productId);
+    public ResponseEntity<Void> reservation(
+            @PathVariable("product_id") Long productId,
+            @RequestBody @Valid ReservationRequest request
+    ) {
+        reservationProductService.execute(productId, request.roomId(), request.scheduledAt(), request.location());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/team/startup/gwangsan/domain/post/presentation/PostController.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/presentation/PostController.java
@@ -116,7 +116,15 @@ public class PostController {
             @PathVariable("product_id") Long productId,
             @RequestBody @Valid ReservationRequest request
     ) {
-        reservationProductService.execute(productId, request.roomId(), request.scheduledAt(), request.location());
+        reservationProductService.execute(
+                productId,
+                request.roomId(),
+                request.scheduledAt(),
+                request.placeName(),
+                request.address(),
+                request.latitude(),
+                request.longitude()
+        );
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/request/ReservationRequest.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/request/ReservationRequest.java
@@ -1,0 +1,13 @@
+package team.startup.gwangsan.domain.post.presentation.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDateTime;
+
+public record ReservationRequest(
+        @NotNull Long roomId,
+        @NotNull LocalDateTime scheduledAt,
+        @NotNull @Size(max = 100) String location
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/request/ReservationRequest.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/request/ReservationRequest.java
@@ -8,6 +8,9 @@ import java.time.LocalDateTime;
 public record ReservationRequest(
         @NotNull Long roomId,
         @NotNull LocalDateTime scheduledAt,
-        @NotNull @Size(max = 100) String location
+        @NotNull @Size(max = 100) String placeName,
+        @NotNull @Size(max = 255) String address,
+        @NotNull Double latitude,
+        @NotNull Double longitude
 ) {
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/ReservationProductService.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/ReservationProductService.java
@@ -1,5 +1,7 @@
 package team.startup.gwangsan.domain.post.service;
 
+import java.time.LocalDateTime;
+
 public interface ReservationProductService {
-    void execute(Long productId);
+    void execute(Long productId, Long roomId, LocalDateTime scheduledAt, String location);
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/ReservationProductService.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/ReservationProductService.java
@@ -3,5 +3,5 @@ package team.startup.gwangsan.domain.post.service;
 import java.time.LocalDateTime;
 
 public interface ReservationProductService {
-    void execute(Long productId, Long roomId, LocalDateTime scheduledAt, String location);
+    void execute(Long productId, Long roomId, LocalDateTime scheduledAt, String placeName, String address, Double latitude, Double longitude);
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
@@ -4,12 +4,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
 import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
+import team.startup.gwangsan.domain.post.exception.ForbiddenProductException;
 import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
 import team.startup.gwangsan.domain.post.exception.ProductAlreadyReservationException;
 import team.startup.gwangsan.domain.post.exception.ProductNotOngoingException;
@@ -33,11 +36,15 @@ public class ReservationProductServiceImpl implements ReservationProductService 
 
     @Override
     @Transactional
-    public void execute(Long productId) {
-        Member reserver = memberUtil.getCurrentMember();
+    public void execute(Long productId, Long roomId, LocalDateTime scheduledAt, String location) {
+        Member member = memberUtil.getCurrentMember();
 
         Product product = productRepository.findActiveById(productId)
                 .orElseThrow(NotFoundProductException::new);
+
+        if (!product.getMember().getId().equals(member.getId())) {
+            throw new ForbiddenProductException();
+        }
 
         if (product.getStatus() == ProductStatus.RESERVATION) {
             throw new ProductAlreadyReservationException();
@@ -47,24 +54,36 @@ public class ReservationProductServiceImpl implements ReservationProductService 
             throw new ProductNotOngoingException();
         }
 
+        ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomId(roomId)
+                .orElseThrow(NotFoundChatRoomException::new);
+
+        if (!chatRoom.getProduct().getId().equals(productId)) {
+            throw new NotFoundChatRoomException();
+        }
+
+        Member reserver = chatRoom.getBuyer().getId().equals(member.getId())
+                ? chatRoom.getSeller()
+                : chatRoom.getBuyer();
+
         productReservationRepository.save(
                 ProductReservation.builder()
                         .product(product)
                         .reserver(reserver)
                         .status(ReservationStatus.PENDING)
+                        .scheduledAt(scheduledAt)
+                        .location(location)
                         .build()
         );
 
         product.updateStatus(ProductStatus.RESERVATION);
 
-        chatRoomRepository.findByProductIdAndMember(productId, reserver)
-                .ifPresent(chatRoom -> applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
-                        chatRoom.getId(),
-                        null,
-                        productId,
-                        false,
-                        true,
-                        LocalDateTime.now()
-                )));
+        applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                chatRoom.getId(),
+                null,
+                productId,
+                false,
+                true,
+                LocalDateTime.now()
+        ));
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
@@ -36,7 +36,7 @@ public class ReservationProductServiceImpl implements ReservationProductService 
 
     @Override
     @Transactional
-    public void execute(Long productId, Long roomId, LocalDateTime scheduledAt, String location) {
+    public void execute(Long productId, Long roomId, LocalDateTime scheduledAt, String placeName, String address, Double latitude, Double longitude) {
         Member member = memberUtil.getCurrentMember();
 
         Product product = productRepository.findActiveById(productId)
@@ -71,7 +71,10 @@ public class ReservationProductServiceImpl implements ReservationProductService 
                         .reserver(reserver)
                         .status(ReservationStatus.PENDING)
                         .scheduledAt(scheduledAt)
-                        .location(location)
+                        .placeName(placeName)
+                        .address(address)
+                        .latitude(latitude)
+                        .longitude(longitude)
                         .build()
         );
 

--- a/src/main/resources/db/migration/V5__add_product_reservation_schedule.sql
+++ b/src/main/resources/db/migration/V5__add_product_reservation_schedule.sql
@@ -1,3 +1,6 @@
 ALTER TABLE tbl_product_reservation
     ADD COLUMN scheduled_at DATETIME NULL,
-    ADD COLUMN location VARCHAR(100) NULL;
+    ADD COLUMN place_name VARCHAR(100) NULL,
+    ADD COLUMN address VARCHAR(255) NULL,
+    ADD COLUMN latitude DOUBLE NULL,
+    ADD COLUMN longitude DOUBLE NULL;

--- a/src/main/resources/db/migration/V5__add_product_reservation_schedule.sql
+++ b/src/main/resources/db/migration/V5__add_product_reservation_schedule.sql
@@ -1,0 +1,3 @@
+ALTER TABLE tbl_product_reservation
+    ADD COLUMN scheduled_at DATETIME NULL,
+    ADD COLUMN location VARCHAR(100) NULL;

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImplTest.java
@@ -20,8 +20,11 @@ import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.image.entity.Image;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.ProductReservation;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
 import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
+import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
@@ -46,6 +49,7 @@ class FindChatMessageByRoomIdServiceImplTest {
     @Mock private ChatMessageImageRepository chatMessageImageRepository;
     @Mock private ProductImageRepository productImageRepository;
     @Mock private TradeCompleteRepository tradeCompleteRepository;
+    @Mock private ProductReservationRepository productReservationRepository;
 
     @InjectMocks
     private FindChatMessageByRoomIdServiceImpl service;
@@ -301,10 +305,45 @@ class FindChatMessageByRoomIdServiceImplTest {
             arrangeRoomAsSellerView();
             arrangeEmptyMessages();
             when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
+            when(productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING))
+                    .thenReturn(Optional.empty());
 
             GetChatMessagesResponse response = service.execute(5L, null, null, 20);
 
             assertThat(response.product().isReserved()).isTrue();
+        }
+
+        @Test
+        @DisplayName("상품이 예약 상태이면 예약 일시와 장소를 함께 반환한다")
+        void it_returns_reservation_schedule_and_location_when_reserved() {
+            arrangeRoomAsSellerView();
+            arrangeEmptyMessages();
+            when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
+
+            ProductReservation reservation = mock(ProductReservation.class);
+            LocalDateTime scheduledAt = LocalDateTime.of(2026, 9, 1, 14, 0);
+            when(reservation.getScheduledAt()).thenReturn(scheduledAt);
+            when(reservation.getLocation()).thenReturn("광산구청 1층 로비");
+            when(productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING))
+                    .thenReturn(Optional.of(reservation));
+
+            GetChatMessagesResponse response = service.execute(5L, null, null, 20);
+
+            assertThat(response.product().reservationScheduledAt()).isEqualTo(scheduledAt);
+            assertThat(response.product().reservationLocation()).isEqualTo("광산구청 1층 로비");
+        }
+
+        @Test
+        @DisplayName("상품이 예약 상태가 아니면 예약 조회 없이 예약 일시/장소는 null 이다")
+        void it_does_not_query_reservation_when_not_reserved() {
+            arrangeRoomAsSellerView();
+            arrangeEmptyMessages();
+
+            GetChatMessagesResponse response = service.execute(5L, null, null, 20);
+
+            assertThat(response.product().reservationScheduledAt()).isNull();
+            assertThat(response.product().reservationLocation()).isNull();
+            verifyNoInteractions(productReservationRepository);
         }
 
         @Test

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImplTest.java
@@ -314,8 +314,8 @@ class FindChatMessageByRoomIdServiceImplTest {
         }
 
         @Test
-        @DisplayName("상품이 예약 상태이면 예약 일시와 장소를 함께 반환한다")
-        void it_returns_reservation_schedule_and_location_when_reserved() {
+        @DisplayName("상품이 예약 상태이면 예약 일시와 장소 정보를 함께 반환한다")
+        void it_returns_reservation_schedule_and_place_when_reserved() {
             arrangeRoomAsSellerView();
             arrangeEmptyMessages();
             when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
@@ -323,18 +323,24 @@ class FindChatMessageByRoomIdServiceImplTest {
             ProductReservation reservation = mock(ProductReservation.class);
             LocalDateTime scheduledAt = LocalDateTime.of(2026, 9, 1, 14, 0);
             when(reservation.getScheduledAt()).thenReturn(scheduledAt);
-            when(reservation.getLocation()).thenReturn("광산구청 1층 로비");
+            when(reservation.getPlaceName()).thenReturn("광산구청");
+            when(reservation.getAddress()).thenReturn("광주광역시 광산구 광산로29번길 15");
+            when(reservation.getLatitude()).thenReturn(35.1397);
+            when(reservation.getLongitude()).thenReturn(126.7935);
             when(productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING))
                     .thenReturn(Optional.of(reservation));
 
             GetChatMessagesResponse response = service.execute(5L, null, null, 20);
 
             assertThat(response.product().reservationScheduledAt()).isEqualTo(scheduledAt);
-            assertThat(response.product().reservationLocation()).isEqualTo("광산구청 1층 로비");
+            assertThat(response.product().reservationPlaceName()).isEqualTo("광산구청");
+            assertThat(response.product().reservationAddress()).isEqualTo("광주광역시 광산구 광산로29번길 15");
+            assertThat(response.product().reservationLatitude()).isEqualTo(35.1397);
+            assertThat(response.product().reservationLongitude()).isEqualTo(126.7935);
         }
 
         @Test
-        @DisplayName("상품이 예약 상태가 아니면 예약 조회 없이 예약 일시/장소는 null 이다")
+        @DisplayName("상품이 예약 상태가 아니면 예약 조회 없이 예약 정보는 null 이다")
         void it_does_not_query_reservation_when_not_reserved() {
             arrangeRoomAsSellerView();
             arrangeEmptyMessages();
@@ -342,7 +348,10 @@ class FindChatMessageByRoomIdServiceImplTest {
             GetChatMessagesResponse response = service.execute(5L, null, null, 20);
 
             assertThat(response.product().reservationScheduledAt()).isNull();
-            assertThat(response.product().reservationLocation()).isNull();
+            assertThat(response.product().reservationPlaceName()).isNull();
+            assertThat(response.product().reservationAddress()).isNull();
+            assertThat(response.product().reservationLatitude()).isNull();
+            assertThat(response.product().reservationLongitude()).isNull();
             verifyNoInteractions(productReservationRepository);
         }
 

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
@@ -10,11 +10,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
 import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.exception.ForbiddenProductException;
 import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
 import team.startup.gwangsan.domain.post.exception.ProductAlreadyReservationException;
 import team.startup.gwangsan.domain.post.exception.ProductNotOngoingException;
@@ -23,6 +25,7 @@ import team.startup.gwangsan.domain.post.repository.ProductReservationRepository
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
@@ -55,6 +58,10 @@ class ReservationProductServiceImplTest {
     @InjectMocks
     private ReservationProductServiceImpl service;
 
+    private static final Long ROOM_ID = 5L;
+    private static final LocalDateTime SCHEDULED_AT = LocalDateTime.of(2026, 9, 1, 14, 0);
+    private static final String LOCATION = "광산구청 1층 로비";
+
     @Nested
     @DisplayName("execute()는")
     class Describe_execute {
@@ -63,15 +70,39 @@ class ReservationProductServiceImplTest {
         @DisplayName("상품이 존재하지 않으면 NotFoundProductException을 던진다")
         void throw_exception_when_product_not_found() {
             Long productId = 1L;
+            Member author = mock(Member.class);
+            when(memberUtil.getCurrentMember()).thenReturn(author);
 
             // given
             when(productRepository.findActiveById(productId)).thenReturn(Optional.empty());
 
             // when & then
             assertThrows(NotFoundProductException.class,
-                    () -> service.execute(productId));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
 
             verify(productRepository).findActiveById(productId);
+        }
+
+        @Test
+        @DisplayName("호출자가 게시물 작성자가 아니면 ForbiddenProductException을 던진다")
+        void throw_exception_when_not_author() {
+            Long productId = 1L;
+
+            Member author = mock(Member.class);
+            when(author.getId()).thenReturn(1L);
+            Member other = mock(Member.class);
+            when(other.getId()).thenReturn(2L);
+            when(memberUtil.getCurrentMember()).thenReturn(other);
+
+            Product product = mock(Product.class);
+            when(product.getMember()).thenReturn(author);
+
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
+
+            assertThrows(ForbiddenProductException.class,
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+
+            verifyNoInteractions(chatRoomRepository, productReservationRepository, applicationEventPublisher);
         }
 
         @Test
@@ -79,15 +110,20 @@ class ReservationProductServiceImplTest {
         void throw_exception_when_already_reserved() {
             Long productId = 1L;
 
+            Member author = mock(Member.class);
+            when(author.getId()).thenReturn(1L);
+            when(memberUtil.getCurrentMember()).thenReturn(author);
+
             // given
             Product product = mock(Product.class);
+            when(product.getMember()).thenReturn(author);
             when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
 
             when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             // when & then
             assertThrows(ProductAlreadyReservationException.class,
-                    () -> service.execute(productId));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
         }
 
         @Test
@@ -95,15 +131,65 @@ class ReservationProductServiceImplTest {
         void throw_exception_when_status_is_not_ongoing() {
             Long productId = 1L;
 
+            Member author = mock(Member.class);
+            when(author.getId()).thenReturn(1L);
+            when(memberUtil.getCurrentMember()).thenReturn(author);
+
             // given
             Product product = mock(Product.class);
+            when(product.getMember()).thenReturn(author);
             when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
 
             when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             // when & then
             assertThrows(ProductNotOngoingException.class,
-                    () -> service.execute(productId));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+        }
+
+        @Test
+        @DisplayName("채팅방을 찾을 수 없으면 NotFoundChatRoomException을 던진다")
+        void throw_exception_when_chat_room_not_found() {
+            Long productId = 1L;
+
+            Member author = mock(Member.class);
+            when(author.getId()).thenReturn(1L);
+            when(memberUtil.getCurrentMember()).thenReturn(author);
+
+            Product product = mock(Product.class);
+            when(product.getMember()).thenReturn(author);
+            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
+
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
+            when(chatRoomRepository.findChatRoomByRoomId(ROOM_ID)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundChatRoomException.class,
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+        }
+
+        @Test
+        @DisplayName("채팅방의 상품이 요청한 상품과 다르면 NotFoundChatRoomException을 던진다")
+        void throw_exception_when_chat_room_product_mismatch() {
+            Long productId = 1L;
+
+            Member author = mock(Member.class);
+            when(author.getId()).thenReturn(1L);
+            when(memberUtil.getCurrentMember()).thenReturn(author);
+
+            Product product = mock(Product.class);
+            when(product.getMember()).thenReturn(author);
+            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
+
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
+
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            Product otherProduct = mock(Product.class);
+            when(otherProduct.getId()).thenReturn(999L);
+            when(chatRoom.getProduct()).thenReturn(otherProduct);
+            when(chatRoomRepository.findChatRoomByRoomId(ROOM_ID)).thenReturn(Optional.of(chatRoom));
+
+            assertThrows(NotFoundChatRoomException.class,
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
         }
 
         @Test
@@ -112,21 +198,28 @@ class ReservationProductServiceImplTest {
             Long productId = 1L;
 
             // given
-            Member reserver = mock(Member.class);
-            when(memberUtil.getCurrentMember()).thenReturn(reserver);
+            Member author = mock(Member.class);
+            when(author.getId()).thenReturn(1L);
+            when(memberUtil.getCurrentMember()).thenReturn(author);
 
             Product product = mock(Product.class);
+            when(product.getMember()).thenReturn(author);
             when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
+            when(product.getId()).thenReturn(productId);
 
             when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
+            Member buyer = mock(Member.class);
+            when(buyer.getId()).thenReturn(2L);
+
             ChatRoom chatRoom = mock(ChatRoom.class);
             when(chatRoom.getId()).thenReturn(10L);
-            when(chatRoomRepository.findByProductIdAndMember(productId, reserver))
-                    .thenReturn(Optional.of(chatRoom));
+            when(chatRoom.getProduct()).thenReturn(product);
+            when(chatRoom.getBuyer()).thenReturn(buyer);
+            when(chatRoomRepository.findChatRoomByRoomId(ROOM_ID)).thenReturn(Optional.of(chatRoom));
 
             // when
-            assertDoesNotThrow(() -> service.execute(productId));
+            assertDoesNotThrow(() -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
 
             // then
             verify(productReservationRepository).save(any(ProductReservation.class));

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
@@ -60,7 +60,10 @@ class ReservationProductServiceImplTest {
 
     private static final Long ROOM_ID = 5L;
     private static final LocalDateTime SCHEDULED_AT = LocalDateTime.of(2026, 9, 1, 14, 0);
-    private static final String LOCATION = "광산구청 1층 로비";
+    private static final String PLACE_NAME = "광산구청";
+    private static final String ADDRESS = "광주광역시 광산구 광산로29번길 15";
+    private static final Double LATITUDE = 35.1397;
+    private static final Double LONGITUDE = 126.7935;
 
     @Nested
     @DisplayName("execute()는")
@@ -78,7 +81,7 @@ class ReservationProductServiceImplTest {
 
             // when & then
             assertThrows(NotFoundProductException.class,
-                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, PLACE_NAME, ADDRESS, LATITUDE, LONGITUDE));
 
             verify(productRepository).findActiveById(productId);
         }
@@ -100,7 +103,7 @@ class ReservationProductServiceImplTest {
             when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
 
             assertThrows(ForbiddenProductException.class,
-                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, PLACE_NAME, ADDRESS, LATITUDE, LONGITUDE));
 
             verifyNoInteractions(chatRoomRepository, productReservationRepository, applicationEventPublisher);
         }
@@ -123,7 +126,7 @@ class ReservationProductServiceImplTest {
 
             // when & then
             assertThrows(ProductAlreadyReservationException.class,
-                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, PLACE_NAME, ADDRESS, LATITUDE, LONGITUDE));
         }
 
         @Test
@@ -144,7 +147,7 @@ class ReservationProductServiceImplTest {
 
             // when & then
             assertThrows(ProductNotOngoingException.class,
-                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, PLACE_NAME, ADDRESS, LATITUDE, LONGITUDE));
         }
 
         @Test
@@ -164,7 +167,7 @@ class ReservationProductServiceImplTest {
             when(chatRoomRepository.findChatRoomByRoomId(ROOM_ID)).thenReturn(Optional.empty());
 
             assertThrows(NotFoundChatRoomException.class,
-                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, PLACE_NAME, ADDRESS, LATITUDE, LONGITUDE));
         }
 
         @Test
@@ -189,7 +192,7 @@ class ReservationProductServiceImplTest {
             when(chatRoomRepository.findChatRoomByRoomId(ROOM_ID)).thenReturn(Optional.of(chatRoom));
 
             assertThrows(NotFoundChatRoomException.class,
-                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+                    () -> service.execute(productId, ROOM_ID, SCHEDULED_AT, PLACE_NAME, ADDRESS, LATITUDE, LONGITUDE));
         }
 
         @Test
@@ -219,7 +222,7 @@ class ReservationProductServiceImplTest {
             when(chatRoomRepository.findChatRoomByRoomId(ROOM_ID)).thenReturn(Optional.of(chatRoom));
 
             // when
-            assertDoesNotThrow(() -> service.execute(productId, ROOM_ID, SCHEDULED_AT, LOCATION));
+            assertDoesNotThrow(() -> service.execute(productId, ROOM_ID, SCHEDULED_AT, PLACE_NAME, ADDRESS, LATITUDE, LONGITUDE));
 
             // then
             verify(productReservationRepository).save(any(ProductReservation.class));


### PR DESCRIPTION
## Summary
- `ProductReservation`에 예약 일시(`scheduledAt`)와 장소 정보(`placeName`, `address`, `latitude`, `longitude`) 컬럼 추가 (Flyway `V5__add_product_reservation_schedule.sql`)
- `PATCH /api/post/reservation/{product_id}`에 `roomId`, `scheduledAt`, `placeName`, `address`, `latitude`, `longitude`를 받는 `ReservationRequest` 바디 추가
- 예약 생성 권한을 게시물 작성자로 제한 (`product.getMember()`가 아니면 기존 `ForbiddenProductException` 재사용), 채팅방(`roomId`)의 상대방을 예약 대상(`reserver`)으로 지정
- `GetChatProductDto`에 `reservationScheduledAt`, `reservationPlaceName`, `reservationAddress`, `reservationLatitude`, `reservationLongitude` 필드를 추가하여 채팅방 조회 응답에서 예약 일시/장소를 바로 확인 가능하도록 확장

## Related
Closes #357

## Test plan
- [x] `ReservationProductServiceImplTest` (작성자 권한 검증, 채팅방 검증, 예약 생성 케이스 포함) 통과
- [x] `DeleteReservationProductServiceImplTest` 회귀 없음 확인
- [x] `FindChatMessageByRoomIdServiceImplTest` (예약 일시/장소 정보 응답 검증 케이스 포함) 통과
- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test`(Docker 미설치로 인한 기존 Testcontainers 통합 테스트 1건 제외) 통과