### PR TITLE
채팅/거래 상태 정확성 수정 방 숨김 해제, 철회 후 상품 상태, 유실 로깅

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImpl.java
@@ -14,7 +14,9 @@ import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
@@ -23,7 +25,10 @@ import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelExce
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCancelException;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +39,7 @@ public class ApproveTradeCancelServiceImpl implements ApproveTradeCancelService 
     private final MemberUtil memberUtil;
     private final MemberDetailRepository memberDetailRepository;
     private final ValidatePlaceUtil validatePlaceUtil;
+    private final ChatRoomRepository chatRoomRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
@@ -75,14 +81,24 @@ public class ApproveTradeCancelServiceImpl implements ApproveTradeCancelService 
 
         tradeComplete.updateStatus(TradeStatus.ROLLED_BACK);
 
+        // 상품을 다시 거래 가능 상태로 되돌린다. 이걸 빠뜨리면 채팅방의 isCompleted 가
+        // Product.status 에서만 파생되므로 철회 후에도 영구히 "거래 완료"로 남는다.
+        product.updateStatus(ProductStatus.ONGOING);
+
         applicationEventPublisher.publishEvent(new CreateAlertEvent(
                 tradeCancel.getId(),
                 alert.getRequester().getId(),
                 AlertType.TRADE_CANCEL
         ));
 
-
-
-
+        chatRoomRepository.findByProductIdAndBuyerAndSeller(product.getId(), buyer, seller)
+                .ifPresent(chatRoom -> applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                        chatRoom.getId(),
+                        null,
+                        product.getId(),
+                        false,
+                        false,
+                        LocalDateTime.now()
+                )));
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
@@ -67,6 +67,10 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
             chatMessageImageRepository.saveAll(chatMessageImages);
         }
 
