### PR TITLE
거래 상태 알림 추적 로그 추가 및 요청 로그 축소

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/service/impl/RequestTradeCompleteServiceImpl.java
@@ -190,6 +190,7 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
 
         // 확정 후에는 대기 중인 요청이 없으므로 requestedBySeller 는 null 이고,
         // requestedAt 은 방금 완료된 요청의 생성 시각을 유지한다. 조회 응답과 같은 값이다.
+        log.info("[TRADE-NOTIFY] publish(confirm) roomId={}, productId={}", chatRoom.getId(), product.getId());
         applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
                 chatRoom.getId(),
                 product.getId(),
@@ -218,6 +219,8 @@ public class RequestTradeCompleteServiceImpl implements RequestTradeCompleteServ
         ));
 
         // save() 로 @CreatedDate 가 채워지므로 조회 응답이 나중에 줄 값과 동일하다.
+        log.info("[TRADE-NOTIFY] publish(request) roomId={}, productId={}, requestedBySeller={}",
+                chatRoom.getId(), product.getId(), newTradeComplete.isRequestedBySeller());
         applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
                 chatRoom.getId(),
                 product.getId(),

--- a/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/notification/ChattingServerTradeStatusNotifierImpl.java
@@ -25,7 +25,7 @@ public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTrad
         if (!properties.isEnabled()) {
             // 설정이 비어 있으면 거래 상태가 채팅 서버에 전혀 전달되지 않는다.
             // 조용히 넘어가면 실시간 갱신이 죽은 것을 알 수 없으므로 남겨 둔다.
-            log.warn("chatting.server.url 이 설정되지 않아 거래 상태 변경을 채팅 서버에 전달하지 않습니다.");
+            log.error("[TRADE-NOTIFY] DISABLED at startup: chatting.server.url 이 비어 있어 거래 상태 변경이 채팅 서버에 전달되지 않습니다.");
             this.restClient = null;
             return;
         }
@@ -40,15 +40,25 @@ public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTrad
         }
 
         this.restClient = builder.build();
+        log.info("[TRADE-NOTIFY] enabled. baseUrl={}, secretConfigured={}, connectTimeout={}, readTimeout={}",
+                properties.url(),
+                properties.internalSecret() != null && !properties.internalSecret().isBlank(),
+                properties.connectTimeout(),
+                properties.readTimeout());
     }
 
     @Override
     public void notifyTradeStatusChanged(TradeStatusChangedEvent event) {
         if (restClient == null) {
+            log.error("[TRADE-NOTIFY] SKIPPED: chatting.server.url 이 비어 있음. roomId={}, productId={}",
+                    event.roomId(), event.productId());
             return;
         }
 
-        restClient.post()
+        log.info("[TRADE-NOTIFY] POST {}{} roomId={}, productId={}, completed={}, reserved={}",
+                properties.url(), TRADE_STATUS_PATH, event.roomId(), event.productId(), event.completed(), event.reserved());
+
+        var response = restClient.post()
                 .uri(TRADE_STATUS_PATH)
                 .contentType(MediaType.APPLICATION_JSON)
                 .header(INTERNAL_SECRET_HEADER, properties.internalSecret())
@@ -62,6 +72,9 @@ public class ChattingServerTradeStatusNotifierImpl implements ChattingServerTrad
                 ))
                 .retrieve()
                 .toBodilessEntity();
