### PR TITLE
    거래 상태 조회와 이벤트 계약 일관성 개선

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImpl.java
@@ -24,11 +24,12 @@ import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelException;
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCancelException;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -40,6 +41,7 @@ public class ApproveTradeCancelServiceImpl implements ApproveTradeCancelService 
     private final MemberDetailRepository memberDetailRepository;
     private final ValidatePlaceUtil validatePlaceUtil;
     private final ChatRoomRepository chatRoomRepository;
+    private final TradeStateReader tradeStateReader;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
@@ -91,14 +93,20 @@ public class ApproveTradeCancelServiceImpl implements ApproveTradeCancelService 
                 AlertType.TRADE_CANCEL
         ));
 
+        // 철회가 승인되면 대기 중인 요청도 완료된 요청도 남지 않으므로
+        // requestedBySeller 와 requestedAt 이 모두 null 이 된다. 그래야 클라이언트가
+        // 거래 카드를 감추고 재요청 버튼을 다시 열어 준다.
         chatRoomRepository.findByProductIdAndBuyerAndSeller(product.getId(), buyer, seller)
-                .ifPresent(chatRoom -> applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
-                        chatRoom.getId(),
-                        null,
-                        product.getId(),
-                        false,
-                        false,
-                        LocalDateTime.now()
-                )));
+                .ifPresent(chatRoom -> {
+                    TradeStateSnapshot tradeState = tradeStateReader.read(product, buyer, seller);
+                    applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                            chatRoom.getId(),
+                            product.getId(),
+                            tradeState.completed(),
+                            tradeState.reserved(),
+                            tradeState.requestedBySeller(),
+                            tradeState.requestedAt()
+                    ));
+                });
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetChatProductDto.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetChatProductDto.java
@@ -9,6 +9,13 @@ public record GetChatProductDto(
         Long id,
         String title,
         List<GetImageResponse> images,
+        /**
+         * 거래 요청(TradeComplete) 생성 시각. <b>상품 생성 시각이 아니다.</b>
+         *
+         * <p>클라이언트가 이 값으로 거래 카드의 노출 여부와 대화 흐름상 위치를 정한다.
+         * 활성 요청도 완료된 요청도 없으면 null 이며, 거래 상태 변경 이벤트의 같은 이름
+         * 필드와 항상 값이 일치한다.
+         */
         LocalDateTime createdAt,
         boolean isSeller,
         boolean isCompletable,

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImpl.java
@@ -18,13 +18,11 @@ import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResp
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductImage;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
-import team.startup.gwangsan.domain.trade.entity.TradeComplete;
-import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
 import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
-import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
-import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.time.LocalDateTime;
@@ -42,7 +40,7 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
     private final ChatMessageRepository chatMessageRepository;
     private final ChatMessageImageRepository chatMessageImageRepository;
     private final ProductImageRepository productImageRepository;
-    private final TradeCompleteRepository tradeCompleteRepository;
+    private final TradeStateReader tradeStateReader;
     private final ProductReservationRepository productReservationRepository;
 
     @Override
@@ -68,13 +66,10 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
                 .toList();
 
         boolean isSeller = memberId.equals(chatRoom.getSeller().getId());
-        Optional<TradeComplete> pendingTradeComplete = tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
-                product, chatRoom.getBuyer(), chatRoom.getSeller(), TradeStatus.PENDING);
-        boolean isCompleted = product.getStatus() == ProductStatus.COMPLETED;
-        boolean isReserved = product.getStatus() == ProductStatus.RESERVATION;
-        boolean isCompletable = !isCompleted && pendingTradeComplete
-                .map(tc -> tc.isRequestedBySeller() != isSeller)
-                .orElse(true);
+
+        // 거래 상태 변경 이벤트와 같은 값을 쓰기 위해 조회도 이 스냅샷을 거친다.
+        TradeStateSnapshot tradeState = tradeStateReader.read(product, chatRoom.getBuyer(), chatRoom.getSeller());
+        boolean isReserved = tradeState.reserved();
 
         Optional<ProductReservation> reservation = isReserved
                 ? productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING)
@@ -84,10 +79,10 @@ public class FindChatMessageByRoomIdServiceImpl implements FindChatMessageByRoom
                 product.getId(),
                 product.getTitle(),
                 imageResponses,
-                pendingTradeComplete.map(TradeComplete::getCreatedAt).orElse(null),
+                tradeState.requestedAt(),
                 isSeller,
-                isCompletable,
-                isCompleted,
+                tradeState.isCompletableFor(isSeller),
+                tradeState.completed(),
                 isReserved,
                 reservation.map(ProductReservation::getScheduledAt).orElse(null),
                 reservation.map(ProductReservation::getPlaceName).orElse(null),

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImpl.java
@@ -14,10 +14,11 @@ import team.startup.gwangsan.domain.post.exception.ReservationParticipantOnlyExc
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
 import team.startup.gwangsan.domain.post.service.DeleteReservationProductService;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
-import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -27,6 +28,7 @@ public class DeleteReservationProductServiceImpl implements DeleteReservationPro
     private final MemberUtil memberUtil;
     private final ProductReservationRepository productReservationRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final TradeStateReader tradeStateReader;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
@@ -45,13 +47,17 @@ public class DeleteReservationProductServiceImpl implements DeleteReservationPro
         product.updateStatus(ProductStatus.ONGOING);
 
         chatRoomRepository.findByProductIdAndMember(product.getId(), productReservation.getReserver())
-                .ifPresent(chatRoom -> applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
-                        chatRoom.getId(),
-                        null,
-                        product.getId(),
-                        false,
-                        false,
-                        LocalDateTime.now()
-                )));
+                .ifPresent(chatRoom -> {
+                    TradeStateSnapshot tradeState =
+                            tradeStateReader.read(product, chatRoom.getBuyer(), chatRoom.getSeller());
+                    applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                            chatRoom.getId(),
+                            product.getId(),
+                            tradeState.completed(),
+                            tradeState.reserved(),
+                            tradeState.requestedBySeller(),
+                            tradeState.requestedAt()
+                    ));
+                });
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
@@ -39,7 +39,6 @@ import team.startup.gwangsan.global.event.CreateAlertEvent;
 import team.startup.gwangsan.global.event.SendNotificationEvent;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -189,14 +188,15 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
                 product.getId()
         ));
 
-        LocalDateTime changedAt = LocalDateTime.now();
+        // 확정 후에는 대기 중인 요청이 없으므로 requestedBySeller 는 null 이고,
+        // requestedAt 은 방금 완료된 요청의 생성 시각을 유지한다. 조회 응답과 같은 값이다.
         applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
                 chatRoom.getId(),
