### PR TITLE
같은 상품 예약/취소 반복 시 유니크 제약으로 인한 실패 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/post/entity/ProductReservation.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/entity/ProductReservation.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Table(
         name = "tbl_product_reservation",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"product_id", "status"})
+        indexes = @Index(name = "idx_product_reservation_product_status", columnList = "product_id, status")
 )
 @EntityListeners(AuditingEntityListener.class)
 public class ProductReservation {

--- a/src/main/resources/db/migration/V6__drop_product_reservation_status_unique.sql
+++ b/src/main/resources/db/migration/V6__drop_product_reservation_status_unique.sql
@@ -1,0 +1,25 @@
+-- (product_id, status) 유니크 제약은 "상품당 상태별 1행"을 강제해서,
+-- 같은 상품을 두 번째로 취소할 때 (product_id, CANCELLED) 중복으로 500이 발생했다.
+-- 동시에 활성(PENDING) 예약이 1건이라는 규칙은 product.status 체크로 애플리케이션에서 보장한다.
+
+-- FK(product_id)가 이 유니크 인덱스를 타고 있을 수 있어, 대체 인덱스를 먼저 만든 뒤 드롭한다.
+CREATE INDEX idx_product_reservation_product_status
+    ON tbl_product_reservation (product_id, status);
+
+-- Flyway 도입 전 Hibernate가 붙인 이름(UK...)은 환경마다 달라 information_schema에서 찾아 드롭한다.
+SET @uk := (
+    SELECT INDEX_NAME
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tbl_product_reservation'
+      AND NON_UNIQUE = 0
+      AND INDEX_NAME <> 'PRIMARY'
+    GROUP BY INDEX_NAME
+    HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = 'product_id,status'
+    LIMIT 1
+);
+SET @sql := IF(@uk IS NULL, 'DO 0',
+               CONCAT('ALTER TABLE tbl_product_reservation DROP INDEX `', @uk, '`'));
+PREPARE stmt FROM @sql;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;

--- a/src/test/java/team/startup/gwangsan/domain/post/repository/ProductReservationRepositoryTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/repository/ProductReservationRepositoryTest.java
@@ -1,0 +1,93 @@
+package team.startup.gwangsan.domain.post.repository;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.ProductReservation;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.ReservationStatus;
+import team.startup.gwangsan.domain.post.entity.constant.Type;
+import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+@DisplayName("ProductReservationRepository 통합 테스트")
+class ProductReservationRepositoryTest {
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private ProductReservationRepository productReservationRepository;
+
+    private Member createMember(String nickname, String phone) {
+        return em.persist(Member.builder()
+                .name("테스트")
+                .nickname(nickname)
+                .password("pw")
+                .phoneNumber(phone)
+                .role(MemberRole.ROLE_USER)
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    private Product createProduct(Member owner) {
+        return em.persist(Product.builder()
+                .title("상품")
+                .description("설명")
+                .gwangsan(5000)
+                .member(owner)
+                .type(Type.SERVICE)
+                .mode(Mode.GIVER)
+                .status(ProductStatus.ONGOING)
+                .build());
+    }
+
+    private ProductReservation reserveAndCancel(Product product, Member reserver) {
+        ProductReservation reservation = productReservationRepository.save(ProductReservation.builder()
+                .product(product)
+                .reserver(reserver)
+                .status(ReservationStatus.PENDING)
+                .build());
+        reservation.cancel();
+        em.flush();
+        return reservation;
+    }
+
+    @Nested
+    @DisplayName("같은 상품의 예약을 반복 취소할 때")
+    class Describe_repeated_cancel {
+
+        @Test
+        @DisplayName("취소 이력이 여러 건 쌓여도 저장에 실패하지 않는다")
+        void it_saves_multiple_cancelled_reservations_for_same_product() {
+            Member seller = createMember("seller", "010-0001-0001");
+            Member reserver = createMember("reserver", "010-0001-0002");
+            Product product = createProduct(seller);
+
+            reserveAndCancel(product, reserver);
+
+            assertThatCode(() -> reserveAndCancel(product, reserver)).doesNotThrowAnyException();
+
+            em.clear();
+            List<ProductReservation> reservations = productReservationRepository.findAll();
+            assertThat(reservations)
+                    .hasSize(2)
+                    .allMatch(reservation -> reservation.getStatus() == ReservationStatus.CANCELLED);
+        }
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

같은 상품에 대해 예약 → 취소를 두 번째로 반복하면 `DELETE /post/reservation/{productId}` 요청이 500으로 실패하였습니다.

`tbl_product_reservation`에 `(product_id, status)` 유니크 제약이 걸려 있어, 같은 상품의 취소 이력이 두 건 이상 쌓일 수 없는 것이 원인이었습니다. 재예약 시 기존 행을 재사용하지 않고 새 행을 INSERT하기 때문에, 두 번째 취소에서 이미 존재하는 `(productId, CANCELLED)` 조합과 충돌하여 `DataIntegrityViolationException`이 발생하였습니다. 거래 완료(`COMPLETED`) 처리도 같은 제약을 공유하므로 동일한 문제를 안고 있었습니다.

Resolves: #370

## 📃 작업내용

- `V6__drop_product_reservation_status_unique.sql` 마이그레이션을 추가하여 `(product_id, status)` 유니크 제약을 제거하였습니다
- `ProductReservation` 엔티티의 `uniqueConstraints`를 동일 컬럼 조합의 일반 인덱스로 교체하였습니다
- 같은 상품의 취소 이력이 여러 건 누적되어도 저장에 실패하지 않는지 검증하는 `ProductReservationRepositoryTest`를 추가하였습니다

## 🙋‍♂️ 리뷰노트

**유니크 제약을 제거해도 되는 이유**

"동시에 활성(PENDING) 예약은 1건" 규칙은 `ReservationProductServiceImpl`에서 `product.status`(ONGOING/RESERVATION)를 확인하는 방식으로 애플리케이션 레벨에서 이미 보장하고 있습니다. 따라서 제약을 제거해도 중복 활성 예약은 발생하지 않으며, 취소/완료 이력만 상품당 여러 건 누적될 수 있게 되었습니다.

**마이그레이션에서 신경 쓴 부분**

- 해당 제약은 Flyway 도입 이전에 Hibernate가 생성한 것이라 인덱스 이름이 `UK{해시}` 형태로 환경마다 다릅니다. 이름을 하드코딩할 수 없어 `information_schema`에서 컬럼 조합으로 찾아 동적으로 DROP하도록 작성하였습니다
- `product_id`가 유니크 인덱스의 선두 컬럼이라 FK가 이 인덱스를 사용 중일 수 있습니다. 그대로 드롭하면 errno 150으로 실패하므로 대체 인덱스를 먼저 생성한 뒤 드롭하도록 순서를 잡았습니다. 이 인덱스는 `findByProductAndStatus` 조회에도 그대로 사용됩니다

**검증 내용**

MariaDB 컨테이너에 유니크 제약이 있는 스키마를 만든 뒤 Flyway로 실제 마이그레이션을 적용하여, 유니크 인덱스만 제거되고 FK는 유지되며 같은 상품의 `CANCELLED` 행이 두 건 저장되는 것을 확인하였습니다. 추가한 테스트는 엔티티의 제약을 되돌리면 실패하는 것까지 확인하였습니다.

`DataIntegrityViolationException` 핸들러 추가는 근본 원인이 제거되어 이번 범위에서는 제외하였습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

기존 `V4`, `V5` 번호가 develop에 이미 사용 중이라 마이그레이션 버전을 `V6`으로 지정하였습니다. 배포 시 운영 DB에 마이그레이션이 적용되어야 하며, `ddl-auto: validate` 기동 확인이 필요합니다.
