### PR TITLE
거래 완료 요청(PENDING) 철회 API 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/post/presentation/PostController.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/presentation/PostController.java
@@ -11,6 +11,7 @@ import team.startup.gwangsan.domain.post.presentation.dto.request.CreateProductR
 import team.startup.gwangsan.domain.post.presentation.dto.request.PatchProductRequest;
 import team.startup.gwangsan.domain.post.presentation.dto.request.RequestTradeCompleteRequest;
 import team.startup.gwangsan.domain.post.presentation.dto.request.ReservationRequest;
+import team.startup.gwangsan.domain.post.presentation.dto.request.WithdrawTradeCompleteRequest;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductByIdResponse;
 import team.startup.gwangsan.domain.post.presentation.dto.response.GetProductResponse;
 import team.startup.gwangsan.domain.post.service.*;
@@ -31,6 +32,7 @@ public class PostController {
     private final DeleteProductByIdService deleteProductByIdService;
     private final FindProductsByMemberIdService findProductsByMemberIdService;
     private final RequestTradeCompleteService requestTradeCompleteService;
+    private final WithdrawTradeCompleteService withdrawTradeCompleteService;
     private final ReservationProductService reservationProductService;
     private final DeleteReservationProductService deleteReservationProductService;
 
@@ -108,6 +110,12 @@ public class PostController {
     @PostMapping("/trade")
     public ResponseEntity<Void> tradeRequest(@RequestBody @Valid RequestTradeCompleteRequest request) {
         requestTradeCompleteService.execute(request.productId(), request.otherMemberId());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @DeleteMapping("/trade")
+    public ResponseEntity<Void> tradeWithdraw(@RequestBody @Valid WithdrawTradeCompleteRequest request) {
+        withdrawTradeCompleteService.execute(request.productId(), request.otherMemberId());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/request/WithdrawTradeCompleteRequest.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/presentation/dto/request/WithdrawTradeCompleteRequest.java
@@ -1,0 +1,7 @@
+package team.startup.gwangsan.domain.post.presentation.dto.request;
+
+public record WithdrawTradeCompleteRequest(
+        Long productId,
+        Long otherMemberId
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/post/service/WithdrawTradeCompleteService.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/WithdrawTradeCompleteService.java
@@ -1,0 +1,5 @@
+package team.startup.gwangsan.domain.post.service;
+
+public interface WithdrawTradeCompleteService {
+    void execute(Long productId, Long otherMemberId);
+}

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/WithdrawTradeCompleteServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/WithdrawTradeCompleteServiceImpl.java
@@ -1,0 +1,109 @@
+package team.startup.gwangsan.domain.post.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
+import team.startup.gwangsan.domain.post.service.WithdrawTradeCompleteService;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.exception.CannotSelectSelfException;
+import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCompleteException;
+import team.startup.gwangsan.domain.trade.exception.NotTradeCompleteRequesterException;
+import team.startup.gwangsan.domain.trade.exception.TradeAlreadyCompleteException;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+@Service
+@RequiredArgsConstructor
+public class WithdrawTradeCompleteServiceImpl implements WithdrawTradeCompleteService {
+
+    private final ProductRepository productRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final TradeCompleteRepository tradeCompleteRepository;
+    private final MemberDetailRepository memberDetailRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final TradeStateReader tradeStateReader;
+
+    @Override
+    @Transactional
+    public void execute(Long productId, Long otherMemberId) {
+        String phoneNumber = SecurityContextHolder.getContext().getAuthentication().getName();
+        MemberDetail memberDetail = memberDetailRepository.findByPhoneNumberWithMember(phoneNumber);
+        Member member = memberDetail.getMember();
+
+        validateNotSelfTrade(member.getId(), otherMemberId);
+
+        Product product = productRepository.findByIdWithLock(productId)
+                .orElseThrow(NotFoundProductException::new);
+        validateProductStatus(product);
+
+        MemberDetail otherMemberDetail = memberDetailRepository.findByMemberIdWithMember(otherMemberId);
+
+        boolean isBuyer = isBuyer(product, member);
+        MemberDetail buyerDetail = isBuyer ? memberDetail : otherMemberDetail;
+        MemberDetail sellerDetail = isBuyer ? otherMemberDetail : memberDetail;
+
+        Member buyer = buyerDetail.getMember();
+        Member seller = sellerDetail.getMember();
+
+        TradeComplete pending = tradeCompleteRepository
+                .findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING)
+                .orElseThrow(NotFoundTradeCompleteException::new);
+
+        boolean isRequester = isBuyer != pending.isRequestedBySeller();
+        if (!isRequester) {
+            throw new NotTradeCompleteRequesterException();
+        }
+
+        ChatRoom chatRoom = chatRoomRepository.findByProductIdAndBuyerAndSeller(product.getId(), buyer, seller)
+                .orElseThrow(NotFoundChatRoomException::new);
+
+        tradeCompleteRepository.delete(pending);
+
+        // 삭제 이후 상태를 단일 지점(TradeStateReader)으로 다시 읽어, 조회 응답과 같은 값을 이벤트에 싣는다.
+        TradeStateSnapshot tradeState = tradeStateReader.read(product, buyer, seller);
+        applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                chatRoom.getId(),
+                product.getId(),
+                tradeState.completed(),
+                tradeState.reserved(),
+                tradeState.requestedBySeller(),
+                tradeState.requestedAt()
+        ));
+    }
+
+    private void validateNotSelfTrade(Long memberId, Long otherMemberId) {
+        if (memberId.equals(otherMemberId)) {
+            throw new CannotSelectSelfException();
+        }
+    }
+
+    private void validateProductStatus(Product product) {
+        if (product.getStatus() == ProductStatus.COMPLETED) {
+            throw new TradeAlreadyCompleteException();
+        }
+    }
+
+    private boolean isBuyer(Product product, Member member) {
+        if (product.getMode() == Mode.GIVER) {
+            return !product.getMember().equals(member);
+        } else {
+            return product.getMember().equals(member);
+        }
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/exception/NotTradeCompleteRequesterException.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/exception/NotTradeCompleteRequesterException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangsan.domain.trade.exception;
+
+import team.startup.gwangsan.global.exception.ErrorCode;
+import team.startup.gwangsan.global.exception.GlobalException;
+
+public class NotTradeCompleteRequesterException extends GlobalException {
+    public NotTradeCompleteRequesterException() {
+        super(ErrorCode.NOT_TRADE_COMPLETE_REQUESTER);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangsan/global/exception/ErrorCode.java
@@ -98,6 +98,7 @@ public enum ErrorCode {
     // trade
     CANNOT_SELECT_SELF(400, "본인을 거래 대상으로 선택할 수 없습니다."),
     NOT_FOUND_TRADE_COMPLETE(404, "거래 완료 요청을 찾을 수 없습니다."),
+    NOT_TRADE_COMPLETE_REQUESTER(403, "거래 완료 요청자가 아닙니다."),
     TRADE_ALREADY_COMPLETE(409, "이미 거래 완료된 상품입니다."),
     TRADE_ALREADY_COMPLETE_REQUEST(409, "이미 거래 완료 요청한 상품입니다."),
     TRADE_COMPLETE_WITHOUT_CHATTING(400, "채팅을 하지 않은 상품은 거래 완료할 수 없습니다."),

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/WithdrawTradeCompleteServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/WithdrawTradeCompleteServiceImplTest.java
@@ -1,0 +1,327 @@
+package team.startup.gwangsan.domain.post.service.impl;
+
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.exception.CannotSelectSelfException;
+import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCompleteException;
+import team.startup.gwangsan.domain.trade.exception.NotTradeCompleteRequesterException;
+import team.startup.gwangsan.domain.trade.exception.TradeAlreadyCompleteException;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.service.TradeStateReader;
+import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("WithdrawTradeCompleteServiceImpl 단위 테스트")
+class WithdrawTradeCompleteServiceImplTest {
+
+    @Mock
+    private ProductRepository productRepository;
+
+    @Mock
+    private ChatRoomRepository chatRoomRepository;
+
+    @Mock
+    private TradeCompleteRepository tradeCompleteRepository;
+
+    @Mock
+    private MemberDetailRepository memberDetailRepository;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private TradeStateReader tradeStateReader;
+
+    @InjectMocks
+    private WithdrawTradeCompleteServiceImpl service;
+
+    private static final String PHONE_NUMBER = "010-1111-2222";
+
+    @BeforeEach
+    void setUpSecurityContext() {
+        Authentication authentication = mock(Authentication.class);
+        when(authentication.getName()).thenReturn(PHONE_NUMBER);
+
+        SecurityContext context = mock(SecurityContext.class);
+        when(context.getAuthentication()).thenReturn(authentication);
+
+        SecurityContextHolder.setContext(context);
+    }
+
+    @AfterEach
+    void clearSecurityContext() {
+        SecurityContextHolder.clearContext();
+    }
+
+    private MemberDetail mockMemberDetail(Long memberId) {
+        Member member = mock(Member.class);
+        when(member.getId()).thenReturn(memberId);
+
+        MemberDetail detail = mock(MemberDetail.class);
+        when(detail.getMember()).thenReturn(member);
+        when(detail.getId()).thenReturn(memberId);
+        return detail;
+    }
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("본인과 거래를 시도하면 CannotSelectSelfException 을 던진다")
+        void execute_shouldThrowCannotSelectSelfException_whenSelfTrade() {
+            Long memberId = 1L;
+            MemberDetail memberDetail = mockMemberDetail(memberId);
+
+            when(memberDetailRepository.findByPhoneNumberWithMember(PHONE_NUMBER))
+                    .thenReturn(memberDetail);
+
+            assertThrows(CannotSelectSelfException.class,
+                    () -> service.execute(10L, memberId));
+
+            verify(productRepository, never()).findByIdWithLock(anyLong());
+        }
+
+        @Test
+        @DisplayName("상품이 존재하지 않으면 NotFoundProductException 을 던진다")
+        void execute_shouldThrowNotFoundProductException_whenProductNotFound() {
+            Long memberId = 1L;
+            Long otherMemberId = 2L;
+
+            MemberDetail memberDetail = mockMemberDetail(memberId);
+            when(memberDetailRepository.findByPhoneNumberWithMember(PHONE_NUMBER)).thenReturn(memberDetail);
+            when(productRepository.findByIdWithLock(100L)).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundProductException.class, () -> service.execute(100L, otherMemberId));
+        }
+
+        @Test
+        @DisplayName("이미 거래 완료된 상품이면 TradeAlreadyCompleteException 을 던진다")
+        void execute_shouldThrowTradeAlreadyCompleteException_whenProductAlreadyCompleted() {
+            Long memberId = 1L;
+            Long otherMemberId = 2L;
+
+            MemberDetail memberDetail = mockMemberDetail(memberId);
+            when(memberDetailRepository.findByPhoneNumberWithMember(PHONE_NUMBER))
+                    .thenReturn(memberDetail);
+
+            Product product = mock(Product.class);
+            when(product.getStatus()).thenReturn(ProductStatus.COMPLETED);
+            when(productRepository.findByIdWithLock(100L))
+                    .thenReturn(Optional.of(product));
+
+            assertThrows(TradeAlreadyCompleteException.class,
+                    () -> service.execute(100L, otherMemberId));
+        }
+
+        @Test
+        @DisplayName("대기 중인 거래 완료 요청이 없으면 NotFoundTradeCompleteException 을 던진다")
+        void execute_shouldThrowNotFoundTradeCompleteException_whenNoPendingRequest() {
+            Long buyerId = 1L;
+            Long sellerId = 2L;
+            Long productId = 100L;
+
+            MemberDetail buyerDetail = mockMemberDetail(buyerId);
+            MemberDetail sellerDetail = mockMemberDetail(sellerId);
+
+            when(memberDetailRepository.findByPhoneNumberWithMember(PHONE_NUMBER))
+                    .thenReturn(buyerDetail);
+            when(memberDetailRepository.findByMemberIdWithMember(sellerId))
+                    .thenReturn(sellerDetail);
+
+            Product product = mock(Product.class);
+            when(product.getId()).thenReturn(productId);
+            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
+            when(product.getMode()).thenReturn(Mode.GIVER);
+            when(product.getMember()).thenReturn(mock(Member.class));
+
+            when(productRepository.findByIdWithLock(productId))
+                    .thenReturn(Optional.of(product));
+
+            when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
+                    product, buyerDetail.getMember(), sellerDetail.getMember(), TradeStatus.PENDING
+            )).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundTradeCompleteException.class,
+                    () -> service.execute(productId, sellerId));
+
+            verify(tradeCompleteRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("요청자가 아닌 상대방이 철회를 시도하면 NotTradeCompleteRequesterException 을 던진다")
+        void execute_shouldThrowNotTradeCompleteRequesterException_whenCallerIsNotRequester() {
+            Long sellerId = 1L;
+            Long buyerId = 2L;
+            Long productId = 100L;
+
+            MemberDetail sellerDetail = mockMemberDetail(sellerId);
+            MemberDetail buyerDetail = mockMemberDetail(buyerId);
+
+            when(memberDetailRepository.findByPhoneNumberWithMember(PHONE_NUMBER))
+                    .thenReturn(sellerDetail);
+            when(memberDetailRepository.findByMemberIdWithMember(buyerId))
+                    .thenReturn(buyerDetail);
+
+            Member sellerMember = sellerDetail.getMember();
+
+            Product product = mock(Product.class);
+            when(product.getId()).thenReturn(productId);
+            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
+            when(product.getMode()).thenReturn(Mode.GIVER);
+            when(product.getMember()).thenReturn(sellerMember);
+
+            when(productRepository.findByIdWithLock(productId))
+                    .thenReturn(Optional.of(product));
+
+            // 요청은 구매자가 보냈는데(requestedBySeller = false), 판매자(비요청자)가 철회를 시도
+            TradeComplete pending = mock(TradeComplete.class);
+            when(pending.isRequestedBySeller()).thenReturn(false);
+            when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
+                    product, buyerDetail.getMember(), sellerDetail.getMember(), TradeStatus.PENDING
+            )).thenReturn(Optional.of(pending));
+
+            assertThrows(NotTradeCompleteRequesterException.class,
+                    () -> service.execute(productId, buyerId));
+
+            verify(tradeCompleteRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("채팅방이 없으면 NotFoundChatRoomException 을 던진다")
+        void execute_shouldThrowNotFoundChatRoomException_whenChatRoomNotFound() {
+            Long sellerId = 1L;
+            Long buyerId = 2L;
+            Long productId = 100L;
+
+            MemberDetail sellerDetail = mockMemberDetail(sellerId);
+            MemberDetail buyerDetail = mockMemberDetail(buyerId);
+
+            when(memberDetailRepository.findByPhoneNumberWithMember(PHONE_NUMBER))
+                    .thenReturn(sellerDetail);
+            when(memberDetailRepository.findByMemberIdWithMember(buyerId))
+                    .thenReturn(buyerDetail);
+
+            Member sellerMember = sellerDetail.getMember();
+
+            Product product = mock(Product.class);
+            when(product.getId()).thenReturn(productId);
+            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
+            when(product.getMode()).thenReturn(Mode.GIVER);
+            when(product.getMember()).thenReturn(sellerMember);
+
+            when(productRepository.findByIdWithLock(productId))
+                    .thenReturn(Optional.of(product));
+
+            // 판매자 본인이 보낸 요청(requestedBySeller = true)을 판매자가 철회 시도
+            TradeComplete pending = mock(TradeComplete.class);
+            when(pending.isRequestedBySeller()).thenReturn(true);
+            when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
+                    product, buyerDetail.getMember(), sellerDetail.getMember(), TradeStatus.PENDING
+            )).thenReturn(Optional.of(pending));
+
+            when(chatRoomRepository.findByProductIdAndBuyerAndSeller(
+                    productId, buyerDetail.getMember(), sellerDetail.getMember()
+            )).thenReturn(Optional.empty());
+
+            assertThrows(NotFoundChatRoomException.class,
+                    () -> service.execute(productId, buyerId));
+
+            verify(tradeCompleteRepository, never()).delete(any());
+        }
+
+        @Test
+        @DisplayName("요청자 본인이 철회하면 PENDING 요청을 삭제하고 최신 거래 상태로 이벤트를 발행한다")
+        void execute_shouldDeletePendingAndPublishEvent_whenCallerIsRequester() {
+            Long sellerId = 1L;
+            Long buyerId = 2L;
+            Long productId = 100L;
+            Long roomId = 700L;
+
+            MemberDetail sellerDetail = mockMemberDetail(sellerId);
+            MemberDetail buyerDetail = mockMemberDetail(buyerId);
+
+            Member sellerMember = sellerDetail.getMember();
+            Member buyerMember = buyerDetail.getMember();
+
+            when(memberDetailRepository.findByPhoneNumberWithMember(PHONE_NUMBER))
+                    .thenReturn(sellerDetail);
+            when(memberDetailRepository.findByMemberIdWithMember(buyerId))
+                    .thenReturn(buyerDetail);
+
+            Product product = mock(Product.class);
+            when(product.getId()).thenReturn(productId);
+            when(product.getStatus()).thenReturn(ProductStatus.ONGOING);
+            when(product.getMode()).thenReturn(Mode.GIVER);
+            when(product.getMember()).thenReturn(sellerMember);
+
+            when(productRepository.findByIdWithLock(productId))
+                    .thenReturn(Optional.of(product));
+
+            TradeComplete pending = mock(TradeComplete.class);
+            when(pending.isRequestedBySeller()).thenReturn(true);
+            when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(
+                    product, buyerMember, sellerMember, TradeStatus.PENDING
+            )).thenReturn(Optional.of(pending));
+
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.getId()).thenReturn(roomId);
+            when(chatRoomRepository.findByProductIdAndBuyerAndSeller(
+                    productId, buyerMember, sellerMember
+            )).thenReturn(Optional.of(chatRoom));
+
+            TradeStateSnapshot snapshotAfterWithdraw = new TradeStateSnapshot(false, false, null, null);
+            when(tradeStateReader.read(product, buyerMember, sellerMember))
+                    .thenReturn(snapshotAfterWithdraw);
+
+            assertDoesNotThrow(() -> service.execute(productId, buyerId));
+
+            verify(tradeCompleteRepository).delete(pending);
+
+            org.mockito.ArgumentCaptor<TradeStatusChangedEvent> eventCaptor =
+                    org.mockito.ArgumentCaptor.forClass(TradeStatusChangedEvent.class);
+            verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+
+            TradeStatusChangedEvent event = eventCaptor.getValue();
+            assertEquals(roomId, event.roomId());
+            assertEquals(productId, event.productId());
+            assertEquals(false, event.completed());
+            assertEquals(false, event.reserved());
+            assertEquals(null, event.requestedBySeller());
+            assertEquals(null, event.requestedAt());
+        }
+    }
+}


