### PR TITLE
채팅 조회 성능 개선

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/repository/custom/impl/ChatRoomCustomRepositoryImpl.java
@@ -176,22 +176,20 @@ public class ChatRoomCustomRepositoryImpl implements ChatRoomCustomRepository {
                 .collect(Collectors.joining(", "));
 
         String sql = """
-                SELECT room_id, message_id, content, message_type, created_at
-                FROM (
-                    SELECT
-                        room_id,
-                        message_id,
-                        content,
-                        message_type,
-                        created_at,
-                        ROW_NUMBER() OVER (
-                            PARTITION BY room_id
-                            ORDER BY created_at DESC, message_id DESC
-                        ) AS row_num
-                    FROM tbl_chat_message
-                    WHERE room_id IN (%s)
-                ) ranked_message
-                WHERE row_num = 1
+                SELECT message.room_id, message.message_id, message.content,
+                       message.message_type, message.created_at
+                FROM tbl_chat_message message
+                WHERE message.message_id IN (
+                    SELECT (
+                        SELECT newest.message_id
+                        FROM tbl_chat_message newest
+                        WHERE newest.room_id = room.room_id
+                        ORDER BY newest.created_at DESC, newest.message_id DESC
+                        LIMIT 1
+                    )
+                    FROM tbl_chat_room room
+                    WHERE room.room_id IN (%s)
+                )
                 """.formatted(placeholders);
 
         Query query = entityManager.createNativeQuery(sql);

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/TradeCompleteRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/TradeCompleteRepository.java
@@ -10,10 +10,29 @@ import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.repository.custom.TradeCompleteCustomRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface TradeCompleteRepository extends JpaRepository<TradeComplete, Long>, TradeCompleteCustomRepository {
+    interface TradeStateProjection {
+        TradeStatus getStatus();
+        Boolean getRequestedBySeller();
+        LocalDateTime getCreatedAt();
+    }
+
     Optional<TradeComplete> findByProductAndBuyerAndSellerAndStatus(Product product, Member buyer, Member seller, TradeStatus tradeStatus);
+
+    @Query("""
+            SELECT t.status AS status, t.requestedBySeller AS requestedBySeller, t.createdAt AS createdAt
+            FROM TradeComplete t
+            WHERE t.product = :product AND t.buyer = :buyer AND t.seller = :seller
+              AND t.status IN (team.startup.gwangsan.domain.trade.entity.constant.TradeStatus.PENDING,
+                               team.startup.gwangsan.domain.trade.entity.constant.TradeStatus.COMPLETED)
+            """)
+    List<TradeStateProjection> findTradeState(@Param("product") Product product,
+                                               @Param("buyer") Member buyer,
+                                               @Param("seller") Member seller);
 
     Optional<TradeComplete> findByProductAndStatus(Product product, TradeStatus tradeStatus);
 

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/TradeStateReader.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/TradeStateReader.java
@@ -5,11 +5,12 @@ import org.springframework.stereotype.Component;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
-import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository.TradeStateProjection;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -25,16 +26,16 @@ public class TradeStateReader {
     private final TradeCompleteRepository tradeCompleteRepository;
 
     public TradeStateSnapshot read(Product product, Member buyer, Member seller) {
-        Optional<TradeComplete> pending = tradeCompleteRepository
-                .findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING);
+        List<TradeStateProjection> states = tradeCompleteRepository.findTradeState(product, buyer, seller);
+        Optional<TradeStateProjection> pending = find(states, TradeStatus.PENDING);
 
         return new TradeStateSnapshot(
                 product.getStatus() == ProductStatus.COMPLETED,
                 product.getStatus() == ProductStatus.RESERVATION,
                 // 대기 중인 요청이 있을 때만 값을 갖는다. 롤백된 요청의 값이 새어 나가면
                 // 클라이언트의 isCompletable 계산이 조회 응답과 어긋난다.
-                pending.map(TradeComplete::isRequestedBySeller).orElse(null),
-                resolveRequestedAt(product, buyer, seller, pending)
+                pending.map(TradeStateProjection::getRequestedBySeller).orElse(null),
+                resolveRequestedAt(states, pending)
         );
     }
 
@@ -47,14 +48,19 @@ public class TradeStateReader {
      * <p>반대로 철회가 승인된 뒤에는 null 이어야 한다. 값이 남으면 클라이언트가 아직
      * 거래 요청이 있다고 판단해 재요청 버튼을 잠근다.
      */
-    private LocalDateTime resolveRequestedAt(Product product, Member buyer, Member seller,
-                                             Optional<TradeComplete> pending) {
+    private LocalDateTime resolveRequestedAt(List<TradeStateProjection> states,
+                                             Optional<TradeStateProjection> pending) {
         if (pending.isPresent()) {
             return pending.get().getCreatedAt();
         }
-        return tradeCompleteRepository
-                .findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.COMPLETED)
-                .map(TradeComplete::getCreatedAt)
+        return find(states, TradeStatus.COMPLETED)
+                .map(TradeStateProjection::getCreatedAt)
                 .orElse(null);
+    }
+
+    private Optional<TradeStateProjection> find(List<TradeStateProjection> states, TradeStatus status) {
+        return states.stream()
+                .filter(state -> state.getStatus() == status)
+                .findFirst();
     }
 }

--- a/src/main/resources/db/migration/V7__optimize_chat_room_participant_lookup.sql
+++ b/src/main/resources/db/migration/V7__optimize_chat_room_participant_lookup.sql
@@ -1,0 +1,8 @@
+CREATE INDEX idx_chat_room_buyer_active_hidden
+    ON tbl_chat_room (buyer_id, is_active, hidden_by_buyer_at);
+
+CREATE INDEX idx_chat_room_seller_active_hidden
+    ON tbl_chat_room (seller_id, is_active, hidden_by_seller_at);
+
+CREATE INDEX idx_chat_message_room_checked_sender
+    ON tbl_chat_message (room_id, checked, sender_id);

--- a/src/test/java/team/startup/gwangsan/domain/trade/repository/TradeCompleteRepositoryTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/repository/TradeCompleteRepositoryTest.java
@@ -1,0 +1,73 @@
+package team.startup.gwangsan.domain.trade.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.Type;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository.TradeStateProjection;
+import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+class TradeCompleteRepositoryTest {
+
+    @Autowired
+    private TradeCompleteRepository repository;
+
+    @Autowired
+    private org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager entityManager;
+
+    @Test
+    void findsPendingAndCompletedStateWithOneProjectionQuery() {
+        Member buyer = member("buyer", "010-1000-0001");
+        Member seller = member("seller", "010-1000-0002");
+        Product product = entityManager.persist(Product.builder()
+                .title("상품")
+                .description("설명")
+                .gwangsan(1000)
+                .member(seller)
+                .type(Type.SERVICE)
+                .mode(Mode.GIVER)
+                .status(ProductStatus.ONGOING)
+                .build());
+
+        entityManager.persist(TradeComplete.builder()
+                .product(product).buyer(buyer).seller(seller)
+                .status(TradeStatus.PENDING).requestedBySeller(true).build());
+        entityManager.persist(TradeComplete.builder()
+                .product(product).buyer(buyer).seller(seller)
+                .status(TradeStatus.COMPLETED).requestedBySeller(false).build());
+        entityManager.flush();
+        entityManager.clear();
+
+        List<TradeStateProjection> states = repository.findTradeState(product, buyer, seller);
+
+        assertThat(states).extracting(TradeStateProjection::getStatus)
+                .containsExactlyInAnyOrder(TradeStatus.PENDING, TradeStatus.COMPLETED);
+        assertThat(states).allSatisfy(state -> assertThat(state.getCreatedAt()).isNotNull());
+    }
+
+    private Member member(String nickname, String phoneNumber) {
+        return entityManager.persist(Member.builder()
+                .name(nickname)
+                .nickname(nickname)
+                .password("pw")
+                .phoneNumber(phoneNumber)
+                .role(MemberRole.ROLE_USER)
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/TradeStateReaderTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/TradeStateReaderTest.java
@@ -10,12 +10,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.post.entity.Product;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
-import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository.TradeStateProjection;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -52,27 +52,22 @@ class TradeStateReaderTest {
     }
 
     private void givenNoTradeComplete() {
-        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING))
-                .thenReturn(Optional.empty());
-        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.COMPLETED))
-                .thenReturn(Optional.empty());
+        when(tradeCompleteRepository.findTradeState(product, buyer, seller)).thenReturn(List.of());
     }
 
     private void givenPendingRequest(boolean requestedBySeller) {
-        TradeComplete pending = mock(TradeComplete.class);
-        when(pending.isRequestedBySeller()).thenReturn(requestedBySeller);
+        TradeStateProjection pending = mock(TradeStateProjection.class);
+        when(pending.getStatus()).thenReturn(TradeStatus.PENDING);
+        when(pending.getRequestedBySeller()).thenReturn(requestedBySeller);
         when(pending.getCreatedAt()).thenReturn(REQUESTED_AT);
-        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING))
-                .thenReturn(Optional.of(pending));
+        when(tradeCompleteRepository.findTradeState(product, buyer, seller)).thenReturn(List.of(pending));
     }
 
     private void givenCompletedRequestOnly() {
-        TradeComplete completed = mock(TradeComplete.class);
+        TradeStateProjection completed = mock(TradeStateProjection.class);
+        when(completed.getStatus()).thenReturn(TradeStatus.COMPLETED);
         when(completed.getCreatedAt()).thenReturn(REQUESTED_AT);
-        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.PENDING))
-                .thenReturn(Optional.empty());
-        when(tradeCompleteRepository.findByProductAndBuyerAndSellerAndStatus(product, buyer, seller, TradeStatus.COMPLETED))
-                .thenReturn(Optional.of(completed));
+        when(tradeCompleteRepository.findTradeState(product, buyer, seller)).thenReturn(List.of(completed));
     }
 
     private TradeStateSnapshot read() {


### PR DESCRIPTION
## 💡 배경 및 개요

채팅방 목록과 상세 조회에서 불필요하게 많은 데이터를 탐색하거나 거래 상태를 중복 조회하던 부분을 개선했습니다.

Resolves: #380

## 📃 작업내용

- 최신 메시지 조회를 기존 인덱스를 활용한 방별 최신 메시지 탐색으로 변경했습니다.
- 거래 상태의 PENDING/COMPLETED 조회를 한 번의 projection 조회로 통합했습니다.
- 채팅방 참여자 및 읽지 않은 메시지 조회 인덱스 3개를 Flyway V7에 추가했습니다.
- 메시지 정렬, cursor paging, 읽음 처리 및 API 응답 계약을 유지했습니다.

## ✅ PR 체크리스트

- [x] 이 작업을 하고나서 공유해야 할 팀원들에게 공유되었나요?
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

프론트엔드와 `Gwangsan-Crossplatform`은 변경하지 않았습니다.
