### PR TITLE
재참여 전 채팅방 숨김 유지 및 푸시 차단

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/entity/ChatRoom.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/entity/ChatRoom.java
@@ -65,6 +65,16 @@ public class ChatRoom {
         return buyer.getId().equals(member.getId()) ? seller : buyer;
     }
 
+    public boolean isHiddenFor(Member member) {
+        if (buyer.getId().equals(member.getId())) {
+            return hiddenByBuyerAt != null;
+        }
+        if (seller.getId().equals(member.getId())) {
+            return hiddenBySellerAt != null;
+        }
+        return false;
+    }
+
     public void hideFor(Member member, LocalDateTime hiddenAt) {
         if (buyer.getId().equals(member.getId())) {
             this.hiddenByBuyerAt = hiddenAt;

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImpl.java
@@ -51,6 +51,7 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
 
         Member otherMember = chatRoom.getOtherMember(member);
         blockValidator.validate(member, otherMember);
+        boolean recipientHidden = chatRoom.isHiddenFor(otherMember);
 
         ChatMessage chatMessage = ChatMessage.builder()
                 .id(messageId)
@@ -72,15 +73,13 @@ public class SaveChatMessageServiceImpl implements SaveChatMessageService {
             chatMessageImageRepository.saveAll(chatMessageImages);
         }
 
-        // 나간 방에 새 메시지가 오면 양쪽 모두에게 다시 보여야 한다.
-        chatRoom.unhideFor(chatRoom.getBuyer());
-        chatRoom.unhideFor(chatRoom.getSeller());
-
-        List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserId(otherMember.getId());
-        if (!deviceTokens.isEmpty()) {
-            applicationEventPublisher.publishEvent(
-                    new SendNotificationEvent(deviceTokens, NotificationType.CHATTING, roomId)
-            );
+        if (!recipientHidden) {
+            List<DeviceToken> deviceTokens = deviceTokenRepository.findAllByUserId(otherMember.getId());
+            if (!deviceTokens.isEmpty()) {
+                applicationEventPublisher.publishEvent(
+                        new SendNotificationEvent(deviceTokens, NotificationType.CHATTING, roomId)
+                );
+            }
         }
 
         return new SaveChatMessageResponse(

--- a/src/test/java/team/startup/gwangsan/domain/chat/entity/ChatRoomTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/entity/ChatRoomTest.java
@@ -1,0 +1,48 @@
+package team.startup.gwangsan.domain.chat.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import team.startup.gwangsan.domain.member.entity.Member;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@DisplayName("ChatRoom 단위 테스트")
+class ChatRoomTest {
+
+    @Nested
+    @DisplayName("isHiddenFor() 메서드는")
+    class Describe_isHiddenFor {
+
+        @Test
+        @DisplayName("참여자별 hidden 상태를 구분하고 비참여자는 false를 반환한다")
+        void it_checks_hidden_state_for_each_participant_only() {
+            Member buyer = mock(Member.class);
+            Member seller = mock(Member.class);
+            Member outsider = mock(Member.class);
+            when(buyer.getId()).thenReturn(1L);
+            when(seller.getId()).thenReturn(2L);
+            when(outsider.getId()).thenReturn(3L);
+            ChatRoom room = ChatRoom.builder().buyer(buyer).seller(seller).build();
+            LocalDateTime now = LocalDateTime.of(2024, 1, 1, 0, 0);
+
+            assertThat(room.isHiddenFor(buyer)).isFalse();
+            assertThat(room.isHiddenFor(seller)).isFalse();
+            room.hideFor(buyer, now);
+            assertThat(room.isHiddenFor(buyer)).isTrue();
+            assertThat(room.isHiddenFor(seller)).isFalse();
+            room.hideFor(seller, now);
+            assertThat(room.isHiddenFor(seller)).isTrue();
+            assertThat(room.isHiddenFor(outsider)).isFalse();
+            room.unhideFor(buyer);
+            assertThat(room.isHiddenFor(buyer)).isFalse();
+            assertThat(room.isHiddenFor(seller)).isTrue();
+            room.unhideFor(seller);
+            assertThat(room.isHiddenFor(seller)).isFalse();
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/SaveChatMessageServiceImplTest.java
@@ -5,11 +5,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
+import team.startup.gwangsan.global.util.MemberUtil;
 import team.startup.gwangsan.domain.chat.entity.ChatMessage;
 import team.startup.gwangsan.domain.chat.entity.ChatRoom;
 import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
@@ -56,6 +63,83 @@ class SaveChatMessageServiceImplTest {
     private SaveChatMessageServiceImpl service;
 
     @Nested
+    @DisplayName("수신자의 나가기 및 재참여 상태에 따른 알림")
+    class RecipientVisibility {
+
+        @ParameterizedTest
+        @CsvSource({"true,true", "false,true", "true,false", "false,false"})
+        @DisplayName("양방향에서 재참여 전까지 숨김과 푸시 차단을 유지하고 재참여 후 알림을 보낸다")
+        void it_notifies_only_previously_visible_recipient(boolean senderIsBuyer, boolean recipientHidden) {
+            Member buyer = mock(Member.class);
+            Member seller = mock(Member.class);
+            when(buyer.getId()).thenReturn(1L);
+            when(seller.getId()).thenReturn(2L);
+            Member sender = senderIsBuyer ? buyer : seller;
+            Member recipient = senderIsBuyer ? seller : buyer;
+            ChatRoom room = ChatRoom.builder().buyer(buyer).seller(seller).build();
+            ReflectionTestUtils.setField(room, "id", 10L);
+            LocalDateTime now = LocalDateTime.of(2024, 1, 1, 0, 0);
+            room.hideFor(sender, now);
+            if (recipientHidden) {
+                room.hideFor(recipient, now);
+            }
+            when(memberRepository.findById(sender.getId())).thenReturn(Optional.of(sender));
+            when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(room));
+            Image image = mock(Image.class);
+            when(image.getId()).thenReturn(100L);
+            when(image.getImageUrl()).thenReturn("image-url");
+            when(imageRepository.findAllById(List.of(100L))).thenReturn(List.of(image));
+            DeviceToken token = mock(DeviceToken.class);
+            if (!recipientHidden) {
+                when(deviceTokenRepository.findAllByUserId(recipient.getId())).thenReturn(List.of(token));
+            }
+
+            SaveChatMessageResponse response = service.execute(
+                    1L, 10L, "이미지", List.of(100L), MessageType.IMAGE, sender.getId(), now);
+
+            verify(chatMessageRepository).save(any(ChatMessage.class));
+            verify(chatMessageImageRepository).saveAll(anyList());
+            assertThat(response.images()).hasSize(1);
+            assertThat(response.images().getFirst().imageId()).isEqualTo(100L);
+            assertThat(room.isHiddenFor(sender)).isTrue();
+            assertThat(room.isHiddenFor(recipient)).isEqualTo(recipientHidden);
+            if (recipientHidden) {
+                verifyNoInteractions(deviceTokenRepository, applicationEventPublisher);
+                service.execute(2L, 10L, "다음 메시지", null, MessageType.TEXT, sender.getId(), now);
+                verify(chatMessageRepository, times(2)).save(any(ChatMessage.class));
+                verifyNoInteractions(deviceTokenRepository, applicationEventPublisher);
+                assertThat(room.isHiddenFor(recipient)).isTrue();
+
+                MemberUtil memberUtil = mock(MemberUtil.class);
+                ProductRepository productRepository = mock(ProductRepository.class);
+                Product product = mock(Product.class);
+                when(memberUtil.getCurrentMember()).thenReturn(recipient);
+                when(productRepository.findActiveById(100L)).thenReturn(Optional.of(product));
+                when(product.getMember()).thenReturn(sender);
+                when(product.getMode()).thenReturn(senderIsBuyer ? Mode.RECEIVER : Mode.GIVER);
+                when(chatRoomRepository.findByProductIdAndBuyerAndSeller(100L, buyer, seller))
+                        .thenReturn(Optional.of(room));
+                CreateChatRoomServiceImpl createService = new CreateChatRoomServiceImpl(
+                        chatRoomRepository, memberUtil, productRepository, blockValidator);
+
+                assertThat(createService.execute(100L).roomId()).isEqualTo(10L);
+                verify(chatRoomRepository, never()).save(any());
+                assertThat(room.isHiddenFor(recipient)).isFalse();
+                assertThat(room.isHiddenFor(sender)).isTrue();
+                when(deviceTokenRepository.findAllByUserId(recipient.getId())).thenReturn(List.of(token));
+                service.execute(3L, 10L, "재참여 후 메시지", null, MessageType.TEXT, sender.getId(), now);
+                verify(deviceTokenRepository).findAllByUserId(recipient.getId());
+                verify(applicationEventPublisher).publishEvent(
+                        new SendNotificationEvent(List.of(token), NotificationType.CHATTING, 10L));
+            } else {
+                verify(deviceTokenRepository).findAllByUserId(recipient.getId());
+                verify(applicationEventPublisher).publishEvent(
+                        new SendNotificationEvent(List.of(token), NotificationType.CHATTING, 10L));
+            }
+        }
+    }
+
+    @Nested
     @DisplayName("execute() 메서드는")
     class Describe_execute {
 
@@ -74,8 +158,6 @@ class SaveChatMessageServiceImplTest {
         private void arrangeDefaultScenario() {
             when(sender.getId()).thenReturn(1L);
             when(otherMember.getId()).thenReturn(2L);
-            when(chatRoom.getBuyer()).thenReturn(sender);
-            when(chatRoom.getSeller()).thenReturn(otherMember);
             when(chatRoom.getOtherMember(sender)).thenReturn(otherMember);
             when(memberRepository.findById(1L)).thenReturn(Optional.of(sender));
             when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
@@ -120,14 +202,13 @@ class SaveChatMessageServiceImplTest {
         }
 
         @Test
-        @DisplayName("새 메시지가 오면 양쪽 모두에게 숨긴 방을 다시 노출한다")
-        void it_unhides_room_for_both_participants() {
+        @DisplayName("새 메시지가 와도 참여자의 숨김을 해제하지 않는다")
+        void it_does_not_unhide_room_when_message_arrives() {
             arrangeDefaultScenario();
 
             service.execute(1L, 10L, "안녕하세요", null, MessageType.TEXT, 1L, now);
 
-            verify(chatRoom).unhideFor(sender);
-            verify(chatRoom).unhideFor(otherMember);
+            verify(chatRoom, never()).unhideFor(any());
         }
 
         @Test
@@ -233,7 +314,6 @@ class SaveChatMessageServiceImplTest {
 
             when(sellerMember.getId()).thenReturn(3L);
             when(buyerMember.getId()).thenReturn(4L);
-            when(room.getBuyer()).thenReturn(buyerMember);
             when(room.getOtherMember(sellerMember)).thenReturn(buyerMember);
             when(memberRepository.findById(3L)).thenReturn(Optional.of(sellerMember));
             when(chatRoomRepository.findChatRoomByRoomId(20L)).thenReturn(Optional.of(room));


### PR DESCRIPTION
## 💡 배경 및 개요

채팅방을 나간 사용자에게도 새 메시지 푸시가 발행되던 문제를 수정하였습니다. 직접 재참여하기 전까지 본인 목록 숨김과 CHATTING 푸시 차단을 유지하도록 변경하였습니다.

Resolves: #383

## 📃 작업내용

- 참여자별 숨김을 확인하는 ChatRoom.isHiddenFor를 추가하였습니다. 비참여자는 false를 반환하도록 하였습니다.
- 숨긴 수신자의 DeviceToken 조회와 SendNotificationEvent 발행을 생략하였습니다. 구매자·판매자 양방향에 동일하게 적용하였습니다.
- 새 메시지 저장 시 양쪽 unhideFor 호출을 제거하였습니다. 메시지·이미지 저장과 기존 대화 보존은 유지하였습니다.
- 연속 수신에도 숨김이 유지되고, 기존 방 생성 API로 요청자가 재참여하면 같은 방에서 알림이 재개되는 시나리오를 검증하였습니다.

## 🙋‍♂️ 리뷰노트

최초 요구의 자동 재노출 유지에서 정책을 변경하기로 합의하였습니다. 새 메시지와 GET 조회는 재참여로 취급하지 않으며, 기존 POST 채팅방 생성 API가 요청자 숨김만 해제하는 동작은 유지하였습니다.

프론트 후속 작업은 School-of-Company/Gwangsan-Crossplatform#609에 통합하였습니다. 기존 프론트의 GET 후 직접 진입, 소켓 로컬 알림, 목록 캐시 처리가 남아 있어 서버 변경만으로 앱 전체 정책이 완성되지 않습니다. 제공자의 별도 재참여 화면은 이번 범위에서 제외하였습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

환경변수·API 스키마·README 변경은 없으며 정책과 프론트 후속 작업은 #609에 기록하였습니다. 코드 동작은 아래 로컬 테스트 범위에서 확인하였습니다. 팀원 공유와 프론트 반영 후 실기기 검증은 아직 완료하지 않았습니다.

## 🎸 기타

- 관련 테스트 46개 및 전체 테스트 450개가 모두 통과하였습니다.
- 로컬 Docker API 호환 문제로 기본 실행은 초기화 실패하였으나, `JAVA_TOOL_OPTIONS=-Dapi.version=1.44 ./gradlew test`로 전체 통과를 확인하였습니다. 저장소 설정이나 의존성은 변경하지 않았습니다.
- 실제 메시지 핸들러·저장 서비스·방 생성 서비스를 사용한 로컬 실행으로 양방향 연속 수신과 재참여 전후 동작을 확인하였습니다. 저장소·외부 알림 경계는 대역을 사용하였으며 실서버부터 실기기까지의 통합 검증은 수행하지 않았습니다.
- 목표·품질·보안·맥락·실행 QA 리뷰를 완료하였으며 차단 이슈는 없었습니다.