-                requester.getId(),
                 product.getId(),
                 true,
                 false,
-                changedAt
+                null,
+                pending.getCreatedAt()
         ));
     }
 
@@ -217,14 +217,14 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
                 AlertType.OTHER_MEMBER_TRADE_COMPLETE
         ));
 
-        LocalDateTime changedAt = LocalDateTime.now();
+        // save() 로 @CreatedDate 가 채워지므로 조회 응답이 나중에 줄 값과 동일하다.
         applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
                 chatRoom.getId(),
-                requestTarget.getId(),
                 product.getId(),
                 false,
                 product.getStatus() == ProductStatus.RESERVATION,
-                changedAt
+                newTradeComplete.isRequestedBySeller(),
+                newTradeComplete.getCreatedAt()
         ));
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImpl.java
@@ -19,6 +19,8 @@ import team.startup.gwangsan.domain.post.exception.ProductNotOngoingException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
 import team.startup.gwangsan.domain.post.service.ReservationProductService;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
@@ -32,6 +34,7 @@ public class ReservationProductServiceImpl implements ReservationProductService 
     private final ProductReservationRepository productReservationRepository;
     private final MemberUtil memberUtil;
     private final ChatRoomRepository chatRoomRepository;
+    private final TradeStateReader tradeStateReader;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Override
@@ -80,13 +83,14 @@ public class ReservationProductServiceImpl implements ReservationProductService 
 
         product.updateStatus(ProductStatus.RESERVATION);
 
+        TradeStateSnapshot tradeState = tradeStateReader.read(product, chatRoom.getBuyer(), chatRoom.getSeller());
         applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
                 chatRoom.getId(),
-                null,
                 productId,