+
+        log.info("[TRADE-NOTIFY] chatting server responded {}. roomId={}, productId={}",
+                response.getStatusCode(), event.roomId(), event.productId());
     }
 
     /**

--- a/src/main/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListener.java
+++ b/src/main/java/team/startup/gwangsan/global/event/handler/TradeStatusChangedEventListener.java
@@ -19,11 +19,14 @@ public class TradeStatusChangedEventListener {
     @Async("asyncExecutor")
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handleTradeStatusChangedEvent(TradeStatusChangedEvent event) {
+        log.info("[TRADE-NOTIFY] listener entered. roomId={}, productId={}, completed={}, reserved={}",
+                event.roomId(), event.productId(), event.completed(), event.reserved());
         try {
             notifier.notifyTradeStatusChanged(event);
+            log.info("[TRADE-NOTIFY] listener done. roomId={}, productId={}", event.roomId(), event.productId());
         } catch (Exception e) {
-            log.warn(
-                    "Failed to notify chatting server of trade status change. roomId={}, productId={}, completed={}, reserved={}",
+            log.error(
+                    "[TRADE-NOTIFY] FAILED. roomId={}, productId={}, completed={}, reserved={}",
                     event.roomId(),
                     event.productId(),
                     event.completed(),

--- a/src/main/java/team/startup/gwangsan/global/filter/RequestLogFilter.java
+++ b/src/main/java/team/startup/gwangsan/global/filter/RequestLogFilter.java
@@ -3,8 +3,10 @@ package team.startup.gwangsan.global.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.nio.charset.StandardCharsets;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
@@ -14,6 +16,11 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 public class RequestLogFilter extends OncePerRequestFilter {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    // ponytail: 본문 로깅 상한. 넘으면 잘라서 찍는다.
+    // 이게 없으면 채팅방 목록 응답 수십 KB가 통째로 흘러들어 로그 파이프라인이 포화되고,
+    // 뒤따르는 로그가 통째로 유실된다.
+    private static final int MAX_BODY_LOG_LENGTH = 2000;
 
     private static final String SENSITIVE_FIELDS_PATTERN;
 
@@ -49,9 +56,7 @@ public class RequestLogFilter extends OncePerRequestFilter {
         if (contentType != null && contentType.contains("application/json")) {
             try {
                 Object json = OBJECT_MAPPER.readValue(body, Object.class);
-                return OBJECT_MAPPER
-                        .writerWithDefaultPrettyPrinter()
-                        .writeValueAsString(json);
+                return OBJECT_MAPPER.writeValueAsString(json);
             } catch (Exception ignore) {
             }
         }
@@ -59,55 +64,51 @@ public class RequestLogFilter extends OncePerRequestFilter {
         return body;
     }
 
+    private String truncate(String body) {
+        if (body.length() <= MAX_BODY_LOG_LENGTH) {
+            return body;
+        }
+        return body.substring(0, MAX_BODY_LOG_LENGTH) + "...(truncated, total " + body.length() + " chars)";
+    }
+
     private String maskBody(String body) {
         if (body == null || body.isBlank()) return body;
         return body.replaceAll(SENSITIVE_FIELDS_PATTERN, "$1\"****\"");
     }
 
-    private String maskHeader(String name, String value) {
-        if ("authorization".equalsIgnoreCase(name) && value != null) {
-            return value.startsWith("Bearer ") ? "Bearer ****" : "****";
-        }
-        return value;
+    private String bodyForLog(byte[] content, String characterEncoding, String contentType) {
+        return truncate(maskBody(formatBody(toString(content, characterEncoding), contentType)));
     }
 
     @Override
-    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+    public void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
         ContentCachingRequestWrapper req = new ContentCachingRequestWrapper(request);
         ContentCachingResponseWrapper res = new ContentCachingResponseWrapper(response);
 
-        log.info("=========================");
-        log.info("client ip = {}", req.getRemoteAddr());
-        log.info("request method = {}", req.getMethod());
-        log.info("request url = {}", req.getRequestURI());
-        log.info("client info = {}", req.getHeader("User-Agent"));
-
-        req.getHeaderNames().asIterator()
-                .forEachRemaining(name -> log.info("header {} = {}", name, maskHeader(name, req.getHeader(name))));
+        long startedAt = System.currentTimeMillis();
 
         try {
             filterChain.doFilter(req, res);
+        } catch (Exception e) {
+            log.error("{} {} failed. client={}", req.getMethod(), req.getRequestURI(), req.getRemoteAddr(), e);
+            throw e;
+        } finally {
+            String requestBody = bodyForLog(req.getContentAsByteArray(), req.getCharacterEncoding(), req.getContentType());
+            String responseBody = bodyForLog(res.getContentAsByteArray(), res.getCharacterEncoding(), res.getContentType());
 
-            String requestBody = toString(req.getContentAsByteArray(), req.getCharacterEncoding());
-            String prettyRequestBody = maskBody(formatBody(requestBody, req.getContentType()));
-            if (!prettyRequestBody.isBlank()) {
-                log.info("request body =\n{}", prettyRequestBody);
-            }
-
-            String responseBody = toString(res.getContentAsByteArray(), res.getCharacterEncoding());
-            String prettyResponseBody = maskBody(formatBody(responseBody, res.getContentType()));
-            log.info("response status = {}", res.getStatus());
-            if (!prettyResponseBody.isBlank()) {
-                log.info("response body =\n{}", prettyResponseBody);
-            }
+            log.info("{} {} -> {} ({}ms) client={} ua={} requestBody={} responseBody={}",
+                    req.getMethod(),
+                    req.getRequestURI(),
+                    res.getStatus(),
+                    System.currentTimeMillis() - startedAt,
+                    req.getRemoteAddr(),
+                    req.getHeader("User-Agent"),
+                    requestBody,
+                    responseBody
+            );
 
             res.copyBodyToResponse();
-        } catch (Exception e) {
-            log.error("=========================");
-            log.error("error = {}", e.getMessage());
-            log.error("=========================");
         }
-
-        log.info("=========================");
     }
 }


### PR DESCRIPTION
## 💡 배경 및 개요

거래 완료 요청(`POST /api/post/trade`)이 채팅방에 실시간 반영되지 않는 문제를 추적하던 중, **어느 구간에서 끊기는지 로그로 판별할 수 없는 상태**임을 확인하였습니다.

운영 로그 확인 결과 해당 요청은 `204`로 정상 처리되고 있으나, 채팅 서버에는 아무것도 도달하지 않고 있었습니다. 그럼에도 `TradeStatusChangedEvent` 발행부터 채팅 서버 HTTP 호출까지의 전 구간에 로그가 없어, 아래 지점들이 모두 **무음으로 실패**할 수 있었습니다.

- `chatting.server.url`이 비어 있으면 `restClient`가 `null`이 되어 로그 없이 `return`
- 이벤트 발행 / 리스너 진입 / HTTP 호출 성공 여부를 확인할 방법 없음

또한 `RequestLogFilter`가 요청 1건당 20줄 이상 + 응답 본문 전체(채팅방 목록 기준 수십 KB)를 기록하고 있어, 30일 범위로 조회해도 마지막 1초치 로그만 확인되는 상태였습니다. 필요한 로그가 노이즈에 묻혀 조회 자체가 불가능하였습니다.

관련 이슈: #319

## 📃 작업내용

**1. 거래 상태 알림 전 구간 추적 로그 추가**

`[TRADE-NOTIFY]` 태그를 붙여 하나의 검색어로 전 구간을 추적할 수 있도록 하였습니다.

- `RequestTradeCompleteServiceImpl` — 이벤트 발행 시점(확정/요청) 로그 추가
- `TradeStatusChangedEventListener` — 리스너 진입·완료 로그 추가, 실패 로그를 `warn`에서 `error`로 상향
- `ChattingServerTradeStatusNotifierImpl`
  - 기동 시 활성화 여부 및 시크릿 설정 여부 기록 (비활성 시 `error`)
  - HTTP 호출 직전 대상 URL 기록, 응답 상태 코드 기록

**2. 요청 로그 축소 및 응답 유실 방지**

- 요청 1건당 20줄 이상 → **1줄**로 축소 (헤더 개별 로깅 제거, 처리 시간 추가)
- 본문 로깅에 2000자 상한 적용
- `catch`가 예외를 삼키던 문제 수정 — 스택트레이스를 기록하고 재던져 `GlobalExceptionHandler`가 처리하도록 변경
- `copyBodyToResponse()`를 `finally`로 이동 — 예외 발생 시 응답 본문이 클라이언트에 전달되지 않던 문제 해결

## 🙋‍♂️ 리뷰노트

- 이번 PR은 **원인 수정이 아니라 원인 특정을 위한 관측성 확보**가 목적입니다. 배포 후 `TRADE-NOTIFY`로 검색하여 로그가 끊기는 지점을 확인하면 원인이 확정됩니다.
- 기동 로그에 `DISABLED at startup`이 찍힐 경우 `CHATTING_SERVER_URL` 환경값 주입 실패가 원인입니다.
- `RequestLogFilter`의 헤더 개별 로깅은 전부 제거하였습니다. 인증 디버깅에 필요해지면 `authorization` 한 건만 다시 추가하면 됩니다.
- `RestClient` 타임아웃은 이번에 넣지 않았습니다. `listener entered`에서 로그가 끊기면 그때 추가하는 것이 맞다고 판단하였습니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

`RequestLogFilter` 변경은 거래 상태 알림과 별개 이슈이나, 이 로그 노이즈 때문에 원인 추적 자체가 불가능하여 같은 PR에 포함하였습니다. 커밋은 분리해두었습니다.
