### PR TITLE
채팅 목록 예약 상태 누락 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetRoomProductDto.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/GetRoomProductDto.java
@@ -8,6 +8,7 @@ public record GetRoomProductDto(
         Long productId,
         String title,
         boolean isCompleted,
+        boolean isReserved,
         List<GetImageResponse> images
 ) {
 }

--- a/src/main/java/team/startup/gwangsan/domain/post/repository/custom/impl/ProductCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/custom/impl/ProductCustomRepositoryImpl.java
@@ -94,9 +94,11 @@ public class ProductCustomRepositoryImpl implements ProductCustomRepository {
             Long imageId = row.get(image.id);
             String imageUrl = row.get(image.imageUrl);
 
+            // 상태 값은 TradeStateReader.read()가 반환하는 completed()/reserved()와 같아야 한다.
+            // 일괄 조회를 유지하기 위해 엔티티 기반 TradeStateReader 대신 조회한 상태로 계산한다.
             GetRoomProductDto dto = resultMap.computeIfAbsent(
                     productId,
-                    id -> new GetRoomProductDto(id, title, status == ProductStatus.COMPLETED, new ArrayList<>())
+                    id -> new GetRoomProductDto(id, title, status == ProductStatus.COMPLETED, status == ProductStatus.RESERVATION, new ArrayList<>())
             );
 
             if (imageId != null) {

--- a/src/test/java/team/startup/gwangsan/domain/chat/presentation/dto/GetRoomsResponseJsonTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/presentation/dto/GetRoomsResponseJsonTest.java
@@ -1,0 +1,51 @@
+package team.startup.gwangsan.domain.chat.presentation.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.ContextConfiguration;
+import team.startup.gwangsan.domain.chat.presentation.dto.response.GetRoomsResponse;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JsonTest
+@ContextConfiguration(classes = GetRoomsResponseJsonTest.JsonConfig.class)
+class GetRoomsResponseJsonTest {
+
+    @Configuration(proxyBeanMethods = false)
+    static class JsonConfig {
+    }
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Nested
+    @DisplayName("채팅 목록 응답 직렬화는")
+    class Describe_serialization {
+
+        @DisplayName("false인 상태 필드도 boolean 값으로 포함한다")
+        @ParameterizedTest
+        @CsvSource({"true, false", "false, true", "false, false"})
+        void it_includes_boolean_status_fields_even_when_false(boolean completed, boolean reserved) throws Exception {
+            var product = new GetRoomProductDto(1L, "상품", completed, reserved, List.of());
+            var response = new GetRoomsResponse(1L, null, null, null, null, null, 0L, product);
+
+            var json = objectMapper.readTree(objectMapper.writeValueAsString(List.of(response))).get(0).get("product");
+
+            assertThat(json.has("isReserved")).isTrue();
+            assertThat(json.get("isReserved").isBoolean()).isTrue();
+            assertThat(json.get("isReserved").booleanValue()).isEqualTo(reserved);
+            assertThat(json.get("isCompleted").isBoolean()).isTrue();
+            assertThat(json.get("isCompleted").booleanValue()).isEqualTo(completed);
+            assertThat(json.get("images").isArray()).isTrue();
+            assertThat(json.get("images").isEmpty()).isTrue();
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindRoomsByCurrentUserServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/FindRoomsByCurrentUserServiceImplTest.java
@@ -66,7 +66,7 @@ class FindRoomsByCurrentUserServiceImplTest {
                     10L, null, 1L, "마지막 메시지", MessageType.TEXT,
                     LocalDateTime.now(), 0L, 100L
             );
-            GetRoomProductDto productDto = new GetRoomProductDto(100L, "상품명", false, List.of());
+            GetRoomProductDto productDto = new GetRoomProductDto(100L, "상품명", false, true, List.of());
 
             when(chatRoomRepository.findRoomsByMemberId(1L)).thenReturn(List.of(roomDto));
             when(productRepository.findRoomProductsWithImagesByIds(Set.of(100L))).thenReturn(List.of(productDto));
@@ -77,6 +77,7 @@ class FindRoomsByCurrentUserServiceImplTest {
             assertThat(result.get(0).roomId()).isEqualTo(10L);
             assertThat(result.get(0).lastMessage()).isEqualTo("마지막 메시지");
             assertThat(result.get(0).product()).isSameAs(productDto);
+            assertThat(result.get(0).product().isReserved()).isTrue();
         }
 
         @Test
@@ -84,8 +85,8 @@ class FindRoomsByCurrentUserServiceImplTest {
         void it_maps_each_room_to_correct_product() {
             GetRoomsDto room1 = new GetRoomsDto(1L, null, 1L, "msg1", MessageType.TEXT, LocalDateTime.now(), 0L, 100L);
             GetRoomsDto room2 = new GetRoomsDto(2L, null, 2L, "msg2", MessageType.TEXT, LocalDateTime.now(), 1L, 200L);
-            GetRoomProductDto product1 = new GetRoomProductDto(100L, "상품1", false, List.of());
-            GetRoomProductDto product2 = new GetRoomProductDto(200L, "상품2", true, List.of());
+            GetRoomProductDto product1 = new GetRoomProductDto(100L, "상품1", false, false, List.of());
+            GetRoomProductDto product2 = new GetRoomProductDto(200L, "상품2", true, false, List.of());
 
             when(chatRoomRepository.findRoomsByMemberId(1L)).thenReturn(List.of(room1, room2));
             when(productRepository.findRoomProductsWithImagesByIds(Set.of(100L, 200L)))

--- a/src/test/java/team/startup/gwangsan/domain/post/repository/ProductRepositoryTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/post/repository/ProductRepositoryTest.java
@@ -4,18 +4,25 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
 import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
 import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.ProductImage;
 import team.startup.gwangsan.domain.post.entity.constant.Mode;
 import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
 import team.startup.gwangsan.domain.post.entity.constant.Type;
 import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -54,6 +61,63 @@ class ProductRepositoryTest {
                 .type(Type.SERVICE)
                 .mode(Mode.GIVER)
                 .build());
+    }
+
+    @Nested
+    @DisplayName("findRoomProductsWithImagesByIds 메서드는")
+    class Describe_findRoomProductsWithImagesByIds {
+
+        @ParameterizedTest
+        @CsvSource({"COMPLETED, true, false", "RESERVATION, false, true", "ONGOING, false, false"})
+        @DisplayName("상품 상태를 isCompleted/isReserved로 매핑한다")
+        void it_maps_status_to_completed_and_reserved(
+                ProductStatus status, boolean completed, boolean reserved) {
+            Product product = persistProduct(status);
+            em.flush();
+            em.clear();
+
+            var result = productRepository.findRoomProductsWithImagesByIds(List.of(product.getId()));
+
+            assertThat(result).hasSize(1);
+            var dto = result.getFirst();
+            assertThat(dto.productId()).isEqualTo(product.getId());
+            assertThat(dto.isCompleted()).isEqualTo(completed);
+            assertThat(dto.isReserved()).isEqualTo(reserved);
+        }
+
+        @Test
+        @DisplayName("이미지가 없는 상품도 빈 이미지 목록과 함께 반환한다")
+        void it_returns_product_without_images() {
+            Product product = persistProduct(ProductStatus.RESERVATION);
+            em.flush();
+            em.clear();
+
+            var result = productRepository.findRoomProductsWithImagesByIds(List.of(product.getId()));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().productId()).isEqualTo(product.getId());
+            assertThat(result.getFirst().images()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("여러 이미지를 상품 하나에 모아 반환한다")
+        void it_groups_images_in_one_product() {
+            Product product = persistProduct(ProductStatus.RESERVATION);
+            Image first = em.persist(Image.builder().imageUrl("https://example.com/first").build());
+            Image second = em.persist(Image.builder().imageUrl("https://example.com/second").build());
+            em.persist(ProductImage.builder().product(product).image(first).build());
+            em.persist(ProductImage.builder().product(product).image(second).build());
+            em.flush();
+            em.clear();
+
+            var result = productRepository.findRoomProductsWithImagesByIds(List.of(product.getId()));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().productId()).isEqualTo(product.getId());
+            assertThat(result.getFirst().images()).containsExactlyInAnyOrder(
+                    new GetImageResponse(first.getId(), first.getImageUrl()),
+                    new GetImageResponse(second.getId(), second.getImageUrl()));
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 💡 배경 및 개요

채팅 목록 API(`GET /api/chat/rooms`)의 상품 응답에 `isReserved`가 누락되어 예약중 상태를 표시할 수 없었던 문제를 수정하였습니다.

Resolves: #379

## 📃 작업내용

- 상품 응답에 `boolean isReserved`를 추가하였습니다.
- 기존에 조회한 상품 상태가 `RESERVATION`인 경우에만 true로 매핑하였습니다.
- 완료·예약·거래중 상태, 이미지 없음·여러 이미지, JSON true/false 필드 노출 테스트를 추가하였습니다.

## 🙋‍♂️ 리뷰노트

상세 조회의 `TradeStateReader`와 동일한 상태 비교식을 사용하였습니다. 기존 일괄 조회 결과로 계산하여 추가 쿼리나 엔티티 조회 없이 처리하였습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

- 별도 환경값이나 문서 변경은 필요하지 않습니다.
- `JAVA_TOOL_OPTIONS=-Dapi.version=1.44 ./gradlew build` 실행 결과 전체 테스트 458개와 빌드가 통과하였습니다.
- 로컬 Docker API 호환성을 위해 실행 시에만 위 옵션을 적용하였습니다.
- 실제 HTTP 호출 검증은 수행하지 않았습니다.
