### PR TITLE
거래 내역 조회 응답에 거래 상대방 정보 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/GetTradeHistoryResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/GetTradeHistoryResponse.java
@@ -10,6 +10,7 @@ public record GetTradeHistoryResponse(
         TradeRole role,
         TradeStatus status,
         LocalDateTime completedAt,
+        GetTradeMemberResponse otherMember,
         GetTradeProductResponse product
 ) {
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/GetTradeMemberResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/GetTradeMemberResponse.java
@@ -1,0 +1,7 @@
+package team.startup.gwangsan.domain.trade.presentation.dto.response;
+
+public record GetTradeMemberResponse(
+        Long memberId,
+        String nickname
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/impl/TradeCompleteCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/custom/impl/TradeCompleteCustomRepositoryImpl.java
@@ -125,6 +125,8 @@ public class TradeCompleteCustomRepositoryImpl implements TradeCompleteCustomRep
         return queryFactory
                 .selectFrom(tradeComplete)
                 .join(tradeComplete.product).fetchJoin()
+                .join(tradeComplete.buyer).fetchJoin()
+                .join(tradeComplete.seller).fetchJoin()
                 .where(
                         tradeComplete.buyer.eq(member).or(tradeComplete.seller.eq(member)),
                         tradeComplete.status.eq(status)

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/FindMyTradeHistoryServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/FindMyTradeHistoryServiceImpl.java
@@ -10,6 +10,7 @@ import team.startup.gwangsan.domain.post.repository.ProductImageRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeHistoryResponse;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeMemberResponse;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeProductResponse;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.constant.TradeRole;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
@@ -58,12 +59,14 @@ public class FindMyTradeHistoryServiceImpl implements FindMyTradeHistoryService 
                     TradeRole role = trade.getBuyer().getId().equals(member.getId())
                             ? TradeRole.BUYER
                             : TradeRole.SELLER;
+                    Member otherMember = role == TradeRole.BUYER ? trade.getSeller() : trade.getBuyer();
 
                     return new GetTradeHistoryResponse(
                             trade.getId(),
                             role,
                             trade.getStatus(),
                             trade.getCompletedAt(),
+                            new GetTradeMemberResponse(otherMember.getId(), otherMember.getNickname()),
                             new GetTradeProductResponse(
                                     product.getId(),
                                     product.getTitle(),

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/FindMyTradeHistoryServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/FindMyTradeHistoryServiceImplTest.java
@@ -45,9 +45,10 @@ class FindMyTradeHistoryServiceImplTest {
     @InjectMocks
     private FindMyTradeHistoryServiceImpl service;
 
-    private Member memberOf(Long id) {
+    private Member memberOf(Long id, String nickname) {
         Member member = mock(Member.class);
         lenient().when(member.getId()).thenReturn(id);
+        lenient().when(member.getNickname()).thenReturn(nickname);
         return member;
     }
 
@@ -64,6 +65,7 @@ class FindMyTradeHistoryServiceImplTest {
         lenient().when(trade.getId()).thenReturn(id);
         lenient().when(trade.getProduct()).thenReturn(product);
         lenient().when(trade.getBuyer()).thenReturn(buyer);
+        lenient().when(trade.getSeller()).thenReturn(seller);
         lenient().when(trade.getStatus()).thenReturn(TradeStatus.COMPLETED);
         lenient().when(trade.getCompletedAt()).thenReturn(completedAt);
         return trade;
@@ -87,8 +89,8 @@ class FindMyTradeHistoryServiceImplTest {
         @Test
         @DisplayName("내가 buyer 인 거래는 role 을 BUYER 로, seller 인 거래는 SELLER 로 내려준다")
         void it_maps_role_by_whether_i_am_buyer_or_seller() {
-            Member me = memberOf(ME_ID);
-            Member opponent = memberOf(OPPONENT_ID);
+            Member me = memberOf(ME_ID, "나");
+            Member opponent = memberOf(OPPONENT_ID, "상대방");
 
             Product bought = productOf(1L, "내가 산 물건", 5000);
             Product sold = productOf(2L, "내가 판 물건", 10000);
@@ -111,19 +113,23 @@ class FindMyTradeHistoryServiceImplTest {
             assertThat(first.role()).isEqualTo(TradeRole.BUYER);
             assertThat(first.status()).isEqualTo(TradeStatus.COMPLETED);
             assertThat(first.completedAt()).isEqualTo(LocalDateTime.of(2026, 8, 20, 10, 0));
+            assertThat(first.otherMember().memberId()).isEqualTo(OPPONENT_ID);
+            assertThat(first.otherMember().nickname()).isEqualTo("상대방");
             assertThat(first.product().productId()).isEqualTo(1L);
             assertThat(first.product().title()).isEqualTo("내가 산 물건");
             assertThat(first.product().gwangsan()).isEqualTo(5000);
 
             assertThat(result.get(1).role()).isEqualTo(TradeRole.SELLER);
+            assertThat(result.get(1).otherMember().memberId()).isEqualTo(OPPONENT_ID);
+            assertThat(result.get(1).otherMember().nickname()).isEqualTo("상대방");
             assertThat(result.get(1).product().title()).isEqualTo("내가 판 물건");
         }
 
         @Test
         @DisplayName("상품 이미지가 여러 장이면 먼저 조회된 것을 대표 이미지로 내려준다")
         void it_picks_first_image_as_thumbnail() {
-            Member me = memberOf(ME_ID);
-            Member opponent = memberOf(OPPONENT_ID);
+            Member me = memberOf(ME_ID, "나");
+            Member opponent = memberOf(OPPONENT_ID, "상대방");
             Product product = productOf(1L, "사진 여러 장", 5000);
             TradeComplete trade = tradeOf(11L, product, me, opponent, LocalDateTime.of(2026, 8, 20, 10, 0));
 
@@ -145,8 +151,8 @@ class FindMyTradeHistoryServiceImplTest {
         @Test
         @DisplayName("이미지가 없는 상품은 대표 이미지를 null 로 내려준다")
         void it_returns_null_image_when_product_has_no_image() {
-            Member me = memberOf(ME_ID);
-            Member opponent = memberOf(OPPONENT_ID);
+            Member me = memberOf(ME_ID, "나");
+            Member opponent = memberOf(OPPONENT_ID, "상대방");
             Product product = productOf(1L, "사진 없음", 5000);
             TradeComplete trade = tradeOf(11L, product, me, opponent, null);
 
@@ -164,7 +170,7 @@ class FindMyTradeHistoryServiceImplTest {
         @Test
         @DisplayName("거래가 없으면 빈 목록을 반환하고 이미지를 조회하지 않는다")
         void it_returns_empty_list_without_querying_images() {
-            Member me = memberOf(ME_ID);
+            Member me = memberOf(ME_ID, "나");
 
             when(memberUtil.getCurrentMember()).thenReturn(me);
             when(tradeCompleteRepository.findAllByMemberAndStatus(me, TradeStatus.COMPLETED))
@@ -179,7 +185,7 @@ class FindMyTradeHistoryServiceImplTest {
         @Test
         @DisplayName("요청한 status 를 그대로 조회 조건에 넘긴다")
         void it_passes_requested_status_to_repository() {
-            Member me = memberOf(ME_ID);
+            Member me = memberOf(ME_ID, "나");
 
             when(memberUtil.getCurrentMember()).thenReturn(me);
             when(tradeCompleteRepository.findAllByMemberAndStatus(me, TradeStatus.PENDING))


### PR DESCRIPTION
## Summary
- `GET /api/trade/history`는 이미 `TradeComplete.buyer`/`seller` 기준으로 거래 당사자 관점(구매/판매)의 완료 내역을 조회하고 있어, 게시글 작성자가 아니어도(상대방 게시글에서 거래한 케이스 포함) 내 거래 내역을 모두 커버하고 있었습니다.
- 다만 응답에 거래 상대방(구매자 쪽에는 판매자, 판매자 쪽에는 구매자) 정보가 없어 프론트에서 이를 표시할 수 없었던 부분을 보완했습니다.
- `GetTradeHistoryResponse`에 `otherMember(memberId, nickname)` 필드를 추가하고, `FindMyTradeHistoryServiceImpl`에서 role에 따라 상대방을 채워 내려주도록 수정했습니다.
- `TradeCompleteCustomRepositoryImpl#findAllByMemberAndStatus`에 `buyer`/`seller` fetch join을 추가해 상대방 조회 시 N+1이 발생하지 않도록 했습니다.

Closes #375

## Test plan
- [ ] `FindMyTradeHistoryServiceImplTest` 단위 테스트 통과 확인 (otherMember 필드 검증 추가)
- [ ] `GET /api/trade/history?status=COMPLETED` 호출 시 buyer/seller 각 케이스에서 `otherMember`가 올바르게 채워지는지 수동 확인