### PR DESCRIPTION
## 문제

`POST /post/trade`(`RequestTradeCompleteServiceImpl`)로 생성된 거래 완료 요청(PENDING `TradeComplete`)을 요청자 본인이 취소·철회할 API가 없어, 한 번 요청을 보내면 상대방이 확정해주기 전까지 영구히 재요청이 불가능했습니다.

- 재요청 시 `409 TRADE_ALREADY_COMPLETE_REQUEST` 발생
- `TradeComplete`(PENDING)를 삭제하는 경로가 상대방의 확정(`deleteByProductAndStatus`) 단 한 곳뿐

Closes #366

## 변경 사항

- `DELETE /api/post/trade` 추가 — 요청자 본인이 만든 PENDING 상태의 거래 완료 요청을 철회
  - `WithdrawTradeCompleteService` / `WithdrawTradeCompleteServiceImpl`
  - `WithdrawTradeCompleteRequest(productId, otherMemberId)`
- 요청자 본인만 철회할 수 있도록 검증(`isBuyer != pending.isRequestedBySeller()`), 아니면 `NotTradeCompleteRequesterException`(403) 발생
- 대기 중인 요청이 없으면 `NotFoundTradeCompleteException`(404)
- PENDING 레코드 삭제 후에는 `TradeStateReader` 단일 지점으로 상태를 다시 읽어 `TradeStatusChangedEvent`에 실어 발행 — 채팅방 조회 응답(`GET /chat/{room_id}`)이 이후 계산할 값과 이벤트 값이 어긋나지 않도록 함(#361에서 도입된 단일 지점 패턴 재사용)
- `ErrorCode.NOT_TRADE_COMPLETE_REQUESTER` 추가

## 스코프 밖

이슈에서 함께 언급된 아래 항목은 이번 PR에 포함하지 않았습니다. 별도 논의/작업이 필요합니다.

- PENDING 자동 만료 정책(대안으로 언급된 항목이며, 취소 API가 추가되어 우선순위가 낮아짐)
- `isCompletable` 계산 로직이 `GET /post/{post_id}`와 `GET /chat/{room_id}`에서 서로 다른 건(둘 다 의도된 차이인지 확인 필요해 별도 이슈로 다루는 것을 제안)

## 테스트

- `WithdrawTradeCompleteServiceImplTest` 신규 작성 (자기 자신과 거래 시도, 상품 없음, 이미 완료된 상품, 대기 요청 없음, 요청자 아님, 채팅방 없음, 정상 철회 시 이벤트 발행까지 검증)
- `./gradlew test` 전체 실행 — 기존 424개 테스트 중 Docker 미설치로 인한 `ChatStreamConsumerIntegrationTest`(Testcontainers) 1건을 제외하고 전부 통과, 본 PR 변경과 무관

## Test plan

- [x] 단위 테스트 통과 확인
- [ ] 실제 서버 기동 후 `DELETE /api/post/trade` 호출로 PENDING 철회 및 재요청(`POST /post/trade`) 가능 여부 수동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)