### PR TITLE
예약 취소 시 잘못된 파생 쿼리로 인한 오동작 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/post/repository/ProductReservationRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/ProductReservationRepository.java
@@ -2,7 +2,6 @@ package team.startup.gwangsan.domain.post.repository;
 
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
 import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
@@ -10,9 +9,6 @@ import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
 import java.util.Optional;
 
 public interface ProductReservationRepository extends JpaRepository<ProductReservation, Long> {
-    @EntityGraph(attributePaths = "product")
-    Optional<ProductReservation> findByProduct_MemberOrReserverAndStatus(Member member, Member reserver, ReservationStatus status);
-
     @EntityGraph(attributePaths = "reserver")
     Optional<ProductReservation> findByProductAndStatus(Product product, ReservationStatus status);
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImpl.java
@@ -10,6 +10,7 @@ import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
 import team.startup.gwangsan.domain.post.exception.ReservationParticipantOnlyException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
@@ -36,11 +37,17 @@ public class DeleteReservationProductServiceImpl implements DeleteReservationPro
     public void execute(Long productId) {
         Member member = memberUtil.getCurrentMember();
 
+        Product product = productRepository.findActiveById(productId)
+                .orElseThrow(NotFoundProductException::new);
+
         ProductReservation productReservation = productReservationRepository
-                .findByProduct_MemberOrReserverAndStatus(member, member, ReservationStatus.PENDING)
+                .findByProductAndStatus(product, ReservationStatus.PENDING)
                 .orElseThrow(ReservationParticipantOnlyException::new);
 
-        Product product = productReservation.getProduct();
+        if (!product.getMember().getId().equals(member.getId())
+                && !productReservation.getReserver().getId().equals(member.getId())) {
+            throw new ReservationParticipantOnlyException();
+        }
 
         productReservation.cancel();
 

--- a/src/test/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/service/impl/DeleteReservationProductServiceImplTest.java
@@ -16,6 +16,7 @@ import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.ProductReservation;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
 import team.startup.gwangsan.domain.post.exception.ReservationParticipantOnlyException;
 import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.post.repository.ProductReservationRepository;
@@ -64,8 +65,56 @@ class DeleteReservationProductServiceImplTest {
     class Describe_execute {
 
         @Test
-        @DisplayName("예약자 또는 상품 등록자가 호출하면 예약을 취소하고 상품 상태를 ONGOING 으로 변경한다")
-        void it_cancels_reservation_and_update_product_status_when_called_by_participant() {
+        @DisplayName("예약자가 호출하면 예약을 취소하고 상품 상태를 ONGOING 으로 변경한다")
+        void it_cancels_reservation_and_update_product_status_when_called_by_reserver() {
+            // given
+            Long productId = 1L;
+
+            Member currentMember = mock(Member.class);
+            Member owner = mock(Member.class);
+            ProductReservation reservation = mock(ProductReservation.class);
+            Product product = mock(Product.class);
+
+            when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+            when(currentMember.getId()).thenReturn(2L);
+            when(owner.getId()).thenReturn(1L);
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
+            when(productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING))
+                    .thenReturn(Optional.of(reservation));
+            when(product.getMember()).thenReturn(owner);
+            when(reservation.getReserver()).thenReturn(currentMember);
+            when(product.getId()).thenReturn(productId);
+
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(chatRoom.getId()).thenReturn(10L);
+            when(chatRoomRepository.findByProductIdAndMember(productId, currentMember))
+                    .thenReturn(Optional.of(chatRoom));
+
+            // when & then
+            when(tradeStateReader.read(any(), any(), any()))
+                    .thenReturn(new TradeStateSnapshot(false, false, null, null));
+            assertDoesNotThrow(() -> service.execute(productId));
+
+            verify(memberUtil).getCurrentMember();
+            verify(productRepository).findActiveById(productId);
+            verify(productReservationRepository).findByProductAndStatus(product, ReservationStatus.PENDING);
+            verify(reservation).cancel();
+            verify(product).updateStatus(ProductStatus.ONGOING);
+
+            ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
+            verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
+            TradeStatusChangedEvent event = (TradeStatusChangedEvent) eventCaptor.getValue();
+            assertEquals(10L, event.roomId());
+            assertEquals(productId, event.productId());
+            assertFalse(event.completed());
+            assertFalse(event.reserved());
+            assertNull(event.requestedBySeller());
+            assertNull(event.requestedAt());
+        }
+
+        @Test
+        @DisplayName("상품 등록자가 호출하면 예약을 취소하고 상품 상태를 ONGOING 으로 변경한다")
+        void it_cancels_reservation_and_update_product_status_when_called_by_product_owner() {
             // given
             Long productId = 1L;
 
@@ -75,12 +124,11 @@ class DeleteReservationProductServiceImplTest {
             Product product = mock(Product.class);
 
             when(memberUtil.getCurrentMember()).thenReturn(currentMember);
-            when(productReservationRepository.findByProduct_MemberOrReserverAndStatus(
-                    currentMember,
-                    currentMember,
-                    ReservationStatus.PENDING
-            )).thenReturn(Optional.of(reservation));
-            when(reservation.getProduct()).thenReturn(product);
+            when(currentMember.getId()).thenReturn(1L);
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
+            when(productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING))
+                    .thenReturn(Optional.of(reservation));
+            when(product.getMember()).thenReturn(currentMember);
             when(reservation.getReserver()).thenReturn(reserver);
             when(product.getId()).thenReturn(productId);
 
@@ -94,26 +142,51 @@ class DeleteReservationProductServiceImplTest {
                     .thenReturn(new TradeStateSnapshot(false, false, null, null));
             assertDoesNotThrow(() -> service.execute(productId));
 
-            verify(memberUtil).getCurrentMember();
-            verify(productReservationRepository).findByProduct_MemberOrReserverAndStatus(
-                    currentMember,
-                    currentMember,
-                    ReservationStatus.PENDING
-            );
             verify(reservation).cancel();
             verify(product).updateStatus(ProductStatus.ONGOING);
+        }
 
-            ArgumentCaptor<Object> eventCaptor = ArgumentCaptor.forClass(Object.class);
-            verify(applicationEventPublisher).publishEvent(eventCaptor.capture());
-            TradeStatusChangedEvent event = (TradeStatusChangedEvent) eventCaptor.getValue();
-            assertEquals(10L, event.roomId());
-            assertEquals(productId, event.productId());
-            assertFalse(event.completed());
-            assertFalse(event.reserved());
-            assertNull(event.requestedBySeller());
-            assertNull(event.requestedAt());
+        @Test
+        @DisplayName("상품이 존재하지 않으면 NotFoundProductException 을 던진다")
+        void it_throws_NotFoundProductException_when_product_not_found() {
+            // given
+            Long productId = 1L;
 
-            verifyNoInteractions(productRepository);
+            Member currentMember = mock(Member.class);
+
+            when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.empty());
+
+            // when & then
+            assertThrows(NotFoundProductException.class,
+                    () -> service.execute(productId));
+
+            verifyNoInteractions(productReservationRepository);
+        }
+
+        @Test
+        @DisplayName("해당 상품에 PENDING 예약이 없으면 ReservationParticipantOnlyException 을 던진다")
+        void it_throws_ReservationParticipantOnlyException_when_reservation_not_found() {
+            // given
+            Long productId = 1L;
+
+            Member currentMember = mock(Member.class);
+            Product product = mock(Product.class);
+
+            when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
+            when(productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING))
+                    .thenReturn(Optional.empty());
+
+            // when & then
+            assertThrows(ReservationParticipantOnlyException.class,
+                    () -> service.execute(productId));
+
+            verify(memberUtil).getCurrentMember();
+            verify(productRepository).findActiveById(productId);
+            verify(productReservationRepository).findByProductAndStatus(product, ReservationStatus.PENDING);
+
+            verifyNoMoreInteractions(productReservationRepository);
         }
 
         @Test
@@ -123,27 +196,27 @@ class DeleteReservationProductServiceImplTest {
             Long productId = 1L;
 
             Member currentMember = mock(Member.class);
+            Member owner = mock(Member.class);
+            Member reserver = mock(Member.class);
+            Product product = mock(Product.class);
+            ProductReservation reservation = mock(ProductReservation.class);
 
             when(memberUtil.getCurrentMember()).thenReturn(currentMember);
-            when(productReservationRepository.findByProduct_MemberOrReserverAndStatus(
-                    currentMember,
-                    currentMember,
-                    ReservationStatus.PENDING
-            )).thenReturn(Optional.empty());
+            when(currentMember.getId()).thenReturn(3L);
+            when(owner.getId()).thenReturn(1L);
+            when(reserver.getId()).thenReturn(2L);
+            when(productRepository.findActiveById(productId)).thenReturn(Optional.of(product));
+            when(productReservationRepository.findByProductAndStatus(product, ReservationStatus.PENDING))
+                    .thenReturn(Optional.of(reservation));
+            when(product.getMember()).thenReturn(owner);
+            when(reservation.getReserver()).thenReturn(reserver);
 
             // when & then
             assertThrows(ReservationParticipantOnlyException.class,
                     () -> service.execute(productId));
 
-            verify(memberUtil).getCurrentMember();
-            verify(productReservationRepository).findByProduct_MemberOrReserverAndStatus(
-                    currentMember,
-                    currentMember,
-                    ReservationStatus.PENDING
-            );
-
-            verifyNoMoreInteractions(productReservationRepository);
-            verifyNoInteractions(productRepository);
+            verify(reservation, never()).cancel();
+            verifyNoInteractions(chatRoomRepository);
         }
     }
 }


### PR DESCRIPTION
## 요약
- `DeleteReservationProductServiceImpl.execute`에서 사용하던 `findByProduct_MemberOrReserverAndStatus`는 Spring Data JPA 파생 쿼리에서 AND가 OR보다 먼저 결합되어 `WHERE product.member = :member OR (reserver = :reserver AND status = :status)`로 파싱됨
  - `productId` 조건이 전혀 반영되지 않음
  - 판매자로 매칭되는 경우 `status` 조건이 빠져 CANCELLED/COMPLETED 예약도 매칭 대상이 됨
  - 결과가 2건 이상이면 `IncorrectResultSizeDataAccessException`(500) 발생, 1건이어도 엉뚱한 예약이 취소될 위험
- `productId`로 `Product`를 먼저 조회하고, 이미 스코프가 맞는 `findByProductAndStatus(product, PENDING)`으로 예약을 조회한 뒤 현재 사용자가 `product.member` 또는 `reservation.reserver`인지 애플리케이션 레벨에서 검증하도록 변경
- 원인이 된 잘못된 파생 쿼리 메서드(`findByProduct_MemberOrReserverAndStatus`)는 리포지토리에서 제거

## 관련 이슈
Closes #365

## 테스트 플랜
- [x] `DeleteReservationProductServiceImplTest` 단위 테스트를 새 로직에 맞게 갱신 (예약자/상품 등록자 성공 케이스, 상품 없음, 예약 없음, 비참여자 케이스)
- [ ] 로컬 Gradle 빌드/테스트 실행 (환경의 JDK 버전 이슈로 `jacocoTestReport` 태스크 생성이 실패하여 직접 확인하지 못함 — CI에서 확인 필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)