### PR TITLE
회원가입 데모 번호 SMS 발송·가입 우회 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/auth/service/impl/SignUpServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/auth/service/impl/SignUpServiceImpl.java
@@ -27,6 +27,7 @@ import team.startup.gwangsan.domain.relatedkeyword.repository.RelatedKeywordRepo
 import team.startup.gwangsan.global.event.CreateAdminAlertEvent;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsDemoAccount;
 
 @Service
 @RequiredArgsConstructor
@@ -48,6 +49,12 @@ public class SignUpServiceImpl implements SignUpService {
     @Override
     @Transactional
     public void execute(SignUpRequest request) {
+        // ponytail: 데모 번호는 App Store 심사용. 데모 회원이 이미 존재하고 phone_number가 unique라
+        // 실제 저장이 불가능하므로 검증/저장 없이 성공 처리한다. 리뷰어는 Review Notes의 데모 계정으로 로그인한다.
+        if (SmsDemoAccount.isDemo(request.phoneNumber())) {
+            return;
+        }
+
         validateBannedPhoneNumber(request.phoneNumber());
         validateDuplicatePhoneNumber(request.phoneNumber());
         validateDuplicateNickname(request.nickname());

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImpl.java
@@ -15,6 +15,7 @@ import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeExceptio
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 import team.startup.gwangsan.domain.sms.service.SendFindNicknameSmsService;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsDemoAccount;
 import team.startup.gwangsan.global.sms.SmsProperties;
 
 import java.security.NoSuchAlgorithmException;
@@ -34,6 +35,11 @@ public class SendFindNicknameSmsServiceImpl implements SendFindNicknameSmsServic
     @Override
     @Transactional
     public void execute(SendSmsRequest request) {
+
+        if (SmsDemoAccount.isDemo(request.phoneNumber())) {
+            log.info("[SMS] 데모 번호 요청 - 발송 생략");
+            return;
+        }
 
         if (!memberRepository.existsByPhoneNumber(request.phoneNumber())) {
             throw new NotRegisteredPhoneNumberException();

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendResetPasswordSmsServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendResetPasswordSmsServiceImpl.java
@@ -1,6 +1,7 @@
 package team.startup.gwangsan.domain.sms.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.member.repository.MemberRepository;
@@ -10,6 +11,7 @@ import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeExceptio
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 import team.startup.gwangsan.domain.sms.service.SendResetPasswordSmsService;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsDemoAccount;
 import team.startup.gwangsan.global.sms.SmsSendHelper;
 import team.startup.gwangsan.global.sms.SmsProperties;
 
@@ -17,6 +19,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.util.Random;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class SendResetPasswordSmsServiceImpl implements SendResetPasswordSmsService {
@@ -29,6 +32,11 @@ public class SendResetPasswordSmsServiceImpl implements SendResetPasswordSmsServ
     @Override
     @Transactional
     public void execute(SendSmsRequest request) {
+
+        if (SmsDemoAccount.isDemo(request.phoneNumber())) {
+            log.info("[SMS] 데모 번호 요청 - 발송 생략");
+            return;
+        }
 
         if (!memberRepository.existsByPhoneNumber(request.phoneNumber())) {
             throw new NotRegisteredPhoneNumberException();

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendSmsServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/SendSmsServiceImpl.java
@@ -10,6 +10,7 @@ import team.startup.gwangsan.domain.sms.exception.TooManyRequestAuthCodeExceptio
 import team.startup.gwangsan.domain.sms.presentation.dto.SendSmsRequest;
 import team.startup.gwangsan.domain.sms.service.SendSmsService;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsDemoAccount;
 import team.startup.gwangsan.global.sms.SmsSendHelper;
 import team.startup.gwangsan.global.sms.SmsProperties;
 
@@ -29,6 +30,11 @@ public class SendSmsServiceImpl implements SendSmsService {
 
     @Override
     public void execute(SendSmsRequest request) {
+
+        if (SmsDemoAccount.isDemo(request.phoneNumber())) {
+            log.info("[SMS] 데모 번호 요청 - 발송 생략");
+            return;
+        }
 
         if (memberRepository.existsByPhoneNumber(request.phoneNumber())) {
             throw new AlreadyRegisteredPhoneNumberException();

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/VerifyCodeServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/VerifyCodeServiceImpl.java
@@ -9,6 +9,7 @@ import team.startup.gwangsan.domain.sms.exception.NotMatchRandomCodeException;
 import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
 import team.startup.gwangsan.domain.sms.service.VerifyCodeService;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsDemoAccount;
 
 @Slf4j
 @Service
@@ -20,9 +21,6 @@ public class VerifyCodeServiceImpl implements VerifyCodeService {
 
     private static final long VERIFIED_TTL_MILLIS = 10 * 60 * 1000L;
 
-    private static final String DEMO_PHONE_NUMBER = "01011111111";
-    private static final String DEMO_FIXED_CODE = "000000";
-
     private final RedisUtil redisUtil;
 
     @Override
@@ -31,7 +29,7 @@ public class VerifyCodeServiceImpl implements VerifyCodeService {
         String phoneNumber = request.phoneNumber();
         String verifiedKey = VERIFIED_KEY_PREFIX + phoneNumber;
 
-        if (DEMO_PHONE_NUMBER.equals(phoneNumber) && DEMO_FIXED_CODE.equals(request.code())) {
+        if (SmsDemoAccount.isDemo(phoneNumber) && SmsDemoAccount.FIXED_CODE.equals(request.code())) {
             redisUtil.set(verifiedKey, Boolean.TRUE, VERIFIED_TTL_MILLIS);
             log.info("[SMS] 인증 성공 (데모) - phoneNumber={}", phoneNumber.replaceAll("(\\d{3})\\d{4}(\\d{4})", "$1****$2"));
             return;

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/VerifyFindNicknameCodeServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/VerifyFindNicknameCodeServiceImpl.java
@@ -8,6 +8,7 @@ import team.startup.gwangsan.domain.sms.exception.NotMatchRandomCodeException;
 import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
 import team.startup.gwangsan.domain.sms.service.VerifyFindNicknameCodeService;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsDemoAccount;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +27,11 @@ public class VerifyFindNicknameCodeServiceImpl implements VerifyFindNicknameCode
         String phoneNumber = request.phoneNumber();
         String codeKey = CODE_KEY_PREFIX + phoneNumber;
         String verifiedKey = VERIFIED_KEY_PREFIX + phoneNumber;
+
+        if (SmsDemoAccount.isDemo(phoneNumber) && SmsDemoAccount.FIXED_CODE.equals(request.code())) {
+            redisUtil.set(verifiedKey, Boolean.TRUE, VERIFIED_TTL_MILLIS);
+            return;
+        }
 
         String savedCode = redisUtil.get(codeKey, String.class);
         if (savedCode == null) {

--- a/src/main/java/team/startup/gwangsan/domain/sms/service/impl/VerifyResetPasswordCodeServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/sms/service/impl/VerifyResetPasswordCodeServiceImpl.java
@@ -8,6 +8,7 @@ import team.startup.gwangsan.domain.sms.exception.NotMatchRandomCodeException;
 import team.startup.gwangsan.domain.sms.presentation.dto.VerifyCodeRequest;
 import team.startup.gwangsan.domain.sms.service.VerifyResetPasswordCodeService;
 import team.startup.gwangsan.global.redis.RedisUtil;
+import team.startup.gwangsan.global.sms.SmsDemoAccount;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +27,11 @@ public class VerifyResetPasswordCodeServiceImpl implements VerifyResetPasswordCo
         String phoneNumber = request.phoneNumber();
         String codeKey = CODE_KEY_PREFIX + phoneNumber;
         String verifiedKey = VERIFIED_KEY_PREFIX + phoneNumber;
+
+        if (SmsDemoAccount.isDemo(phoneNumber) && SmsDemoAccount.FIXED_CODE.equals(request.code())) {
+            redisUtil.set(verifiedKey, Boolean.TRUE, VERIFIED_TTL_MILLIS);
+            return;
+        }
 
         String savedCode = redisUtil.get(codeKey, String.class);
         if (savedCode == null) {

--- a/src/main/java/team/startup/gwangsan/global/sms/SmsDemoAccount.java
+++ b/src/main/java/team/startup/gwangsan/global/sms/SmsDemoAccount.java
@@ -1,0 +1,18 @@
+package team.startup.gwangsan.global.sms;
+
+/**
+ * App Store 심사(Review Notes)에 안내된 데모 번호/고정 코드.
+ * 실제 수신이 불가능한 번호이므로 발송·검증 단계 모두 우회한다.
+ */
+public final class SmsDemoAccount {
+
+    public static final String PHONE_NUMBER = "01011111111";
+    public static final String FIXED_CODE = "000000";
+
+    private SmsDemoAccount() {
+    }
+
+    public static boolean isDemo(String phoneNumber) {
+        return PHONE_NUMBER.equals(phoneNumber);
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/auth/service/impl/SignUpServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/auth/service/impl/SignUpServiceImplTest.java
@@ -62,6 +62,26 @@ class SignUpServiceImplTest {
     class Describe_execute {
 
         @Nested
+        @DisplayName("데모 번호일 때")
+        class Context_with_demo_phone_number {
+
+            @Test
+            @DisplayName("검증·저장 없이 즉시 반환한다")
+            void it_returns_immediately_without_saving_member() {
+                SignUpRequest request = new SignUpRequest(
+                        "심사용", "심사용닉", "password", "01011111111",
+                        "광산동", 1, List.of("Java"), "추천인닉", "자기소개"
+                );
+
+                service.execute(request);
+
+                verifyNoInteractions(memberRepository, redisUtil, withdrawalRecordRepository,
+                        dongRepository, placeRepository, memberDetailRepository,
+                        applicationEventPublisher);
+            }
+        }
+
+        @Nested
         @DisplayName("정상적인 요청일 때")
         class Context_with_valid_request {
 

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendFindNicknameSmsServiceImplTest.java
@@ -43,6 +43,19 @@ class SendFindNicknameSmsServiceImplTest {
     class Describe_execute {
 
         @Nested
+        @DisplayName("데모 번호일 때")
+        class Context_with_demo_phone_number {
+
+            @Test
+            @DisplayName("회원 조회·인증 정보 저장·SMS 발송 없이 즉시 반환한다")
+            void it_returns_immediately_without_sending_sms() {
+                service.execute(new SendSmsRequest("01011111111"));
+
+                verifyNoInteractions(memberRepository, redisUtil, messageService);
+            }
+        }
+
+        @Nested
         @DisplayName("정상적인 요청일 때")
         class Context_with_valid_request {
 

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendResetPasswordSmsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendResetPasswordSmsServiceImplTest.java
@@ -43,6 +43,19 @@ class SendResetPasswordSmsServiceImplTest {
     class Describe_execute {
 
         @Nested
+        @DisplayName("데모 번호일 때")
+        class Context_with_demo_phone_number {
+
+            @Test
+            @DisplayName("회원 조회·인증 정보 저장·SMS 발송 없이 즉시 반환한다")
+            void it_returns_immediately_without_sending_sms() {
+                service.execute(new SendSmsRequest("01011111111"));
+
+                verifyNoInteractions(memberRepository, redisUtil, smsSendHelper);
+            }
+        }
+
+        @Nested
         @DisplayName("정상적인 요청일 때")
         class Context_with_valid_request {
 

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendSmsServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/SendSmsServiceImplTest.java
@@ -43,6 +43,19 @@ class SendSmsServiceImplTest {
     class Describe_execute {
 
         @Nested
+        @DisplayName("데모 번호일 때")
+        class Context_with_demo_phone_number {
+
+            @Test
+            @DisplayName("회원 조회·인증 정보 저장·SMS 발송 없이 즉시 반환한다")
+            void it_returns_immediately_without_sending_sms() {
+                service.execute(new SendSmsRequest("01011111111"));
+
+                verifyNoInteractions(memberRepository, redisUtil, smsSendHelper);
+            }
+        }
+
+        @Nested
         @DisplayName("정상적인 요청일 때")
         class Context_with_valid_request {
 

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyFindNicknameCodeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyFindNicknameCodeServiceImplTest.java
@@ -31,6 +31,20 @@ class VerifyFindNicknameCodeServiceImplTest {
     class Describe_execute {
 
         @Nested
+        @DisplayName("데모 번호와 데모 코드일 때")
+        class Context_with_demo_number_and_code {
+
+            @Test
+            @DisplayName("인증 완료 키만 저장하고 코드 키는 삭제하지 않는다")
+            void it_saves_verified_key_without_deleting_code_key() {
+                service.execute(new VerifyCodeRequest("01011111111", "000000"));
+
+                verify(redisUtil).set(eq("sms:verified:01011111111"), eq(Boolean.TRUE), anyLong());
+                verify(redisUtil, never()).delete(anyString());
+            }
+        }
+
+        @Nested
         @DisplayName("코드가 일치할 때")
         class Context_with_matching_code {
 

--- a/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyResetPasswordCodeServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/sms/service/impl/VerifyResetPasswordCodeServiceImplTest.java
@@ -31,6 +31,20 @@ class VerifyResetPasswordCodeServiceImplTest {
     class Describe_execute {
 
         @Nested
+        @DisplayName("데모 번호와 데모 코드일 때")
+        class Context_with_demo_number_and_code {
+
+            @Test
+            @DisplayName("인증 완료 키만 저장하고 코드 키는 삭제하지 않는다")
+            void it_saves_verified_key_without_deleting_code_key() {
+                service.execute(new VerifyCodeRequest("01011111111", "000000"));
+
+                verify(redisUtil).set(eq("sms:verified:01011111111"), eq(Boolean.TRUE), anyLong());
+                verify(redisUtil, never()).delete(anyString());
+            }
+        }
+
+        @Nested
         @DisplayName("코드가 일치할 때")
         class Context_with_matching_code {
 


### PR DESCRIPTION
## 💡 배경 및 개요

App Store 심사(Guideline 2.1(a))에서 리뷰어가 Review Notes에 안내된 데모 번호 `01011111111`로 인증번호를 요청하면 `POST /api/sms`가 즉시 400 `이미 가입된 전화번호입니다`로 막혀, 인증번호를 입력할 기회조차 없이 앱이 반려되었습니다.

데모 우회 로직이 검증 단계(`VerifyCodeServiceImpl`)에만 존재하고 그 앞의 발송 단계에는 없었기 때문입니다.

추가로 코드를 추적한 결과, 발송 단계만 수정해도 리뷰어는 회원가입을 완료할 수 없었습니다.

| 단계 | 수정 전 결과 |
|------|------|
| `POST /api/sms` | 400 `ALREADY_REGISTERED_PHONE_NUMBER` (데모 번호가 이미 회원으로 등록됨) |
| `POST /api/sms/verify` | 통과 (기존 데모 우회 존재) |
| `POST /api/auth/signup` | 409 `DUPLICATE_PHONE_NUMBER` |

`Member.phoneNumber`가 `unique = true`이므로 중복 검사만 우회해도 실제 저장이 불가능하여, 회원가입 단계도 함께 우회 처리하였습니다.

Resolves: #371

## 📃 작업내용

- 데모 번호/고정 코드 상수를 `global/sms/SmsDemoAccount`로 분리하였습니다. (`VerifyCodeServiceImpl`에 하드코딩되어 있던 값을 이동)
- SMS 발송 서비스 3곳(`SendSmsServiceImpl`, `SendResetPasswordSmsServiceImpl`, `SendFindNicknameSmsServiceImpl`)에 회원 존재 여부 검사보다 **먼저** 데모 번호 조기 반환을 추가하였습니다. 코드 생성·Redis 저장·실제 SMS 발송을 모두 생략합니다.
- 코드 검증 서비스 2곳(`VerifyResetPasswordCodeServiceImpl`, `VerifyFindNicknameCodeServiceImpl`)에 기존 `VerifyCodeServiceImpl`과 동일한 고정 코드(`000000`) 우회를 추가하였습니다.
- `SignUpServiceImpl.execute()` 최상단에 데모 번호 조기 반환을 추가하여 409 차단을 해소하였습니다.
- 위 6개 경로에 대한 단위 테스트를 추가하였습니다.

## 🙋‍♂️ 리뷰노트

**회원가입을 저장 없이 성공 처리한 이유**

`phone_number`가 unique 제약이고 데모 회원이 이미 존재하므로 실제 저장은 불가능합니다. 또한 신규 가입 회원은 `PENDING` 상태라 관리자 승인 전까지 로그인이 불가하여(`SignInServiceImpl`) 저장의 실익도 없습니다. 리뷰어는 가입 플로우를 끝까지 확인한 뒤 Review Notes의 데모 계정으로 로그인하게 됩니다. 심사 때마다 반복 사용 가능하고 DB 오염도 없습니다.

**배포 전 확인 부탁드립니다**

- 운영 DB의 `01011111111` 회원 행은 **삭제하면 안 됩니다.** 비밀번호 재설정·닉네임 찾기 최종 단계가 `findByPhoneNumber`로 해당 회원을 조회하므로 삭제 시 404가 발생합니다.
- 데모 번호와 `000000`을 아는 누구나 `PATCH /api/auth/password`로 데모 계정 비밀번호를 변경할 수 있습니다. 기존 `VerifyCodeServiceImpl` 우회에 이미 내재된 성질이지만 경로가 늘어났으므로, 데모 계정은 `ROLE_USER` 저권한·민감정보 없는 상태로 유지하는 편이 좋겠습니다.

**데모 번호를 yml 프로퍼티로 빼지 않은 이유**

번호 로테이션 요구가 실제로 발생한 적이 없어 기존 하드코딩 방식을 유지하고 상수 클래스로만 공유하였습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`) — 환경값/문서 변경 없음
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요? — `./gradlew test --tests '*Sms*' --tests '*SignUp*'` 통과
- [x] Merge 대상 브랜치가 올바른가요? — `develop`
- [x] PR과 관련 없는 작업이 있지는 않나요?
- [ ] 배포 후 운영 환경에서 데모 번호 회원가입 플로우 실제 확인

## 🎸 기타

전체 `./gradlew build`는 387/388 통과입니다. 실패 1건은 `ChatStreamConsumerWorker 통합 테스트`의 Testcontainers Docker 미가동 이슈로 이번 변경과 무관합니다.
