### PR TITLE
내 구매/판매 내역 조회 API 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/TradeController.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/TradeController.java
@@ -5,10 +5,13 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.TradeCancelRequest;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeHistoryResponse;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.HeadTradeHistoryResponse;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.PlaceTradeHistoryResponse;
+import team.startup.gwangsan.domain.trade.service.FindMyTradeHistoryService;
 import team.startup.gwangsan.domain.trade.service.TradeCancelService;
 import team.startup.gwangsan.domain.trade.service.TradeCancelWithdrawService;
 import team.startup.gwangsan.domain.trade.service.TradeHistoryByHeadService;
@@ -26,6 +29,15 @@ public class TradeController {
     private final TradeHistoryByPlaceService tradeHistoryByPlaceService;
     private final TradeCancelService tradeCancelService;
     private final TradeCancelWithdrawService tradeCancelWithdrawService;
+    private final FindMyTradeHistoryService findMyTradeHistoryService;
+
+    @GetMapping("/history")
+    public ResponseEntity<List<GetTradeHistoryResponse>> getMyTradeHistory(
+            @RequestParam(name = "status", defaultValue = "COMPLETED") TradeStatus status
+    ) {
+        List<GetTradeHistoryResponse> response = findMyTradeHistoryService.execute(status);
+        return ResponseEntity.ok(response);
+    }
 
     @GetMapping("/graph/head")
     public ResponseEntity<List<HeadTradeHistoryResponse>> getHeadHistory(

--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/GetTradeHistoryResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/GetTradeHistoryResponse.java
@@ -1,0 +1,15 @@
+package team.startup.gwangsan.domain.trade.presentation.dto.response;
+
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.constant.TradeRole;
+
+import java.time.LocalDateTime;
+
+public record GetTradeHistoryResponse(
+        Long tradeId,
+        TradeRole role,
+        TradeStatus status,
+        LocalDateTime completedAt,
+        GetTradeProductResponse product
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/GetTradeProductResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/GetTradeProductResponse.java
@@ -1,0 +1,11 @@
+package team.startup.gwangsan.domain.trade.presentation.dto.response;
+
+import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
+
+public record GetTradeProductResponse(
+        Long productId,
+        String title,
+        Integer gwangsan,
+        GetImageResponse image
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/constant/TradeRole.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/constant/TradeRole.java
@@ -1,0 +1,6 @@
+package team.startup.gwangsan.domain.trade.presentation.dto.response.constant;
+
+public enum TradeRole {
+    BUYER,
+    SELLER,
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/TradeCompleteCustomRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/TradeCompleteCustomRepository.java
@@ -1,9 +1,11 @@
 package team.startup.gwangsan.domain.trade.repository.custom;
 
+import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -19,4 +21,6 @@ public interface TradeCompleteCustomRepository {
     Optional<TradeComplete> findByProductIdAndStatus(Long productId, TradeStatus status);
 
     Optional<TradeComplete> findByIdWithProductAndMember(Long id);
+
+    List<TradeComplete> findAllByMemberAndStatus(Member member, TradeStatus status);
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/impl/TradeCompleteCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/impl/TradeCompleteCustomRepositoryImpl.java
@@ -3,6 +3,7 @@ package team.startup.gwangsan.domain.trade.repository.custom.impl;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.repository.custom.TradeCompleteCustomRepository;
@@ -10,6 +11,7 @@ import team.startup.gwangsan.domain.trade.repository.custom.TradeCompleteCustomR
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -116,5 +118,18 @@ public class TradeCompleteCustomRepositoryImpl implements TradeCompleteCustomRep
                         .where(tradeComplete.id.eq(id))
                         .fetchOne()
         );
+    }
+
+    @Override
+    public List<TradeComplete> findAllByMemberAndStatus(Member member, TradeStatus status) {
+        return queryFactory
+                .selectFrom(tradeComplete)
+                .join(tradeComplete.product).fetchJoin()
+                .where(
+                        tradeComplete.buyer.eq(member).or(tradeComplete.seller.eq(member)),
+                        tradeComplete.status.eq(status)
+                )
+                .orderBy(tradeComplete.completedAt.desc().nullsLast(), tradeComplete.id.desc())
+                .fetch();
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/FindMyTradeHistoryService.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/FindMyTradeHistoryService.java
@@ -1,0 +1,10 @@
+package team.startup.gwangsan.domain.trade.service;
+
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeHistoryResponse;
+
+import java.util.List;
+
+public interface FindMyTradeHistoryService {
+    List<GetTradeHistoryResponse> execute(TradeStatus status);
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/FindMyTradeHistoryServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/FindMyTradeHistoryServiceImpl.java
@@ -1,0 +1,77 @@
+package team.startup.gwangsan.domain.trade.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeHistoryResponse;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeProductResponse;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.constant.TradeRole;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.service.FindMyTradeHistoryService;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FindMyTradeHistoryServiceImpl implements FindMyTradeHistoryService {
+
+    private final TradeCompleteRepository tradeCompleteRepository;
+    private final ProductImageRepository productImageRepository;
+    private final MemberUtil memberUtil;
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<GetTradeHistoryResponse> execute(TradeStatus status) {
+        Member member = memberUtil.getCurrentMember();
+
+        List<TradeComplete> trades = tradeCompleteRepository.findAllByMemberAndStatus(member, status);
+
+        if (trades.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> productIds = trades.stream()
+                .map(trade -> trade.getProduct().getId())
+                .distinct()
+                .toList();
+
+        // ponytail: ProductImage에 순서 컬럼이 없어 조회 순서상 첫 장을 대표로 쓴다.
+        Map<Long, GetImageResponse> imageMap = productImageRepository.findAllByProductIdIn(productIds).stream()
+                .collect(Collectors.toMap(
+                        pi -> pi.getProduct().getId(),
+                        pi -> new GetImageResponse(pi.getImage().getId(), pi.getImage().getImageUrl()),
+                        (first, second) -> first
+                ));
+
+        return trades.stream()
+                .map(trade -> {
+                    Product product = trade.getProduct();
+                    TradeRole role = trade.getBuyer().getId().equals(member.getId())
+                            ? TradeRole.BUYER
+                            : TradeRole.SELLER;
+
+                    return new GetTradeHistoryResponse(
+                            trade.getId(),
+                            role,
+                            trade.getStatus(),
+                            trade.getCompletedAt(),
+                            new GetTradeProductResponse(
+                                    product.getId(),
+                                    product.getTitle(),
+                                    product.getGwangsan(),
+                                    imageMap.get(product.getId())
+                            )
+                    );
+                })
+                .toList();
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/FindMyTradeHistoryServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/FindMyTradeHistoryServiceImplTest.java
@@ -1,0 +1,193 @@
+package team.startup.gwangsan.domain.trade.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.ProductImage;
+import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeHistoryResponse;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.constant.TradeRole;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FindMyTradeHistoryServiceImpl 단위 테스트")
+class FindMyTradeHistoryServiceImplTest {
+
+    private static final Long ME_ID = 100L;
+    private static final Long OPPONENT_ID = 200L;
+
+    @Mock
+    private TradeCompleteRepository tradeCompleteRepository;
+
+    @Mock
+    private ProductImageRepository productImageRepository;
+
+    @Mock
+    private MemberUtil memberUtil;
+
+    @InjectMocks
+    private FindMyTradeHistoryServiceImpl service;
+
+    private Member memberOf(Long id) {
+        Member member = mock(Member.class);
+        lenient().when(member.getId()).thenReturn(id);
+        return member;
+    }
+
+    private Product productOf(Long id, String title, Integer gwangsan) {
+        Product product = mock(Product.class);
+        lenient().when(product.getId()).thenReturn(id);
+        lenient().when(product.getTitle()).thenReturn(title);
+        lenient().when(product.getGwangsan()).thenReturn(gwangsan);
+        return product;
+    }
+
+    private TradeComplete tradeOf(Long id, Product product, Member buyer, Member seller, LocalDateTime completedAt) {
+        TradeComplete trade = mock(TradeComplete.class);
+        lenient().when(trade.getId()).thenReturn(id);
+        lenient().when(trade.getProduct()).thenReturn(product);
+        lenient().when(trade.getBuyer()).thenReturn(buyer);
+        lenient().when(trade.getStatus()).thenReturn(TradeStatus.COMPLETED);
+        lenient().when(trade.getCompletedAt()).thenReturn(completedAt);
+        return trade;
+    }
+
+    private ProductImage productImageOf(Product product, Long imageId, String url) {
+        Image image = mock(Image.class);
+        lenient().when(image.getId()).thenReturn(imageId);
+        lenient().when(image.getImageUrl()).thenReturn(url);
+
+        ProductImage productImage = mock(ProductImage.class);
+        lenient().when(productImage.getProduct()).thenReturn(product);
+        lenient().when(productImage.getImage()).thenReturn(image);
+        return productImage;
+    }
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("내가 buyer 인 거래는 role 을 BUYER 로, seller 인 거래는 SELLER 로 내려준다")
+        void it_maps_role_by_whether_i_am_buyer_or_seller() {
+            Member me = memberOf(ME_ID);
+            Member opponent = memberOf(OPPONENT_ID);
+
+            Product bought = productOf(1L, "내가 산 물건", 5000);
+            Product sold = productOf(2L, "내가 판 물건", 10000);
+
+            TradeComplete boughtTrade = tradeOf(11L, bought, me, opponent, LocalDateTime.of(2026, 8, 20, 10, 0));
+            TradeComplete soldTrade = tradeOf(12L, sold, opponent, me, LocalDateTime.of(2026, 8, 19, 10, 0));
+
+            when(memberUtil.getCurrentMember()).thenReturn(me);
+            when(tradeCompleteRepository.findAllByMemberAndStatus(me, TradeStatus.COMPLETED))
+                    .thenReturn(List.of(boughtTrade, soldTrade));
+            when(productImageRepository.findAllByProductIdIn(List.of(1L, 2L)))
+                    .thenReturn(List.of());
+
+            List<GetTradeHistoryResponse> result = service.execute(TradeStatus.COMPLETED);
+
+            assertThat(result).hasSize(2);
+
+            GetTradeHistoryResponse first = result.get(0);
+            assertThat(first.tradeId()).isEqualTo(11L);
+            assertThat(first.role()).isEqualTo(TradeRole.BUYER);
+            assertThat(first.status()).isEqualTo(TradeStatus.COMPLETED);
+            assertThat(first.completedAt()).isEqualTo(LocalDateTime.of(2026, 8, 20, 10, 0));
+            assertThat(first.product().productId()).isEqualTo(1L);
+            assertThat(first.product().title()).isEqualTo("내가 산 물건");
+            assertThat(first.product().gwangsan()).isEqualTo(5000);
+
+            assertThat(result.get(1).role()).isEqualTo(TradeRole.SELLER);
+            assertThat(result.get(1).product().title()).isEqualTo("내가 판 물건");
+        }
+
+        @Test
+        @DisplayName("상품 이미지가 여러 장이면 먼저 조회된 것을 대표 이미지로 내려준다")
+        void it_picks_first_image_as_thumbnail() {
+            Member me = memberOf(ME_ID);
+            Member opponent = memberOf(OPPONENT_ID);
+            Product product = productOf(1L, "사진 여러 장", 5000);
+            TradeComplete trade = tradeOf(11L, product, me, opponent, LocalDateTime.of(2026, 8, 20, 10, 0));
+
+            ProductImage firstImage = productImageOf(product, 31L, "https://example.com/first.png");
+            ProductImage secondImage = productImageOf(product, 32L, "https://example.com/second.png");
+
+            when(memberUtil.getCurrentMember()).thenReturn(me);
+            when(tradeCompleteRepository.findAllByMemberAndStatus(me, TradeStatus.COMPLETED))
+                    .thenReturn(List.of(trade));
+            when(productImageRepository.findAllByProductIdIn(List.of(1L)))
+                    .thenReturn(List.of(firstImage, secondImage));
+
+            List<GetTradeHistoryResponse> result = service.execute(TradeStatus.COMPLETED);
+
+            assertThat(result.get(0).product().image().imageId()).isEqualTo(31L);
+            assertThat(result.get(0).product().image().imageUrl()).isEqualTo("https://example.com/first.png");
+        }
+
+        @Test
+        @DisplayName("이미지가 없는 상품은 대표 이미지를 null 로 내려준다")
+        void it_returns_null_image_when_product_has_no_image() {
+            Member me = memberOf(ME_ID);
+            Member opponent = memberOf(OPPONENT_ID);
+            Product product = productOf(1L, "사진 없음", 5000);
+            TradeComplete trade = tradeOf(11L, product, me, opponent, null);
+
+            when(memberUtil.getCurrentMember()).thenReturn(me);
+            when(tradeCompleteRepository.findAllByMemberAndStatus(me, TradeStatus.COMPLETED))
+                    .thenReturn(List.of(trade));
+            when(productImageRepository.findAllByProductIdIn(List.of(1L))).thenReturn(List.of());
+
+            List<GetTradeHistoryResponse> result = service.execute(TradeStatus.COMPLETED);
+
+            assertThat(result.get(0).product().image()).isNull();
+            assertThat(result.get(0).completedAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("거래가 없으면 빈 목록을 반환하고 이미지를 조회하지 않는다")
+        void it_returns_empty_list_without_querying_images() {
+            Member me = memberOf(ME_ID);
+
+            when(memberUtil.getCurrentMember()).thenReturn(me);
+            when(tradeCompleteRepository.findAllByMemberAndStatus(me, TradeStatus.COMPLETED))
+                    .thenReturn(List.of());
+
+            List<GetTradeHistoryResponse> result = service.execute(TradeStatus.COMPLETED);
+
+            assertThat(result).isEmpty();
+            verify(productImageRepository, never()).findAllByProductIdIn(any());
+        }
+
+        @Test
+        @DisplayName("요청한 status 를 그대로 조회 조건에 넘긴다")
+        void it_passes_requested_status_to_repository() {
+            Member me = memberOf(ME_ID);
+
+            when(memberUtil.getCurrentMember()).thenReturn(me);
+            when(tradeCompleteRepository.findAllByMemberAndStatus(me, TradeStatus.PENDING))
+                    .thenReturn(List.of());
+
+            service.execute(TradeStatus.PENDING);
+
+            verify(tradeCompleteRepository).findAllByMemberAndStatus(me, TradeStatus.PENDING);
+        }
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

프론트엔드에서 거래 내역 화면을 구매 내역 / 판매 내역 탭으로 분리하면서, 서버에 쓸 API가 없어 `GET /post/current`(내가 작성한 글 목록)를 `mode` + `isCompleted`로 클라이언트 필터링해 임시 구현한 상태였습니다.

이 방식은 **내가 글을 작성해서 성사된 거래만** 보여줄 수 있고, 상대방이 작성한 글에 거래신청을 걸어 내가 구매자/판매자로 참여한 거래는 전혀 표시되지 않습니다.

`TradeComplete`는 글 작성자가 누구인지와 무관하게 `buyer`/`seller`로 참여자를 표현하고 있어, 이걸 **로그인한 본인 기준으로 조회하는 API**만 있으면 해결됩니다.

Resolves: #358

## 📃 작업내용

**`GET /api/trade/history`** 신설 (`status` 기본값 `COMPLETED`)

```json
[
  {
    "tradeId": 11,
    "role": "BUYER",
    "status": "COMPLETED",
    "completedAt": "2026-08-20T10:00:00",
    "product": {
      "productId": 1,
      "title": "상품명",
      "gwangsan": 5000,
      "image": { "imageId": 31, "imageUrl": "https://..." }
    }
  }
]
```

- `TradeCompleteCustomRepository.findAllByMemberAndStatus` 추가 — QueryDSL로 `buyer OR seller` 조회, `product` fetch join, `completedAt DESC NULLS LAST` 정렬
- `FindMyTradeHistoryService` / `Impl` 추가
- 응답 DTO `GetTradeHistoryResponse`, `GetTradeProductResponse`, `TradeRole`(BUYER/SELLER) 추가
- `TradeController`에 엔드포인트 추가
- 단위 테스트 5개 추가

## 🙋‍♂️ 리뷰노트

**1. `role`만 내려주고 필터링은 클라이언트에 맡겼습니다**

`?role=BUYER` 파라미터를 받는 방안도 있었지만, 프론트가 탭 두 개를 그리는 화면이라 한 번의 호출로 전체를 받아 나누는 편이 요청 수가 적습니다.

**2. 거래 상대방 정보는 넣지 않았습니다**

이슈 요구 범위(`role`, `product` 요약, `completedAt`, `status`)만 담았습니다. 화면에 "○○님과 거래" 표시가 필요하면 조인 하나 추가하면 되니 말씀 주세요.

**3. 대표 이미지는 기존 쿼리를 재사용했습니다**

`ProductImage`에 순서 컬럼이 없어서, `findAllByProductIdIn`(image/product를 fetch join하는 기존 메서드) 결과에서 상품별로 먼저 조회된 한 장을 대표로 씁니다. 신규 쿼리는 추가하지 않았습니다.

**4. 삭제된 게시글의 거래도 제외하지 않습니다**

`ProductStatus.DELETED`인 글이라도 내가 사고판 기록은 남아야 한다고 판단해 `findActiveById` 같은 필터를 걸지 않았습니다.

**5. 페이지네이션은 넣지 않았습니다**

이슈에서 백엔드 판단에 맡겨주셨고, 기존 `/post/current`, `/post/member/{id}`도 전체 반환이라 동일하게 맞췄습니다.

**6. SecurityConfig는 수정하지 않았습니다**

`/api/trade/*` 중 명시된 건 관리자 전용 4개뿐이고, 나머지는 `anyRequest().hasAnyAuthority(ROLE_USER, ...)`에 걸립니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`) — 환경값·스키마 변경 없음
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요? (`develop`)
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

`./gradlew test` 기준 399개 중 `ChatStreamConsumerWorker 통합 테스트` 1개만 실패하는데, Testcontainers가 Docker를 찾지 못해 나는 오류로 **이 브랜치의 변경 전에도 동일하게 실패**합니다.
