### PR TITLE
채팅 메시지 전송 시 차단 상태 서버 검증 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/entity/ChatRoom.java
@@ -61,6 +61,10 @@ public class ChatRoom {
         return buyer.getId().equals(member.getId()) || seller.getId().equals(member.getId());
     }
 
+    public Member getOtherMember(Member member) {
+        return buyer.getId().equals(member.getId()) ? seller : buyer;
+    }
+
     public void hideFor(Member member, LocalDateTime hiddenAt) {
         if (buyer.getId().equals(member.getId())) {
             this.hiddenByBuyerAt = hiddenAt;

--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/ChatController.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/ChatController.java
@@ -15,6 +15,7 @@ import team.startup.gwangsan.domain.chat.service.FindChatMessageByRoomIdService;
 import team.startup.gwangsan.domain.chat.service.FindRoomsByCurrentUserService;
 import team.startup.gwangsan.domain.chat.service.ReadChatMessageService;
 import team.startup.gwangsan.domain.chat.service.FindRoomIdByProductIdService;
+import team.startup.gwangsan.domain.chat.service.ValidateChatSendableService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,6 +31,7 @@ public class ChatController {
     private final FindRoomsByCurrentUserService findRoomsByCurrentUserService;
     private final FindRoomIdByProductIdService findRoomIdByProductIdService;
     private final DeleteChatRoomService deleteChatRoomService;
+    private final ValidateChatSendableService validateChatSendableService;
 
     @PostMapping("/room/{product_id}")
     public ResponseEntity<CreateChatRoomResponse> createChatRoom(@PathVariable("product_id") Long productId) {
@@ -64,6 +66,13 @@ public class ChatController {
     public ResponseEntity<GetRoomIdResponse> getRoom(@PathVariable("product_id") Long productId) {
         GetRoomIdResponse response = findRoomIdByProductIdService.execute(productId);
         return ResponseEntity.ok(response);
+    }
+
+    // 채팅 서버가 소켓 메시지를 브로드캐스트하기 전에 호출한다.
+    @GetMapping("/room/{room_id}/sendable")
+    public ResponseEntity<Void> validateSendable(@PathVariable("room_id") Long roomId) {
+        validateChatSendableService.execute(roomId);
+        return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/room/{room_id}")

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/ValidateChatSendableService.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/ValidateChatSendableService.java
@@ -1,0 +1,5 @@
+package team.startup.gwangsan.domain.chat.service;
+
+public interface ValidateChatSendableService {
+    void execute(Long roomId);
+}

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
@@ -24,6 +24,7 @@ import team.startup.gwangsan.domain.notification.entity.DeviceToken;
 import team.startup.gwangsan.domain.notification.entity.constant.NotificationType;
 import team.startup.gwangsan.domain.notification.repository.DeviceTokenRepository;
 import team.startup.gwangsan.global.event.SendNotificationEvent;
+import team.startup.gwangsan.global.util.BlockValidator;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -39,6 +40,7 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
     private final ChatMessageImageRepository chatMessageImageRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final DeviceTokenRepository deviceTokenRepository;
+    private final BlockValidator blockValidator;
 
     @Override
     @Transactional
@@ -46,6 +48,9 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
         Member member = memberRepository.findById(senderId).orElseThrow(NotFoundMemberException::new);
         ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomId(roomId)
                 .orElseThrow(NotFoundChatRoomException::new);
+
+        Member otherMember = chatRoom.getOtherMember(member);
+        blockValidator.validate(member, otherMember);
 
         ChatMessage chatMessage = ChatMessage.builder()
                 .id(messageId)
@@ -70,8 +75,6 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
         // 나간 방에 새 메시지가 오면 양쪽 모두에게 다시 보여야 한다.
         chatRoom.unhideFor(chatRoom.getBuyer());
         chatRoom.unhideFor(chatRoom.getSeller());
-
-        Member otherMember = member.getId().equals(chatRoom.getBuyer().getId()) ? chatRoom.getSeller() : chatRoom.getBuyer();
 
         List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserId(otherMember.getId());
         if (!deviceTokens.isEmpty()) {

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/ValidateChatSendableServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/ValidateChatSendableServiceImpl.java
@@ -1,0 +1,36 @@
+package team.startup.gwangsan.domain.chat.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.chat.service.ValidateChatSendableService;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.global.util.BlockValidator;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+@Service
+@RequiredArgsConstructor
+public class ValidateChatSendableServiceImpl implements ValidateChatSendableService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final MemberUtil memberUtil;
+    private final BlockValidator blockValidator;
+
+    @Override
+    @Transactional(readOnly = true)
+    public void execute(Long roomId) {
+        Member member = memberUtil.getCurrentMember();
+        ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomId(roomId)
+                .orElseThrow(NotFoundChatRoomException::new);
+
+        // 참여자가 아니면 방의 존재 자체를 숨긴다 (조회 API 와 동일 정책).
+        if (!chatRoom.isParticipant(member)) {
+            throw new NotFoundChatRoomException();
+        }
+
+        blockValidator.validate(member, chatRoom.getOtherMember(member));
+    }
+}

--- a/src/main/java/team/startup/gwangsan/global/chat/stream/ChatStreamMessageProcessor.java
+++ b/src/main/java/team/startup/gwangsan/global/chat/stream/ChatStreamMessageProcessor.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.stereotype.Component;
+import team.startup.gwangsan.domain.block.exception.BlockedMemberException;
 import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
 import team.startup.gwangsan.domain.chat.exception.InvalidChatStreamPayloadException;
 import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
@@ -79,11 +80,13 @@ public class ChatStreamMessageProcessor {
     }
 
     /**
-     * 재시도해도 결과가 달라지지 않는 실패인지. 없는 방/회원은 나중에 다시 시도해도
-     * 그대로 실패하므로 retry 횟수만 소모하지 말고 바로 DLQ 로 보낸다.
+     * 재시도해도 결과가 달라지지 않는 실패인지. 없는 방/회원, 차단 관계는 나중에 다시
+     * 시도해도 그대로 실패하므로 retry 횟수만 소모하지 말고 바로 DLQ 로 보낸다.
      */
     private boolean isPermanentFailure(Exception e) {
-        return e instanceof NotFoundChatRoomException || e instanceof NotFoundMemberException;
+        return e instanceof NotFoundChatRoomException
+                || e instanceof NotFoundMemberException
+                || e instanceof BlockedMemberException;
     }
 
     private List<Long> parseImageIds(String raw) {

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImplTest.java
@@ -26,7 +26,9 @@ import team.startup.gwangsan.domain.member.repository.MemberRepository;
 import team.startup.gwangsan.domain.notification.entity.DeviceToken;
 import team.startup.gwangsan.domain.notification.entity.constant.NotificationType;
 import team.startup.gwangsan.domain.notification.repository.DeviceTokenRepository;
+import team.startup.gwangsan.domain.block.exception.BlockedMemberException;
 import team.startup.gwangsan.global.event.SendNotificationEvent;
+import team.startup.gwangsan.global.util.BlockValidator;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -48,6 +50,7 @@ class SaveChatMessageServiceImplTest {
     @Mock private ChatMessageImageRepository chatMessageImageRepository;
     @Mock private ApplicationEventPublisher applicationEventPublisher;
     @Mock private DeviceTokenRepository deviceTokenRepository;
+    @Mock private BlockValidator blockValidator;
 
     @InjectMocks
     private SaveChatMessageServiceImpl service;
@@ -73,6 +76,7 @@ class SaveChatMessageServiceImplTest {
             when(otherMember.getId()).thenReturn(2L);
             when(chatRoom.getBuyer()).thenReturn(sender);
             when(chatRoom.getSeller()).thenReturn(otherMember);
+            when(chatRoom.getOtherMember(sender)).thenReturn(otherMember);
             when(memberRepository.findById(1L)).thenReturn(Optional.of(sender));
             when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
             when(chatMessageRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -230,6 +234,7 @@ class SaveChatMessageServiceImplTest {
             when(sellerMember.getId()).thenReturn(3L);
             when(buyerMember.getId()).thenReturn(4L);
             when(room.getBuyer()).thenReturn(buyerMember);
+            when(room.getOtherMember(sellerMember)).thenReturn(buyerMember);
             when(memberRepository.findById(3L)).thenReturn(Optional.of(sellerMember));
             when(chatRoomRepository.findChatRoomByRoomId(20L)).thenReturn(Optional.of(room));
             when(chatMessageRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -238,6 +243,22 @@ class SaveChatMessageServiceImplTest {
             service.execute(1L, 20L, "안녕", null, MessageType.TEXT, 3L, now);
 
             verify(deviceTokenRepository).findAllByUserId(4L);
+        }
+
+        @Test
+        @DisplayName("발신자와 상대방이 차단 관계면 BlockedMemberException 을 던지고 메시지를 저장하지 않는다")
+        void it_throws_BlockedMemberException_when_blocked() {
+            when(chatRoom.getOtherMember(sender)).thenReturn(otherMember);
+            when(memberRepository.findById(1L)).thenReturn(Optional.of(sender));
+            when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
+            doThrow(new BlockedMemberException()).when(blockValidator).validate(sender, otherMember);
+
+            assertThatThrownBy(() -> service.execute(1L, 10L, "안녕", null, MessageType.TEXT, 1L, now))
+                    .isInstanceOf(BlockedMemberException.class);
+
+            verify(chatMessageRepository, never()).save(any());
+            verifyNoInteractions(deviceTokenRepository);
+            verifyNoInteractions(applicationEventPublisher);
         }
     }
 }

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/ValidateChatSendableServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/ValidateChatSendableServiceImplTest.java
@@ -1,0 +1,98 @@
+package team.startup.gwangsan.domain.chat.service.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import team.startup.gwangsan.domain.block.exception.BlockedMemberException;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.global.util.BlockValidator;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("ValidateChatSendableServiceImpl 단위 테스트")
+class ValidateChatSendableServiceImplTest {
+
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private MemberUtil memberUtil;
+    @Mock private BlockValidator blockValidator;
+
+    @InjectMocks
+    private ValidateChatSendableServiceImpl service;
+
+    @Nested
+    @DisplayName("execute() 메서드는")
+    class Describe_execute {
+
+        @Test
+        @DisplayName("채팅방이 존재하지 않으면 NotFoundChatRoomException 을 던진다")
+        void it_throws_NotFoundChatRoomException_when_room_not_found() {
+            when(memberUtil.getCurrentMember()).thenReturn(mock(Member.class));
+            when(chatRoomRepository.findChatRoomByRoomId(1L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> service.execute(1L))
+                    .isInstanceOf(NotFoundChatRoomException.class);
+
+            verifyNoInteractions(blockValidator);
+        }
+
+        @Test
+        @DisplayName("요청자가 채팅방의 참여자가 아니면 NotFoundChatRoomException 을 던진다")
+        void it_throws_NotFoundChatRoomException_when_member_is_not_participant() {
+            Member member = mock(Member.class);
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(memberUtil.getCurrentMember()).thenReturn(member);
+            when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
+            when(chatRoom.isParticipant(member)).thenReturn(false);
+
+            assertThatThrownBy(() -> service.execute(10L))
+                    .isInstanceOf(NotFoundChatRoomException.class);
+
+            verifyNoInteractions(blockValidator);
+        }
+
+        @Test
+        @DisplayName("상대방과 차단 관계면 BlockedMemberException 을 던진다")
+        void it_throws_BlockedMemberException_when_blocked() {
+            Member member = mock(Member.class);
+            Member otherMember = mock(Member.class);
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(memberUtil.getCurrentMember()).thenReturn(member);
+            when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
+            when(chatRoom.isParticipant(member)).thenReturn(true);
+            when(chatRoom.getOtherMember(member)).thenReturn(otherMember);
+            doThrow(new BlockedMemberException()).when(blockValidator).validate(member, otherMember);
+
+            assertThatThrownBy(() -> service.execute(10L))
+                    .isInstanceOf(BlockedMemberException.class);
+        }
+
+        @Test
+        @DisplayName("참여자이고 차단 관계가 없으면 예외 없이 통과한다")
+        void it_passes_when_participant_and_not_blocked() {
+            Member member = mock(Member.class);
+            Member otherMember = mock(Member.class);
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            when(memberUtil.getCurrentMember()).thenReturn(member);
+            when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
+            when(chatRoom.isParticipant(member)).thenReturn(true);
+            when(chatRoom.getOtherMember(member)).thenReturn(otherMember);
+
+            assertThatCode(() -> service.execute(10L)).doesNotThrowAnyException();
+
+            verify(blockValidator).validate(member, otherMember);
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/global/chat/stream/ChatStreamMessageProcessorTest.java
+++ b/src/test/java/team/startup/gwangsan/global/chat/stream/ChatStreamMessageProcessorTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.springframework.data.redis.connection.stream.MapRecord;
 import org.springframework.data.redis.connection.stream.RecordId;
+import team.startup.gwangsan.domain.block.exception.BlockedMemberException;
 import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
 
 import java.util.List;
@@ -142,6 +143,23 @@ class ChatStreamMessageProcessorTest {
             ArgumentCaptor<Integer> attemptCaptor = ArgumentCaptor.forClass(Integer.class);
             verify(redisAdapter).sendToRetry(eq(streamKey), eq(record), attemptCaptor.capture(), any());
             assertThat(attemptCaptor.getValue()).isEqualTo(1);
+            verify(redisAdapter).ack(eq(streamKey), any(RecordId.class));
+        }
+
+        @Test
+        @DisplayName("차단 관계면 재시도하지 않고 바로 DLQ로 보낸다")
+        void it_sends_to_dlq_without_retry_when_blocked() {
+            doThrow(new BlockedMemberException()).when(handler).handle(any(ChatStreamMessage.class));
+
+            MapRecord<String, String, String> record = MapRecord.create(
+                    streamKey,
+                    Map.of("messageId", "999", "roomId", "42", "senderId", "7", "content", "hello", "createdAt", "1700000000000")
+            ).withId(RecordId.of("1700000000000-0"));
+
+            processor.process(streamKey, record, 0);
+
+            verify(redisAdapter).sendToDlq(eq(streamKey), eq(record), any());
+            verify(redisAdapter, never()).sendToRetry(any(), any(), anyInt(), any());
             verify(redisAdapter).ack(eq(streamKey), any(RecordId.class));
         }
 


### PR DESCRIPTION
## 💡 배경 및 개요

프론트엔드에서 "차단한 사용자와의 채팅방" UX를 구현하였으나, 이는 클라이언트 UI 레벨의 제어일 뿐이라 변조된 클라이언트나 기존 소켓 연결로 우회 전송이 가능하였습니다. `SaveChatMessageServiceImpl.execute()` 에는 차단 여부 검증이 전혀 없었습니다.

작업 중 확인한 사항으로, 채팅 서버(NestJS)는 Redis Stream 에 publish 한 **직후 곧바로 소켓 브로드캐스트**를 수행합니다. 따라서 스프링에만 검증을 추가하면 DB 저장과 FCM 알림은 막히지만 상대방 화면에는 메시지가 실시간으로 노출됩니다. 이를 막기 위해 채팅 서버가 전송 전에 호출할 수 있는 조회 API 를 함께 추가하였습니다.

Apple App Store 심사 가이드라인 1.2 (User-Generated Content) 대응 작업의 일환입니다.

Resolves: #376

## 📃 작업내용

- `SaveChatMessageServiceImpl` 에 `BlockValidator` 검증을 추가하여, 차단 관계이면 메시지를 저장하지 않고 `BlockedMemberException`(403) 을 던지도록 하였습니다
- `GET /api/chat/room/{room_id}/sendable` 및 `ValidateChatSendableService` 를 추가하였습니다. 채팅 서버가 브로드캐스트 전에 호출하여 전송 가능 여부를 확인합니다
- `ChatRoom.getOtherMember(member)` 를 추가하여 여러 곳에 흩어져 있던 상대방 판별 삼항 연산자를 엔티티로 옮겼습니다
- `ChatStreamMessageProcessor.isPermanentFailure()` 에 `BlockedMemberException` 을 추가하여, 차단 메시지가 재시도를 소모하지 않고 바로 DLQ 로 가도록 하였습니다
- 위 변경에 대한 단위 테스트를 추가하였습니다

## 🙋‍♂️ 리뷰노트

- **차단 검사는 이미 양방향입니다.** `BlockValidator` 가 사용하는 `existsBlockBetween` 이 blocker/blocked 를 뒤집어 OR 조회하므로, 일방 차단이어도 양쪽 발신이 모두 막힙니다
- **`@CheckBlocked` AOP 는 사용하지 않았습니다.** `BlockAspect` 가 `MemberUtil.getCurrentMember()`(SecurityContext) 에 의존하는데, Redis Stream 컨슈머 스레드에는 인증 컨텍스트가 없어 사용할 수 없습니다
- **비참여자는 `NotFoundChatRoomException` 으로 처리하였습니다.** 기존 `FindChatMessageByRoomIdServiceImpl` 과 동일하게 방의 존재 자체를 숨기는 정책을 따랐습니다
- **`SecurityConfig` 는 수정하지 않았습니다.** `/api/chat/**` 에 명시 매처가 없어 `anyRequest().hasAnyAuthority(...)` 로 이미 인증이 요구됩니다
- **차단 메시지가 DLQ 에 쌓입니다.** 차단은 실패가 아니라 정상 거부이므로 운영 노이즈가 될 수 있습니다. 조용히 drop 하는 편이 낫다는 의견이 있으면 반영하겠습니다
- **배포 순서 주의:** 채팅 서버(`feat/chat-block-guard`) 가 이 엔드포인트를 fail-closed 로 호출하므로, **이 PR 이 먼저 배포되어야 합니다.** 채팅 서버가 먼저 나가면 404 로 인해 전체 메시지 전송이 막힙니다

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

- 신규 엔드포인트가 추가되었으므로 API 문서 공유가 필요합니다
- 채팅 서버 변경은 별도 PR 로 올립니다 (`Gwangsan-Chatting-Server`)
- `ChatStreamConsumerIntegrationTest` 는 로컬 Docker 환경 문제로 실행하지 못하였습니다. 나머지 439개 테스트는 통과하였습니다