-                false,
-                true,
-                LocalDateTime.now()
+                tradeState.completed(),
+                tradeState.reserved(),
+                tradeState.requestedBySeller(),
+                tradeState.requestedAt()
         ));
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/TradeStateReader.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/TradeStateReader.java
@@ -1,0 +1,60 @@
+package team.startup.gwangsan.domain.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * 거래 상태를 읽는 단일 지점.
+ *
+ * <p>채팅방 조회 API와 거래 상태 변경 이벤트 발행부가 모두 이곳을 거치게 해서,
+ * 두 경로가 같은 상태를 다르게 계산하는 일이 구조적으로 생기지 않게 한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class TradeStateReader {
+
+    private final TradeCompleteRepository tradeCompleteRepository;
+
+    public TradeStateSnapshot read(Product product, Member buyer, Member seller) {
+        Optional<TradeComplete> pending = tradeCompleteRepository
+                .findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING);
+
+        return new TradeStateSnapshot(
+                product.getStatus() == ProductStatus.COMPLETED,
+                product.getStatus() == ProductStatus.RESERVATION,
+                // 대기 중인 요청이 있을 때만 값을 갖는다. 롤백된 요청의 값이 새어 나가면
+                // 클라이언트의 isCompletable 계산이 조회 응답과 어긋난다.
+                pending.map(TradeComplete::isRequestedBySeller).orElse(null),
+                resolveRequestedAt(product, buyer, seller, pending)
+        );
+    }
+
+    /**
+     * 거래 카드를 대화 흐름에 배치하고 노출 여부를 정하는 기준 시각.
+     *
+     * <p>대기 중인 요청이 있으면 그 요청 시각, 없으면 완료된 요청의 시각을 쓴다.
+     * 완료 후에도 값이 남아야 거래 카드가 유지되어 완료 표시와 리뷰 작성 진입점이 보인다.
+     *
+     * <p>반대로 철회가 승인된 뒤에는 null 이어야 한다. 값이 남으면 클라이언트가 아직
+     * 거래 요청이 있다고 판단해 재요청 버튼을 잠근다.
+     */
+    private LocalDateTime resolveRequestedAt(Product product, Member buyer, Member seller,
+                                             Optional<TradeComplete> pending) {
+        if (pending.isPresent()) {
+            return pending.get().getCreatedAt();
+        }
+        return tradeCompleteRepository
+                .findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.COMPLETED)
+                .map(TradeComplete::getCreatedAt)
+                .orElse(null);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/TradeStateSnapshot.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/TradeStateSnapshot.java
@@ -1,0 +1,33 @@
+package team.startup.gwangsan.domain.trade.service;
+
+import java.time.LocalDateTime;
+
+/**
+ * 한 채팅방(상품 + 구매자 + 판매자)의 거래 상태 스냅샷.
+ *
+ * <p>채팅방 조회 응답과 거래 상태 변경 이벤트가 <b>같은 값</b>을 쓰도록 하기 위한 타입이다.
+ * 두 경로가 각자 계산하면 같은 상태를 다르게 표현해 클라이언트 화면이 어긋난다.
+ *
+ * <p>여기에는 모든 참여자에게 동일한 사실만 담는다. 보는 사람에 따라 달라지는 값은
+ * {@link #isCompletableFor(boolean)} 처럼 조회 시점에 파생시키고, 방 전체로 발행하지 않는다.
+ */
+public record TradeStateSnapshot(
+        boolean completed,
+        boolean reserved,
+        Boolean requestedBySeller,
+        LocalDateTime requestedAt
+) {
+
+    /**
+     * 이 사람이 거래 완료를 확정할 수 있는지.
+     *
+     * <p>대기 중인 요청을 만든 쪽은 스스로 확정할 수 없으므로 역할이 같으면 false 다.
+     * 대기 중인 요청이 아예 없으면 누구든 새로 요청할 수 있으므로 true 다.
+     *
+     * <p><b>이 값은 viewer 마다 다르므로 이벤트 페이로드에 넣지 않는다.</b> 클라이언트는
+     * {@link #requestedBySeller()} 와 자신의 isSeller 를 조합해 같은 결과를 얻는다.
+     */
+    public boolean isCompletableFor(boolean isSeller) {
+        return !completed && (requestedBySeller == null || requestedBySeller != isSeller);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
@@ -54,22 +54,28 @@ public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTrad
                 .header(INTERNAL_SECRET_HEADER, properties.internalSecret())
                 .body(new TradeStatusChangedRequest(
                         event.roomId(),
-                        event.targetMemberId(),
                         event.productId(),
                         event.completed(),
                         event.reserved(),
-                        event.changedAt()
+                        event.requestedBySeller(),
+                        event.requestedAt()
                 ))
                 .retrieve()
                 .toBodilessEntity();
     }
 
+    /**
+     * 채팅 서버 내부 API 의 요청 스키마.
+     *
+     * <p>필드명은 클라이언트가 읽는 이름을 그대로 따른다. createdAt 은 상품 생성 시각이
+     * 아니라 거래 요청 생성 시각이며, 채팅방 조회 응답의 같은 이름 필드와 값이 일치한다.
+     */
     private record TradeStatusChangedRequest(
             Long roomId,
-            Long targetMemberId,
             Long productId,
             boolean isCompleted,
             boolean isReserved,
+            Boolean requestedBySeller,
             LocalDateTime createdAt
     ) {
     }

--- a/src/main/java/team/startup/gwangsan/global/event/TradeStatusChangedEvent.java
+++ b/src/main/java/team/startup/gwangsan/global/event/TradeStatusChangedEvent.java
@@ -2,12 +2,21 @@ package team.startup.gwangsan.global.event;
 
 import java.time.LocalDateTime;
 
+/**
+ * 거래 상태가 바뀌어 채팅 서버가 양쪽 참여자 화면을 갱신해야 함을 알린다.
+ *
+ * <p>여기 담기는 값은 모든 참여자에게 동일한 사실이어야 한다. isCompletable 처럼
+ * 보는 사람의 isSeller 에 따라 달라지는 값은 방 전체로 발행할 수 없으므로,
+ * 대신 {@code requestedBySeller} 를 보내고 클라이언트가 자신의 isSeller 와 조합해 계산한다.
+ */
 public record TradeStatusChangedEvent(
         Long roomId,
-        Long targetMemberId,
         Long productId,
         boolean completed,
         boolean reserved,
-        LocalDateTime changedAt
+        /** 완료 요청을 먼저 한 쪽이 판매자인지. 대기 중인 요청이 없으면 null. */
+        Boolean requestedBySeller,
+        /** 거래 요청 생성 시각. 활성 요청도 완료된 요청도 없으면 null. */
+        LocalDateTime requestedAt
 ) {
 }

--- a/src/test/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImplTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -26,12 +27,16 @@ import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelException;
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCancelException;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -60,6 +65,9 @@ class ApproveTradeCancelServiceImplTest {
 
     @Mock
     private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private TradeStateReader tradeStateReader;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
@@ -120,6 +128,9 @@ class ApproveTradeCancelServiceImplTest {
                 when(memberDetailRepository.findById(3L)).thenReturn(Optional.of(sellerDetail));
                 when(chatRoomRepository.findByProductIdAndBuyerAndSeller(7L, buyer, seller))
                         .thenReturn(Optional.of(chatRoom));
+                // 철회 승인 후에는 대기 중인 요청도 완료된 요청도 남지 않는다.
+                when(tradeStateReader.read(product, buyer, seller))
+                        .thenReturn(new TradeStateSnapshot(false, false, null, null));
 
                 service.execute(10L);
 
@@ -129,7 +140,15 @@ class ApproveTradeCancelServiceImplTest {
                 verify(tradeComplete).updateStatus(TradeStatus.ROLLED_BACK);
                 verify(product).updateStatus(ProductStatus.ONGOING);
                 verify(applicationEventPublisher).publishEvent(any(CreateAlertEvent.class));
-                verify(applicationEventPublisher).publishEvent(any(TradeStatusChangedEvent.class));
+                ArgumentCaptor<TradeStatusChangedEvent> tradeEventCaptor =
+                        ArgumentCaptor.forClass(TradeStatusChangedEvent.class);
+                verify(applicationEventPublisher).publishEvent(tradeEventCaptor.capture());
+                TradeStatusChangedEvent tradeEvent = tradeEventCaptor.getValue();
+                assertFalse(tradeEvent.completed());
+                assertFalse(tradeEvent.reserved());
+                // 값이 남으면 클라이언트가 아직 거래 요청이 있다고 보고 재요청 버튼을 잠근다.
+                assertNull(tradeEvent.requestedBySeller());
+                assertNull(tradeEvent.requestedAt());
             }
         }
 

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindChatMessageByRoomIdServiceImplTest.java
@@ -21,13 +21,11 @@ import team.startup.gwangsan.domain.image.entity.Image;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
-import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
 import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
-import team.startup.gwangsan.domain.trade.entity.TradeComplete;
-import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
-import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.time.LocalDateTime;
@@ -43,12 +41,14 @@ import static org.mockito.Mockito.*;
 @DisplayName("FindChatMessageByRoomIdServiceImpl 단위 테스트")
 class FindChatMessageByRoomIdServiceImplTest {
 
+    private static final LocalDateTime TRADE_REQUESTED_AT = LocalDateTime.of(2026, 8, 30, 11, 20);
+
     @Mock private ChatRoomRepository chatRoomRepository;
     @Mock private MemberUtil memberUtil;
     @Mock private ChatMessageRepository chatMessageRepository;
     @Mock private ChatMessageImageRepository chatMessageImageRepository;
     @Mock private ProductImageRepository productImageRepository;
-    @Mock private TradeCompleteRepository tradeCompleteRepository;
+    @Mock private TradeStateReader tradeStateReader;
     @Mock private ProductReservationRepository productReservationRepository;
 
     @InjectMocks
@@ -82,11 +82,9 @@ class FindChatMessageByRoomIdServiceImplTest {
             when(chatRoom.getProduct()).thenReturn(product);
             when(product.getId()).thenReturn(10L);
             when(product.getTitle()).thenReturn("상품명");
-            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
             when(chatRoomRepository.findByRoomIdWithSellerAndProduct(5L)).thenReturn(Optional.of(chatRoom));
             when(productImageRepository.findAllByProductId(10L)).thenReturn(List.of());
-            lenient().when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(any(), any(), any(), eq(TradeStatus.PENDING)))
-                    .thenReturn(Optional.empty());
+            givenTradeState(false, false, null);
         }
 
         // buyer == currentMember 인 happy path 공통 설정
@@ -96,11 +94,15 @@ class FindChatMessageByRoomIdServiceImplTest {
             when(chatRoom.getProduct()).thenReturn(product);
             when(product.getId()).thenReturn(10L);
             when(product.getTitle()).thenReturn("상품명");
-            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
             when(chatRoomRepository.findByRoomIdWithSellerAndProduct(5L)).thenReturn(Optional.of(chatRoom));
             when(productImageRepository.findAllByProductId(10L)).thenReturn(List.of());
-            lenient().when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(any(), any(), any(), eq(TradeStatus.PENDING)))
-                    .thenReturn(Optional.empty());
+            givenTradeState(false, false, null);
+        }
+
+        /** 거래 상태 스냅샷을 지정한다. isCompletable 은 실제 record 로직으로 계산된다. */
+        private void givenTradeState(boolean completed, boolean reserved, Boolean requestedBySeller) {
+            lenient().when(tradeStateReader.read(any(), any(), any()))
+                    .thenReturn(new TradeStateSnapshot(completed, reserved, requestedBySeller, TRADE_REQUESTED_AT));
         }
 
         private void arrangeEmptyMessages() {
@@ -235,10 +237,7 @@ class FindChatMessageByRoomIdServiceImplTest {
         void it_sets_isCompletable_false_when_seller_already_requested() {
             arrangeRoomAsSellerView();
             arrangeEmptyMessages();
-            TradeComplete tradeComplete = mock(TradeComplete.class);
-            when(tradeComplete.isRequestedBySeller()).thenReturn(true);
-            when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(any(), any(), any(), eq(TradeStatus.PENDING)))
-                    .thenReturn(Optional.of(tradeComplete));
+            givenTradeState(false, false, true);
 
             GetChatMessagesResponse response = service.execute(5L, null, null, 20);
 
@@ -261,10 +260,7 @@ class FindChatMessageByRoomIdServiceImplTest {
         void it_sets_isCompletable_true_when_buyer_and_seller_requested() {
             arrangeRoomAsBuyerView();
             arrangeEmptyMessages();
-            TradeComplete tradeComplete = mock(TradeComplete.class);
-            when(tradeComplete.isRequestedBySeller()).thenReturn(true);
-            when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(any(), any(), any(), eq(TradeStatus.PENDING)))
-                    .thenReturn(Optional.of(tradeComplete));
+            givenTradeState(false, false, true);
 
             GetChatMessagesResponse response = service.execute(5L, null, null, 20);
 
@@ -276,10 +272,7 @@ class FindChatMessageByRoomIdServiceImplTest {
         void it_sets_isCompletable_false_when_buyer_already_requested() {
             arrangeRoomAsBuyerView();
             arrangeEmptyMessages();
-            TradeComplete tradeComplete = mock(TradeComplete.class);
-            when(tradeComplete.isRequestedBySeller()).thenReturn(false);
-            when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(any(), any(), any(), eq(TradeStatus.PENDING)))
-                    .thenReturn(Optional.of(tradeComplete));
+            givenTradeState(false, false, false);
 
             GetChatMessagesResponse response = service.execute(5L, null, null, 20);
 
@@ -291,7 +284,7 @@ class FindChatMessageByRoomIdServiceImplTest {
         void it_sets_isCompletable_false_when_product_already_completed() {
             arrangeRoomAsSellerView();
             arrangeEmptyMessages();
-            when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
+            givenTradeState(true, false, null);
 
             GetChatMessagesResponse response = service.execute(5L, null, null, 20);
 
@@ -300,11 +293,52 @@ class FindChatMessageByRoomIdServiceImplTest {
         }
 
         @Test
+        @DisplayName("거래 요청 시각을 그대로 응답의 createdAt 으로 내려준다")
+        void it_returns_trade_requested_at_as_created_at() {
+            arrangeRoomAsSellerView();
+            arrangeEmptyMessages();
+            givenTradeState(false, false, true);
+
+            GetChatMessagesResponse response = service.execute(5L, null, null, 20);
+
+            // 상품 생성 시각이 아니라 거래 요청 시각이며, 거래 상태 변경 이벤트와 같은 값이다.
+            assertThat(response.product().createdAt()).isEqualTo(TRADE_REQUESTED_AT);
+        }
+
+        @Test
+        @DisplayName("거래가 완료된 뒤에도 createdAt 이 남아 거래 카드가 유지된다")
+        void it_keeps_created_at_after_trade_completion() {
+            arrangeRoomAsSellerView();
+            arrangeEmptyMessages();
+            givenTradeState(true, false, null);
+
+            GetChatMessagesResponse response = service.execute(5L, null, null, 20);
+
+            // null 이 되면 클라이언트가 거래 카드를 숨겨 완료 표시와 리뷰 작성 진입점이 사라진다.
+            assertThat(response.product().createdAt()).isEqualTo(TRADE_REQUESTED_AT);
+            assertThat(response.product().isCompleted()).isTrue();
+        }
+
+        @Test
+        @DisplayName("철회가 승인되면 createdAt 이 null 이 되어 다시 거래를 요청할 수 있다")
+        void it_clears_created_at_after_rollback() {
+            arrangeRoomAsSellerView();
+            arrangeEmptyMessages();
+            lenient().when(tradeStateReader.read(any(), any(), any()))
+                    .thenReturn(new TradeStateSnapshot(false, false, null, null));
+
+            GetChatMessagesResponse response = service.execute(5L, null, null, 20);
+
+            assertThat(response.product().createdAt()).isNull();
+            assertThat(response.product().isCompletable()).isTrue();
+        }
+
+        @Test
         @DisplayName("상품이 예약 상태이면 isReserved 가 true 이다")
         void it_sets_isReserved_true_when_product_is_reserved() {
             arrangeRoomAsSellerView();
             arrangeEmptyMessages();
-            when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
+            givenTradeState(false, true, null);
             when(productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING))
                     .thenReturn(Optional.empty());
 
@@ -318,7 +352,7 @@ class FindChatMessageByRoomIdServiceImplTest {
         void it_returns_reservation_schedule_and_place_when_reserved() {
             arrangeRoomAsSellerView();
             arrangeEmptyMessages();
-            when(product.getStatus()).thenReturn(ProductStatus.RESERVATION);
+            givenTradeState(false, true, null);
 
             ProductReservation reservation = mock(ProductReservation.class);
             LocalDateTime scheduledAt = LocalDateTime.of(2026, 9, 1, 14, 0);

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImplTest.java
@@ -19,6 +19,8 @@ import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
 import team.startup.gwangsan.domain.post.exception.ReservationParticipantOnlyException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
@@ -46,6 +48,10 @@ class DeleteReservationProductServiceImplTest {
 
     @Mock
     private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+
+    private TradeStateReader tradeStateReader;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
@@ -84,6 +90,8 @@ class DeleteReservationProductServiceImplTest {
                     .thenReturn(Optional.of(chatRoom));
 
             // when & then
+            when(tradeStateReader.read(any(), any(), any()))
+                    .thenReturn(new TradeStateSnapshot(false, false, null, null));
             assertDoesNotThrow(() -> service.execute(productId));
 
             verify(memberUtil).getCurrentMember();
@@ -99,10 +107,11 @@ class DeleteReservationProductServiceImplTest {
             verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
             TradeStatusChangedEvent event = (TradeStatusChangedEvent) eventCaptor.getValue();
             assertEquals(10L, event.roomId());
-            assertNull(event.targetMemberId());
             assertEquals(productId, event.productId());
             assertFalse(event.completed());
             assertFalse(event.reserved());
+            assertNull(event.requestedBySeller());
+            assertNull(event.requestedAt());
 
             verifyNoInteractions(productRepository);
         }

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImplTest.java
@@ -36,12 +36,14 @@ import team.startup.gwangsan.domain.trade.exception.*;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
@@ -49,6 +51,8 @@ import static org.mockito.Mockito.*;
 @MockitoSettings(strictness = Strictness.LENIENT)
 @DisplayName("RequestTradeCompleteServiceImpl 단위 테스트")
 class RequestTradeCompleteServiceImplTest {
+
+    private static final LocalDateTime TRADE_REQUESTED_AT = LocalDateTime.of(2026, 8, 30, 11, 20);
 
     @Mock
     private ProductRepository productRepository;
@@ -333,6 +337,7 @@ class RequestTradeCompleteServiceImplTest {
             // 판매자가 먼저 요청을 보낸 상태(requestedBySeller = true)
             TradeComplete pending = mock(TradeComplete.class);
             when(pending.isRequestedBySeller()).thenReturn(true);
+            when(pending.getCreatedAt()).thenReturn(TRADE_REQUESTED_AT);
             when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
                     product,
                     buyerMember,
@@ -353,7 +358,7 @@ class RequestTradeCompleteServiceImplTest {
             verify(pending).updateStatus(TradeStatus.COMPLETED);
             verify(pending).updateCompletedAt();
             verify(reservation).complete();
-            verifyTradeStatusChangedEvent(roomId, sellerId, productId, true, false);
+            verifyTradeStatusChangedEvent(roomId, null, productId, true, false);
         }
 
         @Test
@@ -405,6 +410,9 @@ class RequestTradeCompleteServiceImplTest {
 
             TradeComplete newTradeComplete = mock(TradeComplete.class);
             when(newTradeComplete.getId()).thenReturn(999L);
+            // 이벤트가 조회 응답과 같은 값을 싣는지 확인하기 위한 스텁
+            when(newTradeComplete.isRequestedBySeller()).thenReturn(true);
+            when(newTradeComplete.getCreatedAt()).thenReturn(TRADE_REQUESTED_AT);
 
             when(tradeCompleteRepository.save(any(TradeComplete.class)))
                     .thenReturn(newTradeComplete);
@@ -416,7 +424,7 @@ class RequestTradeCompleteServiceImplTest {
             ArgumentCaptor<TradeComplete> savedCaptor = ArgumentCaptor.forClass(TradeComplete.class);
             verify(tradeCompleteRepository).save(savedCaptor.capture());
             assertTrue(savedCaptor.getValue().isRequestedBySeller());
-            verifyTradeStatusChangedEvent(roomId, buyerId, productId, false, false);
+            verifyTradeStatusChangedEvent(roomId, true, productId, false, false);
         }
 
         @Test
@@ -470,6 +478,8 @@ class RequestTradeCompleteServiceImplTest {
 
             TradeComplete newTradeComplete = mock(TradeComplete.class);
             when(newTradeComplete.getId()).thenReturn(998L);
+            when(newTradeComplete.isRequestedBySeller()).thenReturn(false);
+            when(newTradeComplete.getCreatedAt()).thenReturn(TRADE_REQUESTED_AT);
 
             when(tradeCompleteRepository.save(any(TradeComplete.class)))
                     .thenReturn(newTradeComplete);
@@ -481,7 +491,7 @@ class RequestTradeCompleteServiceImplTest {
             ArgumentCaptor<TradeComplete> savedCaptor = ArgumentCaptor.forClass(TradeComplete.class);
             verify(tradeCompleteRepository).save(savedCaptor.capture());
             assertTrue(!savedCaptor.getValue().isRequestedBySeller());
-            verifyTradeStatusChangedEvent(roomId, sellerId, productId, false, false);
+            verifyTradeStatusChangedEvent(roomId, false, productId, false, false);
         }
 
         @Test
@@ -526,6 +536,7 @@ class RequestTradeCompleteServiceImplTest {
             // 판매자 본인이 이미 요청을 보낸 상태(requestedBySeller = true)에서 판매자가 다시 호출
             TradeComplete pending = mock(TradeComplete.class);
             when(pending.isRequestedBySeller()).thenReturn(true);
+            when(pending.getCreatedAt()).thenReturn(TRADE_REQUESTED_AT);
             when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
                     product,
                     buyerMember,
@@ -589,6 +600,7 @@ class RequestTradeCompleteServiceImplTest {
 
             TradeComplete pending = mock(TradeComplete.class);
             when(pending.isRequestedBySeller()).thenReturn(true);
+            when(pending.getCreatedAt()).thenReturn(TRADE_REQUESTED_AT);
             when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
                     product,
                     buyerMember,
@@ -609,13 +621,17 @@ class RequestTradeCompleteServiceImplTest {
             verify(pending).updateStatus(TradeStatus.COMPLETED);
             verify(pending).updateCompletedAt();
             verifyNoInteractions(productReservationRepository);
-            verifyTradeStatusChangedEvent(roomId, sellerId, productId, true, false);
+            verifyTradeStatusChangedEvent(roomId, null, productId, true, false);
         }
     }
 
+    /**
+     * @param requestedBySeller 대기 중인 요청을 만든 쪽이 판매자인지. 확정 직후처럼
+     *                          대기 중인 요청이 없으면 null 이어야 한다.
+     */
     private void verifyTradeStatusChangedEvent(
             Long roomId,
-            Long targetMemberId,
+            Boolean requestedBySeller,
             Long productId,
             boolean completed,
             boolean reserved
@@ -630,10 +646,11 @@ class RequestTradeCompleteServiceImplTest {
                 .orElseThrow();
 
         assertEquals(roomId, event.roomId());
-        assertEquals(targetMemberId, event.targetMemberId());
+        assertEquals(requestedBySeller, event.requestedBySeller());
         assertEquals(productId, event.productId());
         assertEquals(completed, event.completed());
         assertEquals(reserved, event.reserved());
-        assertTrue(event.changedAt() != null);
+        // 조회 응답과 같은 값이어야 하므로 거래 요청 시각이 실려 있어야 한다.
+        assertNotNull(event.requestedAt());
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/ReservationProductServiceImplTest.java
@@ -22,6 +22,8 @@ import team.startup.gwangsan.domain.post.exception.ProductAlreadyReservationExce
 import team.startup.gwangsan.domain.post.exception.ProductNotOngoingException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
 import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
@@ -51,6 +53,10 @@ class ReservationProductServiceImplTest {
 
     @Mock
     private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+
+    private TradeStateReader tradeStateReader;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
@@ -222,6 +228,8 @@ class ReservationProductServiceImplTest {
             when(chatRoomRepository.findChatRoomByRoomId(ROOM_ID)).thenReturn(Optional.of(chatRoom));
 
             // when
+            when(tradeStateReader.read(any(), any(), any()))
+                    .thenReturn(new TradeStateSnapshot(false, true, null, null));
             assertDoesNotThrow(() -> service.execute(productId, ROOM_ID, SCHEDULED_AT, PLACE_NAME, ADDRESS, LATITUDE, LONGITUDE));
 
             // then
@@ -232,10 +240,12 @@ class ReservationProductServiceImplTest {
             verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
             TradeStatusChangedEvent event = (TradeStatusChangedEvent) eventCaptor.getValue();
             assertEquals(10L, event.roomId());
-            assertNull(event.targetMemberId());
             assertEquals(productId, event.productId());
             assertFalse(event.completed());
             assertTrue(event.reserved());
+            // 대기 중인 거래 요청이 없으므로 방 전체에 보내는 사실도 비어 있어야 한다.
+            assertNull(event.requestedBySeller());
+            assertNull(event.requestedAt());
         }
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/TradeStateReaderTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/TradeStateReaderTest.java
@@ -1,0 +1,236 @@
+package team.startup.gwangsan.domain.trade.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 채팅방 조회 응답과 거래 상태 변경 이벤트가 같은 값을 쓰는지 고정하는 테스트.
+ *
+ * <p>거래 수명주기의 각 상태에서 방 전체로 보내도 되는 사실(completed / reserved /
+ * requestedBySeller / requestedAt)과 보는 사람마다 달라지는 파생값(isCompletable)을
+ * 구분해 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeStateReader 단위 테스트")
+class TradeStateReaderTest {
+
+    private static final LocalDateTime REQUESTED_AT = LocalDateTime.of(2026, 8, 30, 11, 20);
+
+    @Mock
+    private TradeCompleteRepository tradeCompleteRepository;
+
+    @InjectMocks
+    private TradeStateReader tradeStateReader;
+
+    private final Product product = mock(Product.class);
+    private final Member buyer = mock(Member.class);
+    private final Member seller = mock(Member.class);
+
+    private void givenProductStatus(ProductStatus status) {
+        when(product.getStatus()).thenReturn(status);
+    }
+
+    private void givenNoTradeComplete() {
+        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING))
+                .thenReturn(Optional.empty());
+        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.COMPLETED))
+                .thenReturn(Optional.empty());
+    }
+
+    private void givenPendingRequest(boolean requestedBySeller) {
+        TradeComplete pending = mock(TradeComplete.class);
+        when(pending.isRequestedBySeller()).thenReturn(requestedBySeller);
+        when(pending.getCreatedAt()).thenReturn(REQUESTED_AT);
+        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING))
+                .thenReturn(Optional.of(pending));
+    }
+
+    private void givenCompletedRequestOnly() {
+        TradeComplete completed = mock(TradeComplete.class);
+        when(completed.getCreatedAt()).thenReturn(REQUESTED_AT);
+        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING))
+                .thenReturn(Optional.empty());
+        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.COMPLETED))
+                .thenReturn(Optional.of(completed));
+    }
+
+    private TradeStateSnapshot read() {
+        return tradeStateReader.read(product, buyer, seller);
+    }
+
+    @Nested
+    @DisplayName("read() 메서드는")
+    class Describe_read {
+
+        @Test
+        @DisplayName("거래 요청이 없으면 양쪽 모두 거래를 요청할 수 있다")
+        void it_allows_both_parties_when_no_request_exists() {
+            givenProductStatus(ProductStatus.ONGOING);
+            givenNoTradeComplete();
+
+            TradeStateSnapshot snapshot = read();
+
+            assertFalse(snapshot.completed());
+            assertFalse(snapshot.reserved());
+            assertNull(snapshot.requestedBySeller());
+            assertNull(snapshot.requestedAt());
+            assertTrue(snapshot.isCompletableFor(true));
+            assertTrue(snapshot.isCompletableFor(false));
+        }
+
+        @Test
+        @DisplayName("판매자가 완료를 요청하면 판매자 본인은 확정할 수 없고 구매자는 확정할 수 있다")
+        void it_blocks_seller_when_seller_requested() {
+            givenProductStatus(ProductStatus.ONGOING);
+            givenPendingRequest(true);
+
+            TradeStateSnapshot snapshot = read();
+
+            assertFalse(snapshot.completed());
+            assertEquals(Boolean.TRUE, snapshot.requestedBySeller());
+            assertEquals(REQUESTED_AT, snapshot.requestedAt());
+            assertFalse(snapshot.isCompletableFor(true));
+            assertTrue(snapshot.isCompletableFor(false));
+        }
+
+        @Test
+        @DisplayName("구매자가 완료를 요청하면 구매자 본인은 확정할 수 없고 판매자는 확정할 수 있다")
+        void it_blocks_buyer_when_buyer_requested() {
+            givenProductStatus(ProductStatus.ONGOING);
+            givenPendingRequest(false);
+
+            TradeStateSnapshot snapshot = read();
+
+            assertFalse(snapshot.completed());
+            assertEquals(Boolean.FALSE, snapshot.requestedBySeller());
+            assertEquals(REQUESTED_AT, snapshot.requestedAt());
+            assertTrue(snapshot.isCompletableFor(true));
+            assertFalse(snapshot.isCompletableFor(false));
+        }
+
+        @Test
+        @DisplayName("거래가 완료되면 양쪽 모두 확정할 수 없고 거래 요청 시각은 남는다")
+        void it_keeps_requested_at_after_completion() {
+            givenProductStatus(ProductStatus.COMPLETED);
+            givenCompletedRequestOnly();
+
+            TradeStateSnapshot snapshot = read();
+
+            assertTrue(snapshot.completed());
+            assertFalse(snapshot.reserved());
+            assertNull(snapshot.requestedBySeller());
+            // 값이 남아야 거래 카드가 유지되어 완료 표시와 리뷰 작성 진입점이 보인다.
+            assertEquals(REQUESTED_AT, snapshot.requestedAt());
+            assertFalse(snapshot.isCompletableFor(true));
+            assertFalse(snapshot.isCompletableFor(false));
+        }
+
+        @Test
+        @DisplayName("철회가 승인되면 거래 요청 흔적이 남지 않아 양쪽 모두 다시 요청할 수 있다")
+        void it_clears_state_after_rollback() {
+            // 철회 승인 후 TradeComplete 는 ROLLED_BACK 으로 남고 상품은 다시 거래 가능해진다.
+            // ROLLED_BACK 행의 requestedBySeller 가 새어 나가면 판매자 화면의 isCompletable 이
+            // 조회 응답과 어긋나므로, PENDING/COMPLETED 가 아닌 상태는 조회되지 않아야 한다.
+            givenProductStatus(ProductStatus.ONGOING);
+            givenNoTradeComplete();
+
+            TradeStateSnapshot snapshot = read();
+
+            assertFalse(snapshot.completed());
+            assertNull(snapshot.requestedBySeller());
+            assertNull(snapshot.requestedAt());
+            assertTrue(snapshot.isCompletableFor(true));
+            assertTrue(snapshot.isCompletableFor(false));
+        }
+
+        @Test
+        @DisplayName("예약 상태에서 대기 중인 요청이 없으면 예약만 표시되고 양쪽 모두 요청할 수 있다")
+        void it_marks_reserved_without_pending_request() {
+            givenProductStatus(ProductStatus.RESERVATION);
+            givenNoTradeComplete();
+
+            TradeStateSnapshot snapshot = read();
+
+            assertFalse(snapshot.completed());
+            assertTrue(snapshot.reserved());
+            assertNull(snapshot.requestedBySeller());
+            assertTrue(snapshot.isCompletableFor(true));
+            assertTrue(snapshot.isCompletableFor(false));
+        }
+
+        @Test
+        @DisplayName("예약 상태에서 대기 중인 요청이 있으면 예약과 요청 상태를 함께 표시한다")
+        void it_marks_reserved_with_pending_request() {
+            givenProductStatus(ProductStatus.RESERVATION);
+            givenPendingRequest(true);
+
+            TradeStateSnapshot snapshot = read();
+
+            assertFalse(snapshot.completed());
+            assertTrue(snapshot.reserved());
+            assertEquals(Boolean.TRUE, snapshot.requestedBySeller());
+            assertEquals(REQUESTED_AT, snapshot.requestedAt());
+            assertFalse(snapshot.isCompletableFor(true));
+            assertTrue(snapshot.isCompletableFor(false));
+        }
+    }
+
+    @Nested
+    @DisplayName("isCompletableFor() 는")
+    class Describe_isCompletableFor {
+
+        @Test
+        @DisplayName("거래가 완료되면 대기 중인 요청 정보와 무관하게 항상 false 다")
+        void it_returns_false_when_completed_regardless_of_request() {
+            TradeStateSnapshot completedWithRequester =
+                    new TradeStateSnapshot(true, false, true, REQUESTED_AT);
+
+            assertFalse(completedWithRequester.isCompletableFor(true));
+            assertFalse(completedWithRequester.isCompletableFor(false));
+        }
+
+        @Test
+        @DisplayName("클라이언트가 requestedBySeller 와 isSeller 로 같은 결과를 계산할 수 있다")
+        void it_matches_client_side_formula() {
+            // 클라이언트 공식:
+            //   isCompletable = !isCompleted && (requestedBySeller == null || requestedBySeller !== isSeller)
+            for (Boolean requestedBySeller : new Boolean[]{null, Boolean.TRUE, Boolean.FALSE}) {
+                for (boolean completed : new boolean[]{true, false}) {
+                    for (boolean isSeller : new boolean[]{true, false}) {
+                        TradeStateSnapshot snapshot =
+                                new TradeStateSnapshot(completed, false, requestedBySeller, REQUESTED_AT);
+
+                        boolean clientSide = !completed
+                                && (requestedBySeller == null || requestedBySeller != isSeller);
+
+                        assertEquals(clientSide, snapshot.isCompletableFor(isSeller),
+                                "completed=" + completed
+                                        + ", requestedBySeller=" + requestedBySeller
+                                        + ", isSeller=" + isSeller);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImplTest.java
+++ b/src/test/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImplTest.java
@@ -40,17 +40,21 @@ class ChattingServerTradeStatusNotifierImplTest {
                 .andExpect(method(HttpMethod.POST))
                 .andExpect(header("x-internal-secret", "test-secret"))
                 .andExpect(jsonPath("$.roomId").value(1))
-                .andExpect(jsonPath("$.targetMemberId").value(2))
                 .andExpect(jsonPath("$.productId").value(3))
                 .andExpect(jsonPath("$.isCompleted").value(false))
                 .andExpect(jsonPath("$.isReserved").value(true))
+                // isCompletable 은 보는 사람마다 달라 방 전체로 보낼 수 없으므로,
+                // 클라이언트가 계산할 근거인 requestedBySeller 를 대신 싣는다.
+                .andExpect(jsonPath("$.requestedBySeller").value(true))
+                .andExpect(jsonPath("$.createdAt").exists())
+                .andExpect(jsonPath("$.targetMemberId").doesNotExist())
                 .andRespond(withSuccess());
 
         notifier.notifyTradeStatusChanged(new TradeStatusChangedEvent(
                 1L,
-                2L,
                 3L,
                 false,
+                true,
                 true,
                 LocalDateTime.of(2026, 8, 24, 13, 15)
         ));

--- a/src/test/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListenerTest.java
+++ b/src/test/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListenerTest.java
@@ -20,7 +20,7 @@ class TradeStatusChangedEventListenerTest {
     void it_does_not_propagate_exception_when_chatting_server_notification_fails() {
         ChattingServerTradeStatusNotifier notifier = mock(ChattingServerTradeStatusNotifier.class);
         TradeStatusChangedEventListener listener = new TradeStatusChangedEventListener(notifier);
-        TradeStatusChangedEvent event = new TradeStatusChangedEvent(1L, 2L, 10L, false, false, LocalDateTime.now());
+        TradeStatusChangedEvent event = new TradeStatusChangedEvent(1L, 10L, false, false, null, LocalDateTime.now());
 
         doThrow(new RuntimeException("chatting server unavailable"))
                 .when(notifier)


### PR DESCRIPTION
## 💡 배경 및 개요

채팅방 조회 API 와 거래 상태 변경 이벤트가 **같은 거래 상태를 각자 계산**하고 있어, 같은 거래를 서로 다르게 표현하고 있었습니다. 클라이언트는 두 값을 하나의 캐시에 섞어 쓰므로 WebSocket 갱신 직후와 REST 재조회 후의 화면이 어긋납니다.

구체적으로 두 가지가 갈라져 있었습니다.

| | 조회 API (`FindChatMessageByRoomIdServiceImpl`) | 이벤트 (`RequestTradeCompleteServiceImpl` 외 4곳) |
|---|---|---|
| `createdAt` | `pendingTradeComplete.map(TradeComplete::getCreatedAt)` | `LocalDateTime.now()` — **발행 시각** |
| `isCompletable` | `!isCompleted && (tc.isRequestedBySeller() != isSeller)` | **전송하지 않음** |

`createdAt` 은 같은 거래인데 값이 다르고, `isCompletable` 은 클라이언트가 추측할 수밖에 없어 한 번 `false` 가 되면 폴링 전까지 복구되지 않았습니다.

Related: School-of-Company/Gwangsan-Chatting-Server#32 (선행 배포), School-of-Company/Gwangsan-Crossplatform#532 (후속)

## 📃 작업내용

### 거래 상태를 읽는 단일 지점 추가

`domain/trade/service/TradeStateReader` + `TradeStateSnapshot` 을 추가해, 조회 API 와 이벤트 발행 5곳이 **모두 같은 코드를 거치게** 했습니다. 두 경로가 갈리는 일이 구조적으로 생기지 않습니다.

기존 `findByProductAndBuyerAndSellerAndStatus` 를 재사용하므로 새 리포지토리 메서드는 없습니다.

### 이벤트 페이로드 정리

- `changedAt` → `requestedAt`. 조회 API 와 같은 출처(`TradeComplete.createdAt`)를 씁니다. 거래 요청 시점에는 `save()` 로 `@CreatedDate` 가 채워진 값을 그대로 실어, 조회가 나중에 줄 값과 일치시킵니다.
- `requestedBySeller` 추가
- `targetMemberId` 제거 — 채팅 서버가 이미 무시하고 있고 호출처마다 의미가 달라 혼란만 남았습니다

### 테스트

- `TradeStateReaderTest` 신규 (9건) — 거래 수명주기 7개 상태 × `isCompletableFor(true/false)`
- 기존 6개 테스트 파일을 새 계약에 맞춰 수정

## 🙋‍♂️ 리뷰노트

### `isCompletable` 을 이벤트에 넣지 않은 이유

계산식이 보는 사람의 `isSeller` 에 의존합니다.

```java
isCompletable = !isCompleted && (tc.isRequestedBySeller() != isSeller)
```

하나의 값을 방 전체에 발행하면 참여자 중 한쪽은 반드시 틀립니다. 그래서 `TradeStateSnapshot` 에서도 필드가 아니라 `isCompletableFor(isSeller)` 파생으로 두고, 이벤트에는 모든 참여자에게 동일한 사실인 `requestedBySeller` 만 싣습니다. 클라이언트는 자신의 `isSeller` 와 조합해 같은 결과를 얻습니다.

```
isCompletable = !isCompleted && (requestedBySeller == null || requestedBySeller !== isSeller)
```

### `requestedBySeller` 가 3-상태인 이유

조회 API 의 `.orElse(true)` 가 핵심입니다 — 대기 중인 요청이 없으면 누구나 요청할 수 있으므로 `isCompletable = true` 입니다. 따라서 `requestedBySeller` 는 **PENDING 행이 있을 때만 값을 갖고 그 외에는 `null`** 이어야 합니다.

특히 **철회 승인 후가 결정적**입니다. `TradeComplete` 행이 `ROLLED_BACK` 으로 남아 있는데 그 행의 값을 그대로 보내면 판매자의 클라이언트 계산이 조회 응답과 어긋납니다. `TradeStateReader` 가 `PENDING` 만 조회하도록 해서 이 조건을 한 곳에서 보장하고, 테스트로 고정했습니다.

### ⚠️ `createdAt` 동작 변경 — 제품 확인 부탁드립니다

지금은 `PENDING` 요청만 조회하므로 **거래 확정 후 `null`** 이 됩니다. 그런데 클라이언트는 이 값으로 거래 카드 노출을 결정합니다.

앱 `ChatRoomPage` 에는 리뷰 진입점이 두 개이고 서로 다른 동작입니다.
- 상단 배너: "받은 후기 **보기**"
- 거래 카드: "리뷰 **작성**하기" (`showReviewButton={isTradeCompleted}` → `TradeEmbed` → `ReviewsModal`)

**작성 경로는 거래 카드에만 연결**되어 있어, `createdAt` 이 `null` 이면 카드가 렌더되지 않아 채팅방 내 유일한 리뷰 작성 경로가 닫힙니다.

그래서 `PENDING` 이 없으면 `COMPLETED` 요청의 시각을 쓰도록 바꿨습니다.

| 상태 | `createdAt` | 거래 카드 | "거래요청" 버튼 |
|---|---|---|---|
| 요청 없음 | `null` | 숨김 | 활성 |
| `PENDING` | 값 | 표시 | 비활성 |
| `COMPLETED` | **값** (변경) | **표시 + 리뷰 작성** | 상단 배너가 대체 |
| `ROLLED_BACK` | `null` | 숨김 | 활성 |

"영구 존속"으로 하지 않은 이유는 철회 후에도 값이 남으면 `hasTradeRequest = true` 가 되어 재요청 버튼이 잠기기 때문입니다.

**확정된 거래의 채팅방에 지금은 없던 완료 카드가 나타납니다.** 막혀 있던 기능을 여는 것이라 의도된 수정이지만, 이게 원래 설계 의도였는지 확인 부탁드립니다.

### 필드명을 유지한 이유

`createdAt` 의 실제 의미는 "거래 요청 생성 시각"이고 상품 생성 시각이 아닙니다. `tradeRequestedAt` 이 이상적이지만 앱이 `product.createdAt` 을 6곳에서 읽고 있어 3개 레포 동시 배포가 필요합니다. 주석으로 의미를 문서화하고 리네이밍은 후속 작업으로 분리했습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (환경값 변경 없음)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요?
- [x] 작업한 코드가 정상적으로 동작하나요? (아래 기타 참고)
- [x] Merge 대상 브랜치가 올바른가요? (`develop`)
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

**배포 순서**: 채팅 서버 PR(School-of-Company/Gwangsan-Chatting-Server#32)을 **먼저** 배포해야 합니다. `ValidationPipe({ whitelist: true })` 때문에 DTO 가 먼저 나가지 않으면 새 필드가 조용히 삭제됩니다.

**호환성**: 앱은 아직 `requestedBySeller` 를 읽지 않으므로 이 PR 만으로는 앱 동작이 바뀌지 않습니다. 단 `createdAt` 값이 확정 후 `null` → 값으로 바뀌므로 위 UX 변경이 발생합니다.

**테스트 결과**: 417건 중 416 통과. 실패하는 `ChatStreamConsumerWorker 통합 테스트` 는 로컬 Docker 환경 문제로, 단독 실행 시 5건 모두 통과하며 이 브랜치의 변경 없이 `develop` 에서도 동일하게 실패합니다. CI 결과를 확인해주세요.

**후속 작업 (이 PR 범위 아님)**: 사용자가 보고한 거래 카드 정렬 문제는 앱의 raw string 비교가 직접 원인이며 이 PR 로 해결되지 않습니다. School-of-Company/Gwangsan-Crossplatform#532 의 수정이 필요합니다.