+        // 나간 방에 새 메시지가 오면 양쪽 모두에게 다시 보여야 한다.
+        chatRoom.unhideFor(chatRoom.getBuyer());
+        chatRoom.unhideFor(chatRoom.getSeller());
+
         Member otherMember = member.getId().equals(chatRoom.getBuyer().getId()) ? chatRoom.getSeller() : chatRoom.getBuyer();
 
         List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserId(otherMember.getId());

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerProperties.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerProperties.java
@@ -2,10 +2,14 @@ package team.startup.gwangsan.global.chat.notification;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.time.Duration;
+
 @ConfigurationProperties(prefix = "chatting.server")
 public record ChattingServerProperties(
         String url,
-        String internalSecret
+        String internalSecret,
+        Duration connectTimeout,
+        Duration readTimeout
 ) {
     public boolean isEnabled() {
         return url != null && !url.isBlank();

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
@@ -1,12 +1,15 @@
 package team.startup.gwangsan.global.chat.notification;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 
 import java.time.LocalDateTime;
 
+@Slf4j
 @Component
 public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTradeStatusNotifier {
 
@@ -18,7 +21,25 @@ public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTrad
 
     public ChattingServerTradeStatusNotifierImpl(ChattingServerProperties properties, RestClient.Builder restClientBuilder) {
         this.properties = properties;
-        this.restClient = properties.isEnabled() ? restClientBuilder.baseUrl(properties.url()).build() : null;
+
+        if (!properties.isEnabled()) {
+            // 설정이 비어 있으면 거래 상태가 채팅 서버에 전혀 전달되지 않는다.
+            // 조용히 넘어가면 실시간 갱신이 죽은 것을 알 수 없으므로 남겨 둔다.
+            log.warn("chatting.server.url 이 설정되지 않아 거래 상태 변경을 채팅 서버에 전달하지 않습니다.");
+            this.restClient = null;
+            return;
+        }
+
+        RestClient.Builder builder = restClientBuilder.clone().baseUrl(properties.url());
+
+        if (properties.connectTimeout() != null && properties.readTimeout() != null) {
+            SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+            requestFactory.setConnectTimeout(properties.connectTimeout());
+            requestFactory.setReadTimeout(properties.readTimeout());
+            builder.requestFactory(requestFactory);
+        }
+
+        this.restClient = builder.build();
     }
 
     @Override

--- a/src/main/java/team/startup/gwangsan/global/chat/stream/ChatStreamMessageProcessor.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/stream/ChatStreamMessageProcessor.java
@@ -4,10 +4,13 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.stereotype.Component;
 import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
 import team.startup.gwangsan.domain.chat.exception.InvalidChatStreamPayloadException;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberException;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -15,6 +18,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChatStreamMessageProcessor {
@@ -46,6 +50,8 @@ public class ChatStreamMessageProcessor {
             LocalDateTime createdAt = parseCreatedAt(body.get(ChatStreamField.CREATED_AT));
             message = new ChatStreamMessage(messageId, roomId, content, imageIds, messageType, senderId, createdAt);
         } catch (Exception e) {
+            log.error("[ChatStream] 메시지 매핑 실패로 폐기합니다. streamKey={}, recordId={}, body={}",
+                    streamKey, record.getId(), body, e);
             redisAdapter.sendToDlq(streamKey, record, "MAPPING_ERROR: " + e.getMessage());
             redisAdapter.ack(streamKey, record.getId());
             return;
@@ -55,9 +61,13 @@ public class ChatStreamMessageProcessor {
             try {
                 handler.handle(message);
             } catch (Exception e) {
-                if (attempt >= props.getRetryMax()) {
+                if (attempt >= props.getRetryMax() || isPermanentFailure(e)) {
+                    log.error("[ChatStream] 메시지 처리 실패로 폐기합니다. streamKey={}, recordId={}, messageId={}, attempt={}",
+                            streamKey, record.getId(), message.messageId(), attempt, e);
                     redisAdapter.sendToDlq(streamKey, record, e.getMessage());
                 } else {
+                    log.warn("[ChatStream] 메시지 처리 실패, 재시도합니다. streamKey={}, messageId={}, attempt={}, cause={}",
+                            streamKey, message.messageId(), attempt, e.getMessage());
                     redisAdapter.sendToRetry(streamKey, record, attempt + 1, e.getMessage());
                 }
                 redisAdapter.ack(streamKey, record.getId());
@@ -66,6 +76,14 @@ public class ChatStreamMessageProcessor {
         }
 
         redisAdapter.ack(streamKey, record.getId());
+    }
+
+    /**
+     * 재시도해도 결과가 달라지지 않는 실패인지. 없는 방/회원은 나중에 다시 시도해도
+     * 그대로 실패하므로 retry 횟수만 소모하지 말고 바로 DLQ 로 보낸다.
+     */
+    private boolean isPermanentFailure(Exception e) {
+        return e instanceof NotFoundChatRoomException || e instanceof NotFoundMemberException;
     }
 
     private List<Long> parseImageIds(String raw) {

--- a/src/main/java/team/startup/gwangsan/global/chat/stream/ChatStreamRedisAdapter.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/stream/ChatStreamRedisAdapter.java
@@ -73,9 +73,31 @@ public class ChatStreamRedisAdapter {
             streamOps().createGroup(streamKey, ReadOffset.from("0"), props.getGroup());
             initializedGroups.add(streamKey);
         } catch (Exception e) {
-            log.debug("[ChatStream] Group '{}' already exists or stream missing: {}", props.getGroup(), e.getMessage());
-            initializedGroups.add(streamKey);
+            // 이미 존재하는 경우에만 완료로 표시한다. 진짜 실패까지 완료로 두면 그 방은
+            // 이후 매 사이클 NOGROUP 만 내면서 영영 저장되지 않는다.
+            if (containsError(e, "BUSYGROUP")) {
+                log.debug("[ChatStream] Group '{}' already exists for {}", props.getGroup(), streamKey);
+                initializedGroups.add(streamKey);
+                return;
+            }
+            // 아직 만들어지지 않은 스트림(예: 실패가 없어 비어 있는 retry 스트림)은 정상이다.
+            // 스트림이 생기면 다음 사이클에 그룹도 만들어진다.
+            if (containsError(e, "requires the key to exist")) {
+                log.debug("[ChatStream] Stream {} does not exist yet, group creation deferred", streamKey);
+                return;
+            }
+            log.warn("[ChatStream] Failed to create group '{}' for {}: {}", props.getGroup(), streamKey, e.getMessage());
         }
+    }
+
+    private boolean containsError(Throwable e, String token) {
+        for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+            String message = cause.getMessage();
+            if (message != null && message.contains(token)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -50,6 +50,8 @@ chatting:
     # Keep empty in tests to disable external chatting server calls by default.
     url: ""
     internal-secret: ""
+    connect-timeout: 100ms
+    read-timeout: 100ms
 
 ai:
   server:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,6 +73,8 @@ chatting:
     # Internal API settings for propagating trade status changes to the chatting server.
     url: ${CHATTING_SERVER_URL:}
     internal-secret: ${CHATTING_SERVER_INTERNAL_SECRET:}
+    connect-timeout: ${CHATTING_CONNECT_TIMEOUT:2s}
+    read-timeout: ${CHATTING_READ_TIMEOUT:5s}
 
 ai:
   server:

--- a/src/test/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImplTest.java
@@ -12,10 +12,13 @@ import team.startup.gwangsan.domain.admin.entity.AdminAlert;
 import team.startup.gwangsan.domain.admin.exception.NotFoundAdminAlertException;
 import team.startup.gwangsan.domain.admin.repository.AdminAlertRepository;
 import team.startup.gwangsan.domain.admin.util.ValidatePlaceUtil;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
 import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
@@ -24,6 +27,7 @@ import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelExce
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCancelException;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.Optional;
@@ -53,6 +57,9 @@ class ApproveTradeCancelServiceImplTest {
 
     @Mock
     private ValidatePlaceUtil validatePlaceUtil;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
@@ -89,6 +96,10 @@ class ApproveTradeCancelServiceImplTest {
 
                 Product product = mock(Product.class);
                 when(product.getGwangsan()).thenReturn(1000);
+                when(product.getId()).thenReturn(7L);
+
+                ChatRoom chatRoom = mock(ChatRoom.class);
+                when(chatRoom.getId()).thenReturn(77L);
 
                 TradeComplete tradeComplete = mock(TradeComplete.class);
                 when(tradeComplete.getProduct()).thenReturn(product);
@@ -107,6 +118,8 @@ class ApproveTradeCancelServiceImplTest {
                         .thenReturn(Optional.of(tradeCancel));
                 when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(buyerDetail));
                 when(memberDetailRepository.findById(3L)).thenReturn(Optional.of(sellerDetail));
+                when(chatRoomRepository.findByProductIdAndBuyerAndSeller(7L, buyer, seller))
+                        .thenReturn(Optional.of(chatRoom));
 
                 service.execute(10L);
 
@@ -114,7 +127,9 @@ class ApproveTradeCancelServiceImplTest {
                 verify(sellerDetail).minusGwangsan(1000);
                 verify(tradeCancel).updateStatus(TradeCancelStatus.APPROVED);
                 verify(tradeComplete).updateStatus(TradeStatus.ROLLED_BACK);
+                verify(product).updateStatus(ProductStatus.ONGOING);
                 verify(applicationEventPublisher).publishEvent(any(CreateAlertEvent.class));
+                verify(applicationEventPublisher).publishEvent(any(TradeStatusChangedEvent.class));
             }
         }
 

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImplTest.java
@@ -116,6 +116,17 @@ class SaveChatMessageServiceImplTest {
         }
 
         @Test
+        @DisplayName("새 메시지가 오면 양쪽 모두에게 숨긴 방을 다시 노출한다")
+        void it_unhides_room_for_both_participants() {
+            arrangeDefaultScenario();
+
+            service.execute(1L, 10L, "안녕하세요", null, MessageType.TEXT, 1L, now);
+
+            verify(chatRoom).unhideFor(sender);
+            verify(chatRoom).unhideFor(otherMember);
+        }
+
+        @Test
         @DisplayName("IMAGE 타입이고 imageIds 가 있으면 이미지를 저장한다")
         void it_saves_images_when_message_type_is_image() {
             arrangeDefaultScenario();

--- a/src/test/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImplTest.java
+++ b/src/test/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImplTest.java
@@ -28,7 +28,7 @@ class ChattingServerTradeStatusNotifierImplTest {
         RestClient.Builder builder = RestClient.builder();
         server = MockRestServiceServer.bindTo(builder).build();
         notifier = new ChattingServerTradeStatusNotifierImpl(
-                new ChattingServerProperties("http://chatting-server", "test-secret"),
+                new ChattingServerProperties("http://chatting-server", "test-secret", null, null),
                 builder
         );
     }


### PR DESCRIPTION
## 💡 배경 및 개요

채팅 실시간 싱크 문제를 추적하면서 발견한 **상태 정확성 결함**들을 고칩니다. 소켓 룸 전달 버그 자체는 채팅 서버에서 별도로 수정했습니다 (School-of-Company/Gwangsan-Chatting-Server#31).

크게 세 갈래입니다.

**1. 나간 방이 새 메시지가 와도 다시 보이지 않음**

`ChatRoom.unhideFor`의 유일한 호출처가 `CreateChatRoomServiceImpl`(방 생성/재진입)이라, `SaveChatMessageServiceImpl`은 이를 호출하지 않았습니다. `findRoomsByMemberId`가 `hiddenByBuyerAt IS NULL`로 필터하므로:

> A가 방을 나감 → B가 메시지 전송 → **A의 `/api/chat/rooms`에 그 방이 아예 없음**

푸시 알림은 가는데 목록에는 방이 없는 상태가 됩니다.

**2. 거래 철회를 승인해도 영구히 "거래 완료"**

`ApproveTradeCancelServiceImpl`이 `TradeStatus.ROLLED_BACK`과 광산 롤백은 하는데 **`Product.status`를 되돌리지 않았습니다.** 채팅방 조회의 `isCompleted`는 `Product.status`에서만 파생되므로(`FindChatMessageByRoomIdServiceImpl`), 철회가 승인돼도 양쪽 사용자 화면이 계속 "거래 완료"로 남았습니다.

**3. 실패가 아무 흔적 없이 사라짐**

- `ChattingServerTradeStatusNotifierImpl`은 `CHATTING_SERVER_URL`이 비어 있으면 **로그 한 줄 없이 no-op**입니다. 배포 환경변수 하나가 빠져도 실시간 갱신이 죽었는지 살았는지 알 수 없었습니다.
- `ChatStreamMessageProcessor`가 매핑 실패 시 **아무 로그 없이** DLQ로 보내고 ACK합니다. 채팅 화면엔 있는데 DB엔 없는 메시지가 생겨도 추적이 불가능했습니다.
- `ChatStreamRedisAdapter.ensureGroupExists`가 **생성에 실패한 경우까지 완료로 표시**해서, 해당 방은 이후 매 사이클 NOGROUP만 내면서 영영 저장되지 않았습니다.

Resolves: #361

## 📃 작업내용

**상태 정확성**
- `SaveChatMessageServiceImpl`: 메시지 저장 시 양쪽 참여자의 방 숨김 해제
- `ApproveTradeCancelServiceImpl`: `product.updateStatus(ONGOING)` 추가 + `TradeStatusChangedEvent` 발행

**실패 가시화**
- `chatting.server.url` 미설정 시 경고 로그
- 채팅 서버 호출에 connect/read 타임아웃 적용 (`ai.server`와 동일한 방식, 기본 2s/5s)
- Redis Stream 매핑 실패/처리 실패 시 로그 추가
- 없는 방·회원 예외는 재시도해도 결과가 같으므로 retry를 건너뛰고 바로 DLQ
- consumer group 생성은 `BUSYGROUP`(이미 존재)일 때만 완료로 표시

**테스트**
- `it_unhides_room_for_both_participants()` 추가
- `ApproveTradeCancelServiceImplTest`에 상품 상태·이벤트 발행 검증 추가

## 🙋‍♂️ 리뷰노트

**철회 요청/회수는 이벤트를 발행하지 않았습니다.** 처음엔 넣으려 했는데, 이 둘은 상품 상태가 바뀌지 않고 현재 페이로드가 `completed`/`reserved` 두 개뿐이라 **이전과 완전히 동일한 값이 전송**됩니다. 클라이언트 화면이 바뀌지 않는 죽은 코드라 뺐습니다. "철회 심사중"을 표현하려면 페이로드 확장이 먼저입니다.

**consumer group 처리에서 두 가지 실패를 구분했습니다.** `BUSYGROUP`은 정상(이미 존재)이라 완료 표시하고, "requires the key to exist"는 아직 스트림이 안 만들어진 경우라 debug 로그만 남기고 다음 사이클에 재시도합니다. 후자를 warn으로 두면 실패가 없어 비어 있는 retry 스트림 때문에 500ms마다 경고가 찍힙니다.

**환경값이 2개 추가됐습니다** — `CHATTING_CONNECT_TIMEOUT`, `CHATTING_READ_TIMEOUT`. 기본값이 있어 배포 시 별도 설정은 불필요합니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (`application.yml`에 타임아웃 2개 추가, 기본값 있음)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요?
- [x] 작업한 코드가 정상적으로 동작하나요? (아래 기타 참고)
- [x] Merge 대상 브랜치가 올바른가요? (`develop`)
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

**배포 순서**: 채팅 서버 PR(School-of-Company/Gwangsan-Chatting-Server#31)을 **먼저** 배포해주세요. 철회 승인 이벤트가 채팅 서버의 새 emit 로직을 전제로 합니다.

**테스트 결과**: 405개 중 404개 통과. 실패하는 `ChatStreamConsumerWorker 통합 테스트`는 로컬 Docker 환경 문제로, **이 브랜치의 변경 없이 develop에서도 동일하게 실패**합니다(단독 실행 시에는 통과). CI 결과를 확인해주세요.

관련: 앱 후속 정리 School-of-Company/Gwangsan-Crossplatform#522
