### PR TITLE
거래 양측이 철회를 요청하면 관리자 승인 없이 자동 철회

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ repositories {
 	mavenCentral()
 }
 
+ext['testcontainers.version'] = '1.21.3'
+
 dependencies {
 	// spring-boot-starter
 	implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -68,6 +70,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
 	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:mariadb'
 	testRuntimeOnly 'com.h2database:h2'
 
 	// cloud
@@ -134,5 +137,10 @@ jacocoTestCoverageVerification {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	// Docker Engine 29 는 API 1.40 미만을 거부한다. docker-java 가 기본으로 고르는 버전이
+	// 그보다 낮아 Testcontainers 가 /info 에서 400 을 받으므로 명시한다.
+	environment 'DOCKER_API_VERSION', '1.41'
+	environment 'TESTCONTAINERS_API_VERSION', '1.41'
+	systemProperty 'api.version', '1.41'
 	finalizedBy jacocoTestReport
 }

--- a/src/main/java/team/startup/gwangsan/domain/admin/repository/AdminAlertRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/repository/AdminAlertRepository.java
@@ -16,6 +16,8 @@ public interface AdminAlertRepository extends JpaRepository<AdminAlert, Long>, A
 
     Optional<AdminAlert> findByIdAndType(Long alertId, AlertType type);
 
+    Optional<AdminAlert> findByTypeAndSourceId(AlertType type, Long sourceId);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE AdminAlert a SET a.otherMember = :dummy WHERE a.otherMember = :target")
     void reassignOtherMember(@Param("target") Member target, @Param("dummy") Member dummy);

--- a/src/main/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImpl.java
@@ -1,35 +1,26 @@
 package team.startup.gwangsan.domain.admin.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.admin.entity.AdminAlert;
 import team.startup.gwangsan.domain.admin.exception.NotFoundAdminAlertException;
 import team.startup.gwangsan.domain.admin.repository.AdminAlertRepository;
 import team.startup.gwangsan.domain.admin.service.ApproveTradeCancelService;
 import team.startup.gwangsan.domain.admin.util.ValidatePlaceUtil;
-import team.startup.gwangsan.domain.alert.entity.constant.AlertType;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
-import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
-import team.startup.gwangsan.domain.post.entity.Product;
-import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
-import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
-import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
-import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelException;
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCancelException;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
-import team.startup.gwangsan.domain.trade.service.TradeStateReader;
-import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
-import team.startup.gwangsan.global.event.CreateAlertEvent;
-import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+import team.startup.gwangsan.domain.trade.service.TradeCancelApplier;
 import team.startup.gwangsan.global.util.MemberUtil;
-
 
 @Service
 @RequiredArgsConstructor
@@ -37,76 +28,49 @@ public class ApproveTradeCancelServiceImpl implements ApproveTradeCancelService 
 
     private final AdminAlertRepository adminAlertRepository;
     private final TradeCancelRepository tradeCancelRepository;
+    private final ProductRepository productRepository;
     private final MemberUtil memberUtil;
     private final MemberDetailRepository memberDetailRepository;
     private final ValidatePlaceUtil validatePlaceUtil;
-    private final ChatRoomRepository chatRoomRepository;
-    private final TradeStateReader tradeStateReader;
-    private final ApplicationEventPublisher applicationEventPublisher;
+    private final TradeCancelApplier tradeCancelApplier;
 
+    /**
+     * 잠금 순서가 핵심이다. TradeCancel 을 잠금 전에 엔티티로 읽으면 그 값이 1차 캐시에 남아,
+     * 양측 동의로 이미 철회된 뒤에도 PENDING 으로 보여 광산이 두 번 환불된다. 그래서 상품 ID 만
+     * 스칼라로 먼저 읽어 잠금을 잡고, TradeCancel 은 그 뒤에 처음 로드한다.
+     * READ_COMMITTED 이유는 {@code TradeCancelServiceImpl} 주석 참고.
+     */
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void execute(Long alertId) {
         Member admin = memberUtil.getCurrentMember();
         AdminAlert alert = adminAlertRepository.findByIdWithMember(alertId)
                 .orElseThrow(NotFoundAdminAlertException::new);
 
-        MemberDetail adminDetail = memberDetailRepository.findById(admin.getId())
-                .orElseThrow(NotFoundMemberDetailException::new);
+        MemberDetail adminDetail = getMemberDetail(admin.getId());
+
+        Long productId = tradeCancelRepository.findProductIdById(alert.getSourceId())
+                .orElseThrow(NotFoundTradeCancelException::new);
+
+        productRepository.findByIdForUpdate(productId)
+                .orElseThrow(NotFoundProductException::new);
 
         TradeCancel tradeCancel = tradeCancelRepository.findByIdWithTradeCompleteAndBuyerAndSellerAndProduct(alert.getSourceId())
                 .orElseThrow(NotFoundTradeCancelException::new);
 
-        if (tradeCancel.getStatus() != TradeCancelStatus.PENDING) {
-            throw new CannotPendingTradeCancelException();
-        }
-
         TradeComplete tradeComplete = tradeCancel.getTradeComplete();
-        Product product = tradeComplete.getProduct();
-        Member buyer = tradeComplete.getBuyer();
-        Member seller = tradeComplete.getSeller();
 
-        MemberDetail buyerDetail = memberDetailRepository.findById(buyer.getId())
-                .orElseThrow(NotFoundMemberDetailException::new);
-        MemberDetail sellerDetail = memberDetailRepository.findById(seller.getId())
-                .orElseThrow(NotFoundMemberDetailException::new);
+        MemberDetail buyerDetail = getMemberDetail(tradeComplete.getBuyer().getId());
+        MemberDetail sellerDetail = getMemberDetail(tradeComplete.getSeller().getId());
 
         validatePlaceUtil.validateSamePlace(admin, adminDetail, buyerDetail);
         validatePlaceUtil.validateSamePlace(admin, adminDetail, sellerDetail);
 
-        int gwangsan = product.getGwangsan();
+        tradeCancelApplier.apply(tradeCancel);
+    }
 
-        buyerDetail.plusGwangsan(gwangsan);
-        sellerDetail.minusGwangsan(gwangsan);
-
-        tradeCancel.updateStatus(TradeCancelStatus.APPROVED);
-
-        tradeComplete.updateStatus(TradeStatus.ROLLED_BACK);
-
-        // 상품을 다시 거래 가능 상태로 되돌린다. 이걸 빠뜨리면 채팅방의 isCompleted 가
-        // Product.status 에서만 파생되므로 철회 후에도 영구히 "거래 완료"로 남는다.
-        product.updateStatus(ProductStatus.ONGOING);
-
-        applicationEventPublisher.publishEvent(new CreateAlertEvent(
-                tradeCancel.getId(),
-                alert.getRequester().getId(),
-                AlertType.TRADE_CANCEL
-        ));
-
-        // 철회가 승인되면 대기 중인 요청도 완료된 요청도 남지 않으므로
-        // requestedBySeller 와 requestedAt 이 모두 null 이 된다. 그래야 클라이언트가
-        // 거래 카드를 감추고 재요청 버튼을 다시 열어 준다.
-        chatRoomRepository.findByProductIdAndBuyerAndSeller(product.getId(), buyer, seller)
-                .ifPresent(chatRoom -> {
-                    TradeStateSnapshot tradeState = tradeStateReader.read(product, buyer, seller);
-                    applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
-                            chatRoom.getId(),
-                            product.getId(),
-                            tradeState.completed(),
-                            tradeState.reserved(),
-                            tradeState.requestedBySeller(),
-                            tradeState.requestedAt()
-                    ));
-                });
+    private MemberDetail getMemberDetail(Long memberId) {
+        return memberDetailRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberDetailException::new);
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/admin/service/impl/RejectAdminAlertServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/admin/service/impl/RejectAdminAlertServiceImpl.java
@@ -3,6 +3,7 @@ package team.startup.gwangsan.domain.admin.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.admin.entity.AdminAlert;
 import team.startup.gwangsan.domain.admin.exception.NotFoundAdminAlertException;
@@ -14,11 +15,14 @@ import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.report.entity.Report;
 import team.startup.gwangsan.domain.report.exception.NotFoundReportException;
 import team.startup.gwangsan.domain.report.repository.ReportRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelException;
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCancelException;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
@@ -34,10 +38,12 @@ public class RejectAdminAlertServiceImpl implements RejectAdminAlertService {
     private final MemberDetailRepository memberDetailRepository;
     private final ValidatePlaceUtil validatePlaceUtil;
     private final TradeCancelRepository tradeCancelRepository;
+    private final ProductRepository productRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /** 잠금과 격리 수준의 이유는 {@code TradeCancelServiceImpl} 주석 참고. */
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void execute(Long alertId) {
         Member admin = memberUtil.getCurrentMember();
         MemberDetail adminDetail = getMemberDetail(admin.getId());
@@ -46,6 +52,15 @@ public class RejectAdminAlertServiceImpl implements RejectAdminAlertService {
         MemberDetail alertMemberDetail = getMemberDetail(alert.getRequester().getId());
 
         validatePlaceUtil.validateSamePlace(admin, adminDetail, alertMemberDetail);
+
+        // 기각도 철회 요청·승인·자동 철회와 같은 잠금을 거쳐야 한다. 그러지 않으면
+        // 이미 승인된(APPROVED) 철회를 REJECTED 로 덮어써 광산과 상태가 어긋난다.
+        if (alert.getType() == team.startup.gwangsan.domain.admin.entity.constant.AlertType.TRADE_CANCEL) {
+            Long productId = tradeCancelRepository.findProductIdById(alert.getSourceId())
+                    .orElseThrow(NotFoundTradeCancelException::new);
+            productRepository.findByIdForUpdate(productId)
+                    .orElseThrow(NotFoundProductException::new);
+        }
 
         adminAlertRepository.delete(alert);
 
@@ -84,6 +99,10 @@ public class RejectAdminAlertServiceImpl implements RejectAdminAlertService {
     private void rejectTradeCancel(AdminAlert alert) {
         TradeCancel tradeCancel = tradeCancelRepository.findById(alert.getSourceId())
                 .orElseThrow(NotFoundTradeCancelException::new);
+
+        if (tradeCancel.getStatus() != TradeCancelStatus.PENDING) {
+            throw new CannotPendingTradeCancelException();
+        }
 
         tradeCancel.updateStatus(TradeCancelStatus.REJECTED);
 

--- a/src/main/java/team/startup/gwangsan/domain/post/repository/ProductRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/post/repository/ProductRepository.java
@@ -23,9 +23,24 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
         return findByIdAndStatusNot(id, ProductStatus.DELETED);
     }
 
+    /**
+     * 거래를 새로 진행하기 위한 잠금. 삭제된 게시글은 제외한다.
+     */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("select p from Product p where p.id = :id and p.status <> team.startup.gwangsan.domain.post.entity.constant.ProductStatus.DELETED")
     Optional<Product> findByIdWithLock(Long id);
+
+    /**
+     * 이미 성립한 거래를 되돌리기 위한 잠금. 삭제된 게시글도 포함한다.
+     *
+     * <p>게시글 삭제는 거래 상태를 검사하지 않으므로(DeleteProductByIdServiceImpl), 철회 대기 중에
+     * 판매자가 글을 지울 수 있다. 여기서 DELETED 를 걸러내면 광산 환불이 영구히 막히고 관리자
+     * 알림도 처리 불가 상태로 남는다. 잠그는 행은 {@link #findByIdWithLock} 과 같으므로
+     * 거래 완료 요청 경로와의 직렬화는 그대로 유지된다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("select p from Product p where p.id = :id")
+    Optional<Product> findByIdForUpdate(Long id);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE Product p SET p.member = :dummy WHERE p.member = :target")

--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/TradeController.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/TradeController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.TradeCancelRequest;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.TradeCancelResponse;
 import team.startup.gwangsan.domain.trade.presentation.dto.request.constant.Period;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.GetTradeHistoryResponse;
 import team.startup.gwangsan.domain.trade.presentation.dto.response.HeadTradeHistoryResponse;
@@ -78,12 +79,11 @@ public class TradeController {
     }
 
     @PostMapping("/cancel/{product_id}")
-    public ResponseEntity<Void> cancel(
+    public ResponseEntity<TradeCancelResponse> cancel(
             @PathVariable("product_id") Long productId,
             @RequestBody TradeCancelRequest request
     ) {
-        tradeCancelService.execute(productId, request.reason(), request.imageIds());
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(tradeCancelService.execute(productId, request.reason(), request.imageIds()));
     }
 
     @DeleteMapping("/cancel/{product_id}")

--- a/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/TradeCancelResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/presentation/dto/response/TradeCancelResponse.java
@@ -1,0 +1,13 @@
+package team.startup.gwangsan.domain.trade.presentation.dto.response;
+
+/**
+ * 철회 요청의 처리 결과.
+ *
+ * @param cancelled true 면 상대방이 이미 요청해 둔 상태라 즉시 철회까지 끝났고,
+ *                  false 면 관리자 승인을 기다리는 요청만 접수됐다.
+ *                  응답 코드는 두 경우 모두 200 이므로 이 값으로만 구분할 수 있다.
+ */
+public record TradeCancelResponse(
+        boolean cancelled
+) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/repository/TradeCancelRepository.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/repository/TradeCancelRepository.java
@@ -12,9 +12,14 @@ import team.startup.gwangsan.domain.trade.repository.custom.TradeCancelCustomRep
 import java.util.Optional;
 
 public interface TradeCancelRepository extends JpaRepository<TradeCancel, Long>, TradeCancelCustomRepository {
-    boolean existsByTradeCompleteIdAndStatus(Long tradeCompleteId, TradeCancelStatus status);
-
     Optional<TradeCancel> findByTradeCompleteIdAndStatus(Long tradeCompleteId, TradeCancelStatus status);
+
+    /**
+     * 상품 ID 만 스칼라로 읽는다. 엔티티를 영속화하지 않아 1차 캐시를 오염시키지 않으므로,
+     * 잠금을 잡기 전에 잠글 대상을 알아내는 용도로만 쓴다.
+     */
+    @Query("select tc.tradeComplete.product.id from TradeCancel tc where tc.id = :id")
+    Optional<Long> findProductIdById(@Param("id") Long id);
 
     @Modifying(clearAutomatically = true)
     @Query("UPDATE TradeCancel t SET t.member = :dummy WHERE t.member = :target")

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/TradeCancelApplier.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/TradeCancelApplier.java
@@ -1,0 +1,110 @@
+package team.startup.gwangsan.domain.trade.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import team.startup.gwangsan.domain.admin.repository.AdminAlertRepository;
+import team.startup.gwangsan.domain.alert.entity.constant.AlertType;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.trade.entity.TradeCancel;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelException;
+import team.startup.gwangsan.global.event.CreateAlertEvent;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+/**
+ * 거래 철회를 실제로 반영하는 단일 지점.
+ *
+ * <p>관리자 승인 경로와 양측 동의 자동 철회 경로가 이 클래스를 공유한다. 두 경로가 잔액과
+ * 상태를 각자 바꾸면 결과가 갈라지므로, 관리자 인가({@code ValidatePlaceUtil})만 호출자에 남기고
+ * 나머지 상태 전이는 전부 여기로 모았다.
+ */
+@Component
+@RequiredArgsConstructor
+public class TradeCancelApplier {
+
+    private final MemberDetailRepository memberDetailRepository;
+    private final AdminAlertRepository adminAlertRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final TradeStateReader tradeStateReader;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    /**
+     * 호출 전제: 호출자가 이미 해당 상품 행을 비관적 잠금으로 확보했고, {@code tradeCancel} 을
+     * 그 잠금 이후에 처음 읽었다. 잠금 전에 읽은 엔티티를 넘기면 아래 PENDING 검사가 옛 값을 보고
+     * 통과해 광산이 두 번 환불된다.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    public void apply(TradeCancel tradeCancel) {
+        if (tradeCancel.getStatus() != TradeCancelStatus.PENDING) {
+            throw new CannotPendingTradeCancelException();
+        }
+
+        TradeComplete tradeComplete = tradeCancel.getTradeComplete();
+        Product product = tradeComplete.getProduct();
+        Member buyer = tradeComplete.getBuyer();
+        Member seller = tradeComplete.getSeller();
+
+        MemberDetail buyerDetail = getMemberDetail(buyer.getId());
+        MemberDetail sellerDetail = getMemberDetail(seller.getId());
+
+        int gwangsan = product.getGwangsan();
+
+        buyerDetail.plusGwangsan(gwangsan);
+        sellerDetail.minusGwangsan(gwangsan);
+
+        tradeCancel.updateStatus(TradeCancelStatus.APPROVED);
+
+        tradeComplete.updateStatus(TradeStatus.ROLLED_BACK);
+
+        // 상품을 다시 거래 가능 상태로 되돌린다. 이걸 빠뜨리면 채팅방의 isCompleted 가
+        // Product.status 에서만 파생되므로 철회 후에도 영구히 "거래 완료"로 남는다.
+        product.updateStatus(ProductStatus.ONGOING);
+
+        // 처리된 요청이 관리자 목록에 남으면 승인도 기각도 되지 않는 유령 항목이 된다.
+        // sourceId 는 도메인마다 따로 매겨지므로 타입까지 좁혀야 다른 알림을 지우지 않는다.
+        adminAlertRepository.findByTypeAndSourceId(
+                        team.startup.gwangsan.domain.admin.entity.constant.AlertType.TRADE_CANCEL,
+                        tradeCancel.getId())
+                .ifPresent(adminAlertRepository::delete);
+
+        // CreateAlertServiceImpl 의 TRADE_CANCEL 분기가 buyer 와 seller 양쪽에 AlertReceipt 를
+        // 만든다. memberId 는 수신자가 아니라 존재 검증용이라 한 건만 발행하면 된다.
+        applicationEventPublisher.publishEvent(new CreateAlertEvent(
+                tradeCancel.getId(),
+                tradeCancel.getMember().getId(),
+                AlertType.TRADE_CANCEL
+        ));
+
+        // 철회가 반영되면 대기 중인 요청도 완료된 요청도 남지 않으므로
+        // requestedBySeller 와 requestedAt 이 모두 null 이 된다. 그래야 클라이언트가
+        // 거래 카드를 감추고 재요청 버튼을 다시 열어 준다.
+        chatRoomRepository.findByProductIdAndBuyerAndSeller(product.getId(), buyer, seller)
+                .ifPresent(chatRoom -> {
+                    TradeStateSnapshot tradeState = tradeStateReader.read(product, buyer, seller);
+                    applicationEventPublisher.publishEvent(new TradeStatusChangedEvent(
+                            chatRoom.getId(),
+                            product.getId(),
+                            tradeState.completed(),
+                            tradeState.reserved(),
+                            tradeState.requestedBySeller(),
+                            tradeState.requestedAt()
+                    ));
+                });
+    }
+
+    private MemberDetail getMemberDetail(Long memberId) {
+        return memberDetailRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberDetailException::new);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/TradeCancelService.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/TradeCancelService.java
@@ -1,7 +1,9 @@
 package team.startup.gwangsan.domain.trade.service;
 
+import team.startup.gwangsan.domain.trade.presentation.dto.response.TradeCancelResponse;
+
 import java.util.List;
 
 public interface TradeCancelService {
-    void execute(Long productId, String reason, List<Long> imageIds);
+    TradeCancelResponse execute(Long productId, String reason, List<Long> imageIds);
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImpl.java
@@ -3,11 +3,14 @@ package team.startup.gwangsan.domain.trade.service.impl;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.admin.entity.constant.AlertType;
 import team.startup.gwangsan.domain.image.entity.Image;
 import team.startup.gwangsan.domain.image.repository.ImageRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.TradeCancelImage;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
@@ -16,31 +19,48 @@ import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.exception.AlreadyTradeCancelRequestException;
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCompleteException;
 import team.startup.gwangsan.domain.trade.exception.TradeParticipantOnlyException;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.TradeCancelResponse;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelImageRepository;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.service.TradeCancelApplier;
 import team.startup.gwangsan.domain.trade.service.TradeCancelService;
 import team.startup.gwangsan.global.event.CreateAdminAlertEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class TradeCancelServiceImpl implements TradeCancelService {
 
     private final MemberUtil memberUtil;
+    private final ProductRepository productRepository;
     private final TradeCompleteRepository tradeCompleteRepository;
     private final TradeCancelRepository tradeCancelRepository;
     private final ImageRepository imageRepository;
     private final TradeCancelImageRepository tradeCancelImageRepository;
+    private final TradeCancelApplier tradeCancelApplier;
     private final ApplicationEventPublisher applicationEventPublisher;
 
+    /**
+     * READ_COMMITTED 를 쓰는 이유: 기본값인 REPEATABLE READ 에서는 첫 SELECT 인
+     * {@code getCurrentMember()} 시점에 read view 가 고정된다. 그러면 아래에서 상품 잠금을
+     * 기다리는 동안 상대방 트랜잭션이 철회를 커밋해도 이 트랜잭션은 계속 옛 값을 보고,
+     * 광산이 두 번 환불된다. 잠금을 잡은 뒤의 조회가 최신 커밋본을 보게 해야 한다.
+     */
     @Override
-    @Transactional
-    public void execute(Long productId, String reason, List<Long> imageIds) {
+    @Transactional(isolation = Isolation.READ_COMMITTED)
+    public TradeCancelResponse execute(Long productId, String reason, List<Long> imageIds) {
         Member member = memberUtil.getCurrentMember();
+
+        // 철회 요청·승인·기각·요청 취소가 모두 이 잠금을 거쳐 직렬화된다.
+        // 첫 요청 시점에는 TradeCancel 행이 아직 없으므로 상시 존재하는 상품 행을 잠근다.
+        // 판매자가 철회 대기 중에 글을 지워도 환불이 막히면 안 되므로 삭제된 게시글도 포함한다.
+        productRepository.findByIdForUpdate(productId)
+                .orElseThrow(NotFoundProductException::new);
 
         TradeComplete tradeComplete = tradeCompleteRepository.findByProductIdAndStatus(
                         productId, TradeStatus.COMPLETED)
@@ -51,8 +71,20 @@ public class TradeCancelServiceImpl implements TradeCancelService {
             throw new TradeParticipantOnlyException();
         }
 
-        if (tradeCancelRepository.existsByTradeCompleteIdAndStatus(tradeComplete.getId(), TradeCancelStatus.PENDING)) {
-            throw new AlreadyTradeCancelRequestException();
+        Optional<TradeCancel> pending = tradeCancelRepository.findByTradeCompleteIdAndStatus(
+                tradeComplete.getId(), TradeCancelStatus.PENDING);
+
+        if (pending.isPresent()) {
+            TradeCancel requested = pending.get();
+
+            if (Objects.equals(requested.getMember().getId(), member.getId())) {
+                throw new AlreadyTradeCancelRequestException();
+            }
+
+            // 상대방이 같은 거래의 철회를 요청했다는 것은 양측이 동의했다는 뜻이다.
+            // 두 번째 요청은 동의 신호로만 쓰고 별도 TradeCancel 로 남기지 않는다.
+            tradeCancelApplier.apply(requested);
+            return new TradeCancelResponse(true);
         }
 
         TradeCancel tradeCancel = tradeCancelRepository.save(TradeCancel.builder()
@@ -74,5 +106,7 @@ public class TradeCancelServiceImpl implements TradeCancelService {
         tradeCancelImageRepository.saveAll(tradeCancelImages);
 
         applicationEventPublisher.publishEvent(new CreateAdminAlertEvent(AlertType.TRADE_CANCEL, tradeCancel.getId(), member.getId()));
+
+        return new TradeCancelResponse(false);
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImpl.java
@@ -2,8 +2,11 @@ package team.startup.gwangsan.domain.trade.service.impl;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
@@ -24,14 +27,19 @@ import java.util.Objects;
 public class TradeCancelWithdrawServiceImpl implements TradeCancelWithdrawService {
 
     private final MemberUtil memberUtil;
+    private final ProductRepository productRepository;
     private final TradeCompleteRepository tradeCompleteRepository;
     private final TradeCancelRepository tradeCancelRepository;
     private final TradeCancelImageRepository tradeCancelImageRepository;
 
+    /** 잠금과 격리 수준의 이유는 {@code TradeCancelServiceImpl} 주석 참고. */
     @Override
-    @Transactional
+    @Transactional(isolation = Isolation.READ_COMMITTED)
     public void execute(Long productId) {
         Member member = memberUtil.getCurrentMember();
+
+        productRepository.findByIdForUpdate(productId)
+                .orElseThrow(NotFoundProductException::new);
 
         TradeComplete tradeComplete = tradeCompleteRepository.findByProductIdAndStatus(
                 productId, TradeStatus.COMPLETED)

--- a/src/test/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/admin/service/impl/ApproveTradeCancelServiceImplTest.java
@@ -4,39 +4,30 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 import team.startup.gwangsan.domain.admin.entity.AdminAlert;
 import team.startup.gwangsan.domain.admin.exception.NotFoundAdminAlertException;
 import team.startup.gwangsan.domain.admin.repository.AdminAlertRepository;
 import team.startup.gwangsan.domain.admin.util.ValidatePlaceUtil;
-import team.startup.gwangsan.domain.chat.entity.ChatRoom;
-import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.place.exception.PlaceMismatchException;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
 import team.startup.gwangsan.domain.post.entity.Product;
-import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
-import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
-import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
-import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelException;
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCancelException;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
-import team.startup.gwangsan.domain.trade.service.TradeStateReader;
-import team.startup.gwangsan.domain.trade.service.TradeStateSnapshot;
-import team.startup.gwangsan.global.event.CreateAlertEvent;
-import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+import team.startup.gwangsan.domain.trade.service.TradeCancelApplier;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -45,139 +36,123 @@ import static org.mockito.Mockito.*;
 @DisplayName("ApproveTradeCancelServiceImpl 단위 테스트")
 class ApproveTradeCancelServiceImplTest {
 
-    @InjectMocks
-    private ApproveTradeCancelServiceImpl service;
+    private static final Long ALERT_ID = 10L;
+    private static final Long TRADE_CANCEL_ID = 5L;
+    private static final Long PRODUCT_ID = 7L;
+    private static final Long ADMIN_ID = 1L;
+    private static final Long BUYER_ID = 2L;
+    private static final Long SELLER_ID = 3L;
 
-    @Mock
-    private AdminAlertRepository adminAlertRepository;
+    @InjectMocks private ApproveTradeCancelServiceImpl service;
 
-    @Mock
-    private TradeCancelRepository tradeCancelRepository;
+    @Mock private AdminAlertRepository adminAlertRepository;
+    @Mock private TradeCancelRepository tradeCancelRepository;
+    @Mock private ProductRepository productRepository;
+    @Mock private MemberUtil memberUtil;
+    @Mock private MemberDetailRepository memberDetailRepository;
+    @Mock private ValidatePlaceUtil validatePlaceUtil;
+    @Mock private TradeCancelApplier tradeCancelApplier;
 
-    @Mock
-    private MemberUtil memberUtil;
+    private Member member(Long id) {
+        Member member = mock(Member.class);
+        lenient().when(member.getId()).thenReturn(id);
+        return member;
+    }
 
-    @Mock
-    private MemberDetailRepository memberDetailRepository;
+    /** 관리자 로그인 + 알림 조회까지 준비한다. */
+    private void givenAdminAndAlert() {
+        Member admin = member(ADMIN_ID);
+        when(memberUtil.getCurrentMember()).thenReturn(admin);
 
-    @Mock
-    private ValidatePlaceUtil validatePlaceUtil;
+        AdminAlert alert = mock(AdminAlert.class);
+        lenient().when(alert.getSourceId()).thenReturn(TRADE_CANCEL_ID);
+        when(adminAlertRepository.findByIdWithMember(ALERT_ID)).thenReturn(Optional.of(alert));
 
-    @Mock
-    private ChatRoomRepository chatRoomRepository;
+        when(memberDetailRepository.findById(ADMIN_ID)).thenReturn(Optional.of(mock(MemberDetail.class)));
+    }
 
-    @Mock
-    private TradeStateReader tradeStateReader;
+    /** 잠금까지 통과한 뒤 반환될 TradeCancel 을 준비한다. */
+    private TradeCancel givenLockedTradeCancel() {
+        when(tradeCancelRepository.findProductIdById(TRADE_CANCEL_ID)).thenReturn(Optional.of(PRODUCT_ID));
+        when(productRepository.findByIdForUpdate(PRODUCT_ID)).thenReturn(Optional.of(mock(Product.class)));
 
-    @Mock
-    private ApplicationEventPublisher applicationEventPublisher;
+        Member buyer = member(BUYER_ID);
+        Member seller = member(SELLER_ID);
+
+        TradeComplete tradeComplete = mock(TradeComplete.class);
+        lenient().when(tradeComplete.getBuyer()).thenReturn(buyer);
+        lenient().when(tradeComplete.getSeller()).thenReturn(seller);
+
+        TradeCancel tradeCancel = mock(TradeCancel.class);
+        lenient().when(tradeCancel.getTradeComplete()).thenReturn(tradeComplete);
+
+        when(tradeCancelRepository.findByIdWithTradeCompleteAndBuyerAndSellerAndProduct(TRADE_CANCEL_ID))
+                .thenReturn(Optional.of(tradeCancel));
+
+        lenient().when(memberDetailRepository.findById(BUYER_ID)).thenReturn(Optional.of(mock(MemberDetail.class)));
+        lenient().when(memberDetailRepository.findById(SELLER_ID)).thenReturn(Optional.of(mock(MemberDetail.class)));
+
+        return tradeCancel;
+    }
 
     @Nested
     @DisplayName("execute() 메서드는")
     class Describe_execute {
 
         @Nested
-        @DisplayName("PENDING 상태의 거래 취소 승인 시")
-        class Context_with_pending_trade_cancel {
+        @DisplayName("정상 승인 시")
+        class Context_with_valid_alert {
 
             @Test
-            @DisplayName("광산을 환불하고 상태를 APPROVED/ROLLED_BACK으로 변경 후 이벤트를 발행한다")
-            void it_approves_trade_cancel() {
-                Member admin = mock(Member.class);
-                when(admin.getId()).thenReturn(1L);
+            @DisplayName("상품 행을 잠근 뒤 철회 반영을 TradeCancelApplier 에 위임한다")
+            void it_delegates_to_applier() {
+                givenAdminAndAlert();
+                TradeCancel tradeCancel = givenLockedTradeCancel();
 
-                Member requester = mock(Member.class);
-                when(requester.getId()).thenReturn(4L);
-                AdminAlert alert = mock(AdminAlert.class);
-                when(alert.getSourceId()).thenReturn(5L);
-                when(alert.getRequester()).thenReturn(requester);
+                service.execute(ALERT_ID);
 
-                MemberDetail adminDetail = mock(MemberDetail.class);
-
-                Member buyer = mock(Member.class);
-                when(buyer.getId()).thenReturn(2L);
-                Member seller = mock(Member.class);
-                when(seller.getId()).thenReturn(3L);
-
-                MemberDetail buyerDetail = mock(MemberDetail.class);
-                MemberDetail sellerDetail = mock(MemberDetail.class);
-
-                Product product = mock(Product.class);
-                when(product.getGwangsan()).thenReturn(1000);
-                when(product.getId()).thenReturn(7L);
-
-                ChatRoom chatRoom = mock(ChatRoom.class);
-                when(chatRoom.getId()).thenReturn(77L);
-
-                TradeComplete tradeComplete = mock(TradeComplete.class);
-                when(tradeComplete.getProduct()).thenReturn(product);
-                when(tradeComplete.getBuyer()).thenReturn(buyer);
-                when(tradeComplete.getSeller()).thenReturn(seller);
-
-                TradeCancel tradeCancel = mock(TradeCancel.class);
-                when(tradeCancel.getStatus()).thenReturn(TradeCancelStatus.PENDING);
-                when(tradeCancel.getTradeComplete()).thenReturn(tradeComplete);
-                when(tradeCancel.getId()).thenReturn(5L);
-
-                when(memberUtil.getCurrentMember()).thenReturn(admin);
-                when(adminAlertRepository.findByIdWithMember(10L)).thenReturn(Optional.of(alert));
-                when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
-                when(tradeCancelRepository.findByIdWithTradeCompleteAndBuyerAndSellerAndProduct(5L))
-                        .thenReturn(Optional.of(tradeCancel));
-                when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(buyerDetail));
-                when(memberDetailRepository.findById(3L)).thenReturn(Optional.of(sellerDetail));
-                when(chatRoomRepository.findByProductIdAndBuyerAndSeller(7L, buyer, seller))
-                        .thenReturn(Optional.of(chatRoom));
-                // 철회 승인 후에는 대기 중인 요청도 완료된 요청도 남지 않는다.
-                when(tradeStateReader.read(product, buyer, seller))
-                        .thenReturn(new TradeStateSnapshot(false, false, null, null));
-
-                service.execute(10L);
-
-                verify(buyerDetail).plusGwangsan(1000);
-                verify(sellerDetail).minusGwangsan(1000);
-                verify(tradeCancel).updateStatus(TradeCancelStatus.APPROVED);
-                verify(tradeComplete).updateStatus(TradeStatus.ROLLED_BACK);
-                verify(product).updateStatus(ProductStatus.ONGOING);
-                verify(applicationEventPublisher).publishEvent(any(CreateAlertEvent.class));
-                ArgumentCaptor<TradeStatusChangedEvent> tradeEventCaptor =
-                        ArgumentCaptor.forClass(TradeStatusChangedEvent.class);
-                verify(applicationEventPublisher).publishEvent(tradeEventCaptor.capture());
-                TradeStatusChangedEvent tradeEvent = tradeEventCaptor.getValue();
-                assertFalse(tradeEvent.completed());
-                assertFalse(tradeEvent.reserved());
-                // 값이 남으면 클라이언트가 아직 거래 요청이 있다고 보고 재요청 버튼을 잠근다.
-                assertNull(tradeEvent.requestedBySeller());
-                assertNull(tradeEvent.requestedAt());
+                verify(productRepository).findByIdForUpdate(PRODUCT_ID);
+                verify(tradeCancelApplier).apply(tradeCancel);
             }
-        }
-
-        @Nested
-        @DisplayName("PENDING 상태가 아닌 거래 취소 승인 시")
-        class Context_with_non_pending_trade_cancel {
 
             @Test
-            @DisplayName("CannotPendingTradeCancelException을 던진다")
-            void it_throws_cannot_pending_exception() {
-                Member admin = mock(Member.class);
-                when(admin.getId()).thenReturn(1L);
+            @DisplayName("TradeCancel 은 잠금을 잡은 뒤에 조회한다")
+            void it_loads_trade_cancel_after_locking() {
+                givenAdminAndAlert();
+                givenLockedTradeCancel();
 
-                AdminAlert alert = mock(AdminAlert.class);
-                when(alert.getSourceId()).thenReturn(5L);
+                service.execute(ALERT_ID);
 
-                MemberDetail adminDetail = mock(MemberDetail.class);
+                // 잠금 전에 엔티티를 읽으면 1차 캐시의 옛 상태를 보고 광산이 두 번 환불된다.
+                InOrder order = inOrder(tradeCancelRepository, productRepository);
+                order.verify(tradeCancelRepository).findProductIdById(TRADE_CANCEL_ID);
+                order.verify(productRepository).findByIdForUpdate(PRODUCT_ID);
+                order.verify(tradeCancelRepository).findByIdWithTradeCompleteAndBuyerAndSellerAndProduct(TRADE_CANCEL_ID);
+            }
 
-                TradeCancel tradeCancel = mock(TradeCancel.class);
-                when(tradeCancel.getStatus()).thenReturn(TradeCancelStatus.APPROVED);
+            @Test
+            @DisplayName("구매자와 판매자 모두 관리자와 같은 지역인지 검증한다")
+            void it_validates_place_for_both_sides() {
+                givenAdminAndAlert();
+                givenLockedTradeCancel();
 
-                when(memberUtil.getCurrentMember()).thenReturn(admin);
-                when(adminAlertRepository.findByIdWithMember(10L)).thenReturn(Optional.of(alert));
-                when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
-                when(tradeCancelRepository.findByIdWithTradeCompleteAndBuyerAndSellerAndProduct(5L))
-                        .thenReturn(Optional.of(tradeCancel));
+                service.execute(ALERT_ID);
 
-                assertThatThrownBy(() -> service.execute(10L))
-                        .isInstanceOf(CannotPendingTradeCancelException.class);
+                verify(validatePlaceUtil, times(2)).validateSamePlace(any(), any(), any());
+            }
+
+            @Test
+            @DisplayName("지역이 다르면 철회를 반영하지 않는다")
+            void it_does_not_apply_when_place_mismatched() {
+                givenAdminAndAlert();
+                givenLockedTradeCancel();
+
+                doThrow(new PlaceMismatchException()).when(validatePlaceUtil).validateSamePlace(any(), any(), any());
+
+                assertThatThrownBy(() -> service.execute(ALERT_ID))
+                        .isInstanceOf(PlaceMismatchException.class);
+
+                verify(tradeCancelApplier, never()).apply(any());
             }
         }
 
@@ -188,11 +163,10 @@ class ApproveTradeCancelServiceImplTest {
             @Test
             @DisplayName("NotFoundAdminAlertException을 던진다")
             void it_throws_not_found_admin_alert_exception() {
-                Member admin = mock(Member.class);
-                when(memberUtil.getCurrentMember()).thenReturn(admin);
-                when(adminAlertRepository.findByIdWithMember(10L)).thenReturn(Optional.empty());
+                when(memberUtil.getCurrentMember()).thenReturn(mock(Member.class));
+                when(adminAlertRepository.findByIdWithMember(ALERT_ID)).thenReturn(Optional.empty());
 
-                assertThatThrownBy(() -> service.execute(10L))
+                assertThatThrownBy(() -> service.execute(ALERT_ID))
                         .isInstanceOf(NotFoundAdminAlertException.class);
             }
         }
@@ -204,22 +178,31 @@ class ApproveTradeCancelServiceImplTest {
             @Test
             @DisplayName("NotFoundTradeCancelException을 던진다")
             void it_throws_not_found_trade_cancel_exception() {
-                Member admin = mock(Member.class);
-                when(admin.getId()).thenReturn(1L);
+                givenAdminAndAlert();
+                when(tradeCancelRepository.findProductIdById(TRADE_CANCEL_ID)).thenReturn(Optional.empty());
 
-                AdminAlert alert = mock(AdminAlert.class);
-                when(alert.getSourceId()).thenReturn(5L);
-
-                MemberDetail adminDetail = mock(MemberDetail.class);
-
-                when(memberUtil.getCurrentMember()).thenReturn(admin);
-                when(adminAlertRepository.findByIdWithMember(10L)).thenReturn(Optional.of(alert));
-                when(memberDetailRepository.findById(1L)).thenReturn(Optional.of(adminDetail));
-                when(tradeCancelRepository.findByIdWithTradeCompleteAndBuyerAndSellerAndProduct(5L))
-                        .thenReturn(Optional.empty());
-
-                assertThatThrownBy(() -> service.execute(10L))
+                assertThatThrownBy(() -> service.execute(ALERT_ID))
                         .isInstanceOf(NotFoundTradeCancelException.class);
+
+                verify(productRepository, never()).findByIdForUpdate(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("상품이 삭제되었을 때")
+        class Context_with_product_not_found {
+
+            @Test
+            @DisplayName("NotFoundProductException을 던진다")
+            void it_throws_not_found_product_exception() {
+                givenAdminAndAlert();
+                when(tradeCancelRepository.findProductIdById(TRADE_CANCEL_ID)).thenReturn(Optional.of(PRODUCT_ID));
+                when(productRepository.findByIdForUpdate(PRODUCT_ID)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(ALERT_ID))
+                        .isInstanceOf(NotFoundProductException.class);
+
+                verify(tradeCancelApplier, never()).apply(any());
             }
         }
     }

--- a/src/test/java/team/startup/gwangsan/domain/admin/service/impl/RejectAdminAlertServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/admin/service/impl/RejectAdminAlertServiceImplTest.java
@@ -16,10 +16,13 @@ import team.startup.gwangsan.domain.admin.util.ValidatePlaceUtil;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.domain.member.entity.MemberDetail;
 import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.report.entity.Report;
 import team.startup.gwangsan.domain.report.repository.ReportRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelException;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
 import team.startup.gwangsan.global.event.CreateAlertEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
@@ -54,6 +57,9 @@ class RejectAdminAlertServiceImplTest {
 
     @Mock
     private TradeCancelRepository tradeCancelRepository;
+
+    @Mock
+    private ProductRepository productRepository;
 
     @Mock
     private ApplicationEventPublisher applicationEventPublisher;
@@ -161,15 +167,50 @@ class RejectAdminAlertServiceImplTest {
                 TradeCancel tradeCancel = mock(TradeCancel.class);
                 when(tradeCancel.getId()).thenReturn(7L);
                 when(tradeCancel.getMember()).thenReturn(cancelMember);
+                when(tradeCancel.getStatus()).thenReturn(TradeCancelStatus.PENDING);
 
                 when(adminAlertRepository.findById(10L)).thenReturn(Optional.of(alert));
                 when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(requesterDetail));
+                when(tradeCancelRepository.findProductIdById(7L)).thenReturn(Optional.of(70L));
+                when(productRepository.findByIdForUpdate(70L)).thenReturn(Optional.of(mock(Product.class)));
                 when(tradeCancelRepository.findById(7L)).thenReturn(Optional.of(tradeCancel));
 
                 service.execute(10L);
 
+                verify(productRepository).findByIdForUpdate(70L);
                 verify(tradeCancel).updateStatus(TradeCancelStatus.REJECTED);
                 verify(applicationEventPublisher).publishEvent(any(CreateAlertEvent.class));
+            }
+
+            @Test
+            @DisplayName("이미 처리된 철회는 CannotPendingTradeCancelException을 던진다")
+            void it_throws_when_trade_cancel_already_handled() {
+                Member admin = mock(Member.class);
+                when(admin.getId()).thenReturn(1L);
+                MemberDetail adminDetail = mock(MemberDetail.class);
+                givenAdmin(admin, adminDetail);
+
+                Member requester = mock(Member.class);
+                when(requester.getId()).thenReturn(2L);
+                AdminAlert alert = mock(AdminAlert.class);
+                when(alert.getType()).thenReturn(AlertType.TRADE_CANCEL);
+                when(alert.getRequester()).thenReturn(requester);
+                when(alert.getSourceId()).thenReturn(7L);
+
+                // 양측 동의로 이미 철회가 반영된 뒤 관리자가 기각을 누른 상황.
+                TradeCancel tradeCancel = mock(TradeCancel.class);
+                when(tradeCancel.getStatus()).thenReturn(TradeCancelStatus.APPROVED);
+
+                when(adminAlertRepository.findById(10L)).thenReturn(Optional.of(alert));
+                when(memberDetailRepository.findById(2L)).thenReturn(Optional.of(mock(MemberDetail.class)));
+                when(tradeCancelRepository.findProductIdById(7L)).thenReturn(Optional.of(70L));
+                when(productRepository.findByIdForUpdate(70L)).thenReturn(Optional.of(mock(Product.class)));
+                when(tradeCancelRepository.findById(7L)).thenReturn(Optional.of(tradeCancel));
+
+                assertThatThrownBy(() -> service.execute(10L))
+                        .isInstanceOf(CannotPendingTradeCancelException.class);
+
+                verify(tradeCancel, never()).updateStatus(TradeCancelStatus.REJECTED);
             }
         }
 

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/TradeCancelApplierTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/TradeCancelApplierTest.java
@@ -1,0 +1,288 @@
+package team.startup.gwangsan.domain.trade.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import team.startup.gwangsan.domain.admin.entity.AdminAlert;
+import team.startup.gwangsan.domain.admin.entity.constant.AlertType;
+import team.startup.gwangsan.domain.admin.repository.AdminAlertRepository;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.exception.NotFoundMemberDetailException;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.trade.entity.TradeCancel;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.exception.CannotPendingTradeCancelException;
+import team.startup.gwangsan.global.event.CreateAlertEvent;
+import team.startup.gwangsan.global.event.TradeStatusChangedEvent;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TradeCancelApplier 단위 테스트")
+class TradeCancelApplierTest {
+
+    private static final Long TRADE_CANCEL_ID = 5L;
+    private static final Long PRODUCT_ID = 7L;
+    private static final Long CHAT_ROOM_ID = 77L;
+    private static final Long BUYER_ID = 2L;
+    private static final Long SELLER_ID = 3L;
+    private static final Long REQUESTER_ID = 2L;
+    private static final int GWANGSAN = 1000;
+
+    @InjectMocks private TradeCancelApplier applier;
+
+    @Mock private MemberDetailRepository memberDetailRepository;
+    @Mock private AdminAlertRepository adminAlertRepository;
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private TradeStateReader tradeStateReader;
+    @Mock private ApplicationEventPublisher applicationEventPublisher;
+
+    private Member buyer;
+    private Member seller;
+    private Product product;
+    private TradeComplete tradeComplete;
+    private MemberDetail buyerDetail;
+    private MemberDetail sellerDetail;
+
+    private Member member(Long id) {
+        Member member = mock(Member.class);
+        lenient().when(member.getId()).thenReturn(id);
+        return member;
+    }
+
+    /** PENDING 인 철회 요청과 그 주변 엔티티를 준비한다. */
+    private TradeCancel givenPendingTradeCancel() {
+        buyer = member(BUYER_ID);
+        seller = member(SELLER_ID);
+
+        product = mock(Product.class);
+        lenient().when(product.getId()).thenReturn(PRODUCT_ID);
+        lenient().when(product.getGwangsan()).thenReturn(GWANGSAN);
+
+        tradeComplete = mock(TradeComplete.class);
+        lenient().when(tradeComplete.getProduct()).thenReturn(product);
+        lenient().when(tradeComplete.getBuyer()).thenReturn(buyer);
+        lenient().when(tradeComplete.getSeller()).thenReturn(seller);
+
+        Member requester = member(REQUESTER_ID);
+
+        TradeCancel tradeCancel = mock(TradeCancel.class);
+        lenient().when(tradeCancel.getId()).thenReturn(TRADE_CANCEL_ID);
+        lenient().when(tradeCancel.getStatus()).thenReturn(TradeCancelStatus.PENDING);
+        lenient().when(tradeCancel.getTradeComplete()).thenReturn(tradeComplete);
+        lenient().when(tradeCancel.getMember()).thenReturn(requester);
+
+        buyerDetail = mock(MemberDetail.class);
+        sellerDetail = mock(MemberDetail.class);
+        lenient().when(memberDetailRepository.findById(BUYER_ID)).thenReturn(Optional.of(buyerDetail));
+        lenient().when(memberDetailRepository.findById(SELLER_ID)).thenReturn(Optional.of(sellerDetail));
+
+        return tradeCancel;
+    }
+
+    private void givenNoAdminAlert() {
+        lenient().when(adminAlertRepository.findByTypeAndSourceId(AlertType.TRADE_CANCEL, TRADE_CANCEL_ID))
+                .thenReturn(Optional.empty());
+    }
+
+    private void givenNoChatRoom() {
+        lenient().when(chatRoomRepository.findByProductIdAndBuyerAndSeller(PRODUCT_ID, buyer, seller))
+                .thenReturn(Optional.empty());
+    }
+
+    @Nested
+    @DisplayName("apply() 메서드는")
+    class Describe_apply {
+
+        @Nested
+        @DisplayName("PENDING 상태의 철회 요청을 받으면")
+        class Context_with_pending_trade_cancel {
+
+            @Test
+            @DisplayName("구매자에게 환불하고 판매자에게서 차감한다")
+            void it_moves_gwangsan_back() {
+                TradeCancel tradeCancel = givenPendingTradeCancel();
+                givenNoAdminAlert();
+                givenNoChatRoom();
+
+                applier.apply(tradeCancel);
+
+                verify(buyerDetail).plusGwangsan(GWANGSAN);
+                verify(sellerDetail).minusGwangsan(GWANGSAN);
+            }
+
+            @Test
+            @DisplayName("철회·거래·상품 상태를 모두 되돌린다")
+            void it_rolls_back_every_status() {
+                TradeCancel tradeCancel = givenPendingTradeCancel();
+                givenNoAdminAlert();
+                givenNoChatRoom();
+
+                applier.apply(tradeCancel);
+
+                verify(tradeCancel).updateStatus(TradeCancelStatus.APPROVED);
+                verify(tradeComplete).updateStatus(TradeStatus.ROLLED_BACK);
+                verify(product).updateStatus(ProductStatus.ONGOING);
+            }
+
+            @Test
+            @DisplayName("철회 완료 알림 이벤트를 발행한다")
+            void it_publishes_create_alert_event() {
+                TradeCancel tradeCancel = givenPendingTradeCancel();
+                givenNoAdminAlert();
+                givenNoChatRoom();
+
+                applier.apply(tradeCancel);
+
+                ArgumentCaptor<CreateAlertEvent> captor = ArgumentCaptor.forClass(CreateAlertEvent.class);
+                verify(applicationEventPublisher).publishEvent(captor.capture());
+
+                CreateAlertEvent event = captor.getValue();
+                assertThat(event.sourceId()).isEqualTo(TRADE_CANCEL_ID);
+                assertThat(event.memberId()).isEqualTo(REQUESTER_ID);
+                assertThat(event.alertType())
+                        .isEqualTo(team.startup.gwangsan.domain.alert.entity.constant.AlertType.TRADE_CANCEL);
+            }
+
+            @Test
+            @DisplayName("남아 있는 관리자 알림을 지운다")
+            void it_deletes_admin_alert() {
+                TradeCancel tradeCancel = givenPendingTradeCancel();
+                givenNoChatRoom();
+
+                AdminAlert alert = mock(AdminAlert.class);
+                when(adminAlertRepository.findByTypeAndSourceId(AlertType.TRADE_CANCEL, TRADE_CANCEL_ID))
+                        .thenReturn(Optional.of(alert));
+
+                applier.apply(tradeCancel);
+
+                verify(adminAlertRepository).delete(alert);
+            }
+
+            @Test
+            @DisplayName("관리자 알림이 이미 없으면 삭제를 시도하지 않는다")
+            void it_skips_delete_when_admin_alert_absent() {
+                TradeCancel tradeCancel = givenPendingTradeCancel();
+                givenNoAdminAlert();
+                givenNoChatRoom();
+
+                applier.apply(tradeCancel);
+
+                verify(adminAlertRepository, never()).delete(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("채팅방이 있을 때")
+        class Context_with_chat_room {
+
+            @Test
+            @DisplayName("대기 중인 요청이 없는 상태로 거래 상태 이벤트를 발행한다")
+            void it_publishes_trade_status_changed_event() {
+                TradeCancel tradeCancel = givenPendingTradeCancel();
+                givenNoAdminAlert();
+
+                ChatRoom chatRoom = mock(ChatRoom.class);
+                when(chatRoom.getId()).thenReturn(CHAT_ROOM_ID);
+                when(chatRoomRepository.findByProductIdAndBuyerAndSeller(PRODUCT_ID, buyer, seller))
+                        .thenReturn(Optional.of(chatRoom));
+                // 철회가 반영되면 대기 중인 요청도 완료된 요청도 남지 않는다.
+                when(tradeStateReader.read(product, buyer, seller))
+                        .thenReturn(new TradeStateSnapshot(false, false, null, null));
+
+                applier.apply(tradeCancel);
+
+                // 알림 이벤트와 거래 상태 이벤트가 함께 나가므로 타입으로 골라낸다.
+                ArgumentCaptor<Object> captor = ArgumentCaptor.forClass(Object.class);
+                verify(applicationEventPublisher, times(2)).publishEvent(captor.capture());
+
+                TradeStatusChangedEvent event = captor.getAllValues().stream()
+                        .filter(TradeStatusChangedEvent.class::isInstance)
+                        .map(TradeStatusChangedEvent.class::cast)
+                        .findFirst()
+                        .orElseThrow();
+
+                assertThat(event.roomId()).isEqualTo(CHAT_ROOM_ID);
+                assertThat(event.productId()).isEqualTo(PRODUCT_ID);
+                assertFalse(event.completed());
+                assertFalse(event.reserved());
+                // 값이 남으면 클라이언트가 아직 거래 요청이 있다고 보고 재요청 버튼을 잠근다.
+                assertNull(event.requestedBySeller());
+                assertNull(event.requestedAt());
+            }
+        }
+
+        @Nested
+        @DisplayName("채팅방이 없을 때")
+        class Context_without_chat_room {
+
+            @Test
+            @DisplayName("거래 상태 이벤트를 발행하지 않는다")
+            void it_does_not_publish_trade_status_changed_event() {
+                TradeCancel tradeCancel = givenPendingTradeCancel();
+                givenNoAdminAlert();
+                givenNoChatRoom();
+
+                applier.apply(tradeCancel);
+
+                verify(applicationEventPublisher, never()).publishEvent(any(TradeStatusChangedEvent.class));
+                verify(tradeStateReader, never()).read(any(), any(), any());
+            }
+        }
+
+        @Nested
+        @DisplayName("PENDING 상태가 아닐 때")
+        class Context_with_non_pending_trade_cancel {
+
+            @Test
+            @DisplayName("CannotPendingTradeCancelException을 던지고 아무것도 바꾸지 않는다")
+            void it_throws_and_changes_nothing() {
+                TradeCancel tradeCancel = mock(TradeCancel.class);
+                when(tradeCancel.getStatus()).thenReturn(TradeCancelStatus.APPROVED);
+
+                assertThatThrownBy(() -> applier.apply(tradeCancel))
+                        .isInstanceOf(CannotPendingTradeCancelException.class);
+
+                verifyNoInteractions(memberDetailRepository, adminAlertRepository,
+                        chatRoomRepository, tradeStateReader, applicationEventPublisher);
+            }
+        }
+
+        @Nested
+        @DisplayName("회원 상세 정보가 없을 때")
+        class Context_with_member_detail_not_found {
+
+            @Test
+            @DisplayName("NotFoundMemberDetailException을 던진다")
+            void it_throws_not_found_member_detail_exception() {
+                TradeCancel tradeCancel = givenPendingTradeCancel();
+                when(memberDetailRepository.findById(BUYER_ID)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> applier.apply(tradeCancel))
+                        .isInstanceOf(NotFoundMemberDetailException.class);
+
+                verify(applicationEventPublisher, never()).publishEvent(any());
+            }
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelConcurrencyTest.java
@@ -1,0 +1,229 @@
+package team.startup.gwangsan.domain.trade.service.impl;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import team.startup.gwangsan.domain.dong.entity.Dong;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.place.entity.Head;
+import team.startup.gwangsan.domain.place.entity.Place;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.Type;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
+import team.startup.gwangsan.domain.trade.entity.TradeCancel;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
+import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.member.repository.MemberDetailRepository;
+import team.startup.gwangsan.domain.trade.service.TradeCancelApplier;
+import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * 구매자와 판매자가 동시에 철회를 요청해도 광산이 정확히 한 번만 이동하는지 검증한다.
+ *
+ * <p>H2 로는 이 테스트를 쓸 수 없다. 이번에 막은 결함은 InnoDB 의 {@code FOR UPDATE} 동작과
+ * REPEATABLE READ 스냅샷에서만 재현되는데 H2 는 둘 다 그대로 흉내 내지 않는다. 그래서
+ * 실제 MariaDB 컨테이너를 띄운다.
+ *
+ * <p>{@code @DataJpaTest} 의 기본 트랜잭션은 꺼 둔다. 두 스레드가 각자 자기 트랜잭션을 열어야
+ * 잠금 경합이 생기기 때문이다.
+ */
+@DataJpaTest
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QueryDslConfig.class, TradeCancelServiceImpl.class, TradeCancelApplier.class,
+        team.startup.gwangsan.domain.trade.service.TradeStateReader.class})
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@DisplayName("거래 철회 동시 요청 통합 테스트")
+class TradeCancelConcurrencyTest {
+
+    private static final int GWANGSAN = 5_000;
+
+    @Container
+    static final MariaDBContainer<?> mariadb = new MariaDBContainer<>("mariadb:11.4");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mariadb::getJdbcUrl);
+        registry.add("spring.datasource.username", mariadb::getUsername);
+        registry.add("spring.datasource.password", mariadb::getPassword);
+        registry.add("spring.datasource.driver-class-name", mariadb::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    /** 스레드마다 다른 사용자로 요청하기 위해 현재 회원을 스레드 로컬로 흘려 넣는다. */
+    private static final ThreadLocal<Member> CURRENT_MEMBER = new ThreadLocal<>();
+
+    @MockitoBean
+    private MemberUtil memberUtil;
+
+    @Autowired private TradeCancelServiceImpl tradeCancelService;
+    @Autowired private TradeCompleteRepository tradeCompleteRepository;
+    @Autowired private TradeCancelRepository tradeCancelRepository;
+    @Autowired private MemberDetailRepository memberDetailRepository;
+    @Autowired private ProductRepository productRepository;
+    @Autowired private EntityManager entityManager;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    @Test
+    @DisplayName("양측이 동시에 철회를 요청해도 광산은 한 번만 이동하고 철회 요청도 한 건만 남는다")
+    void it_moves_gwangsan_exactly_once() throws Exception {
+        when(memberUtil.getCurrentMember()).thenAnswer(invocation -> CURRENT_MEMBER.get());
+
+        Fixture fixture = persistCompletedTrade();
+
+        int buyerBefore = gwangsanOf(fixture.buyerId);
+        int sellerBefore = gwangsanOf(fixture.sellerId);
+
+        runConcurrently(fixture.buyer, fixture.seller, fixture.productId);
+
+        // 광산은 정확히 1회분만 이동해야 한다. 잠금이 없으면 PENDING 이 두 건 생겨
+        // 아무 이동도 일어나지 않거나(둘 다 첫 요청으로 처리), 두 번 환불된다.
+        assertThat(gwangsanOf(fixture.buyerId)).isEqualTo(buyerBefore + GWANGSAN);
+        assertThat(gwangsanOf(fixture.sellerId)).isEqualTo(sellerBefore - GWANGSAN);
+
+        List<TradeCancel> cancels = tradeCancelRepository.findAll();
+        assertThat(cancels).hasSize(1);
+        assertThat(cancels.get(0).getStatus()).isEqualTo(TradeCancelStatus.APPROVED);
+
+        TradeComplete tradeComplete = tradeCompleteRepository.findById(fixture.tradeCompleteId).orElseThrow();
+        assertThat(tradeComplete.getStatus()).isEqualTo(TradeStatus.ROLLED_BACK);
+
+        Product product = productRepository.findById(fixture.productId).orElseThrow();
+        assertThat(product.getStatus()).isEqualTo(ProductStatus.ONGOING);
+    }
+
+    /** 두 요청을 같은 순간에 출발시킨다. 예외는 정상 결과다 — 한쪽이 늦게 도착하면 자동 철회가 된다. */
+    private void runConcurrently(Member buyer, Member seller, Long productId) throws Exception {
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(2);
+        AtomicReference<Throwable> unexpected = new AtomicReference<>();
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        for (Member requester : List.of(buyer, seller)) {
+            pool.submit(() -> {
+                CURRENT_MEMBER.set(requester);
+                try {
+                    start.await();
+                    tradeCancelService.execute(productId, "동시 요청", List.of());
+                } catch (RuntimeException e) {
+                    // AlreadyTradeCancelRequestException 등 도메인 예외는 허용된 결과다.
+                    if (!e.getClass().getPackageName().startsWith("team.startup.gwangsan")) {
+                        unexpected.set(e);
+                    }
+                } catch (Throwable t) {
+                    unexpected.set(t);
+                } finally {
+                    CURRENT_MEMBER.remove();
+                    done.countDown();
+                }
+            });
+        }
+
+        start.countDown();
+        assertThat(done.await(30, TimeUnit.SECONDS)).isTrue();
+        pool.shutdownNow();
+
+        assertThat(unexpected.get()).isNull();
+    }
+
+    private int gwangsanOf(Long memberId) {
+        return memberDetailRepository.findById(memberId).orElseThrow().getGwangsan();
+    }
+
+    private record Fixture(Member buyer, Member seller, Long buyerId, Long sellerId,
+                           Long productId, Long tradeCompleteId) {
+    }
+
+    /**
+     * 픽스처는 커밋해 둬야 다른 스레드가 볼 수 있다. 테스트 자체는 트랜잭션이 꺼져 있으므로
+     * TransactionTemplate 으로 별도 트랜잭션을 열어 저장한다.
+     */
+    private Fixture persistCompletedTrade() {
+        return new TransactionTemplate(transactionManager).execute(status -> {
+            Head head = new Head("본부");
+            entityManager.persist(head);
+            Place place = Place.builder().name("지점").head(head).build();
+            entityManager.persist(place);
+            // MemberDetail.dong 이 @OneToOne 이라 dong_id 에 유니크 제약이 걸린다.
+            // 두 회원이 같은 동을 공유할 수 없어 따로 만든다.
+            Dong buyerDong = Dong.builder().name("구매자동").build();
+            Dong sellerDong = Dong.builder().name("판매자동").build();
+            entityManager.persist(buyerDong);
+            entityManager.persist(sellerDong);
+
+            Member buyer = member("구매자", "010-0000-0001");
+            Member seller = member("판매자", "010-0000-0002");
+            entityManager.persist(buyer);
+            entityManager.persist(seller);
+
+            entityManager.persist(memberDetail(buyer, buyerDong, place));
+            entityManager.persist(memberDetail(seller, sellerDong, place));
+
+            Product product = Product.builder()
+                    .title("상품").description("설명").gwangsan(GWANGSAN)
+                    .member(seller).type(Type.SERVICE).mode(Mode.GIVER)
+                    .status(ProductStatus.COMPLETED)
+                    .build();
+            entityManager.persist(product);
+
+            TradeComplete tradeComplete = TradeComplete.builder()
+                    .product(product).buyer(buyer).seller(seller)
+                    .status(TradeStatus.COMPLETED).requestedBySeller(true)
+                    .build();
+            entityManager.persist(tradeComplete);
+
+            entityManager.flush();
+
+            return new Fixture(buyer, seller, buyer.getId(), seller.getId(),
+                    product.getId(), tradeComplete.getId());
+        });
+    }
+
+    private Member member(String name, String phoneNumber) {
+        return Member.builder()
+                .name(name).nickname(name).password("pw").phoneNumber(phoneNumber)
+                .role(MemberRole.ROLE_USER).status(MemberStatus.ACTIVE)
+                .build();
+    }
+
+    private MemberDetail memberDetail(Member member, Dong dong, Place place) {
+        return MemberDetail.builder()
+                .member(member).dong(dong).gwangsan(GWANGSAN * 2)
+                .place(place).light(0).description("소개")
+                .build();
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelServiceImplTest.java
@@ -8,10 +8,12 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import team.startup.gwangsan.global.event.CreateAdminAlertEvent;
 import team.startup.gwangsan.domain.image.entity.Image;
 import team.startup.gwangsan.domain.image.repository.ImageRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.exception.NotFoundProductException;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
@@ -19,14 +21,18 @@ import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
 import team.startup.gwangsan.domain.trade.exception.AlreadyTradeCancelRequestException;
 import team.startup.gwangsan.domain.trade.exception.NotFoundTradeCompleteException;
 import team.startup.gwangsan.domain.trade.exception.TradeParticipantOnlyException;
+import team.startup.gwangsan.domain.trade.presentation.dto.response.TradeCancelResponse;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelImageRepository;
 import team.startup.gwangsan.domain.trade.repository.TradeCancelRepository;
 import team.startup.gwangsan.domain.trade.repository.TradeCompleteRepository;
+import team.startup.gwangsan.domain.trade.service.TradeCancelApplier;
+import team.startup.gwangsan.global.event.CreateAdminAlertEvent;
 import team.startup.gwangsan.global.util.MemberUtil;
 
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -35,54 +41,203 @@ import static org.mockito.Mockito.*;
 @DisplayName("TradeCancelServiceImpl 단위 테스트")
 class TradeCancelServiceImplTest {
 
+    private static final Long PRODUCT_ID = 100L;
+    private static final Long TRADE_COMPLETE_ID = 10L;
+    private static final Long BUYER_ID = 1L;
+    private static final Long SELLER_ID = 2L;
+
     @InjectMocks private TradeCancelServiceImpl service;
 
     @Mock private MemberUtil memberUtil;
+    @Mock private ProductRepository productRepository;
     @Mock private TradeCompleteRepository tradeCompleteRepository;
     @Mock private TradeCancelRepository tradeCancelRepository;
     @Mock private ImageRepository imageRepository;
     @Mock private TradeCancelImageRepository tradeCancelImageRepository;
+    @Mock private TradeCancelApplier tradeCancelApplier;
     @Mock private ApplicationEventPublisher applicationEventPublisher;
+
+    // 케이스마다 실제로 호출되는 getter 가 달라(구매자가 먼저 매치되면 판매자 getId() 는
+    // 호출되지 않는다) 헬퍼가 만드는 목은 lenient 로 둔다. 동작 검증은 verify 로 한다.
+    private Member member(Long id) {
+        Member member = mock(Member.class);
+        lenient().when(member.getId()).thenReturn(id);
+        return member;
+    }
+
+    /** 잠긴 상품 + COMPLETED 거래를 준비하고 그 거래를 돌려준다. */
+    private TradeComplete givenLockedTrade() {
+        Member buyer = member(BUYER_ID);
+        Member seller = member(SELLER_ID);
+
+        TradeComplete tradeComplete = mock(TradeComplete.class);
+        lenient().when(tradeComplete.getId()).thenReturn(TRADE_COMPLETE_ID);
+        lenient().when(tradeComplete.getBuyer()).thenReturn(buyer);
+        lenient().when(tradeComplete.getSeller()).thenReturn(seller);
+
+        Product product = mock(Product.class);
+        when(productRepository.findByIdForUpdate(PRODUCT_ID)).thenReturn(Optional.of(product));
+        when(tradeCompleteRepository.findByProductIdAndStatus(PRODUCT_ID, TradeStatus.COMPLETED))
+                .thenReturn(Optional.of(tradeComplete));
+
+        return tradeComplete;
+    }
+
+    private TradeCancel pendingRequestedBy(Long memberId) {
+        Member requester = member(memberId);
+        TradeCancel tradeCancel = mock(TradeCancel.class);
+        lenient().when(tradeCancel.getMember()).thenReturn(requester);
+        return tradeCancel;
+    }
+
+    private void givenPending(TradeCancel tradeCancel) {
+        when(tradeCancelRepository.findByTradeCompleteIdAndStatus(TRADE_COMPLETE_ID, TradeCancelStatus.PENDING))
+                .thenReturn(Optional.ofNullable(tradeCancel));
+    }
 
     @Nested
     @DisplayName("execute() 메서드는")
     class Describe_execute {
 
         @Nested
-        @DisplayName("정상 요청일 때")
-        class Context_with_valid_request {
+        @DisplayName("대기 중인 철회 요청이 없을 때")
+        class Context_without_pending_request {
 
             @Test
-            @DisplayName("취소 요청을 저장하고 이벤트를 발행한다")
+            @DisplayName("취소 요청을 저장하고 관리자 알림 이벤트를 발행한다")
             void it_saves_trade_cancel_and_publishes_event() {
-                Member member = mock(Member.class);
-                when(member.getId()).thenReturn(1L);
-                when(memberUtil.getCurrentMember()).thenReturn(member);
+                Member currentMember = member(BUYER_ID);
+                when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+                givenLockedTrade();
+                givenPending(null);
 
-                Member buyer = mock(Member.class);
-                when(buyer.getId()).thenReturn(1L);
+                TradeCancel saved = mock(TradeCancel.class);
+                lenient().when(saved.getId()).thenReturn(20L);
+                when(tradeCancelRepository.save(any())).thenReturn(saved);
+                when(imageRepository.findAllById(List.of(5L))).thenReturn(List.of(mock(Image.class)));
 
-                TradeComplete tradeComplete = mock(TradeComplete.class);
-                when(tradeComplete.getId()).thenReturn(10L);
-                when(tradeComplete.getBuyer()).thenReturn(buyer);
+                TradeCancelResponse response = service.execute(PRODUCT_ID, "이유", List.of(5L));
 
-                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
-                        .thenReturn(Optional.of(tradeComplete));
-                when(tradeCancelRepository.existsByTradeCompleteIdAndStatus(10L, TradeCancelStatus.PENDING))
-                        .thenReturn(false);
-
-                TradeCancel savedCancel = mock(TradeCancel.class);
-                when(savedCancel.getId()).thenReturn(20L);
-                when(tradeCancelRepository.save(any())).thenReturn(savedCancel);
-
-                Image image = mock(Image.class);
-                when(imageRepository.findAllById(List.of(5L))).thenReturn(List.of(image));
-
-                service.execute(100L, "이유", List.of(5L));
-
+                // 관리자 승인 대기 상태임을 클라이언트가 알 수 있어야 한다.
+                assertThat(response.cancelled()).isFalse();
                 verify(tradeCancelRepository).save(any());
                 verify(tradeCancelImageRepository).saveAll(any());
                 verify(applicationEventPublisher).publishEvent(any(CreateAdminAlertEvent.class));
+                verify(tradeCancelApplier, never()).apply(any());
+            }
+
+            @Test
+            @DisplayName("상품 행을 비관적 잠금으로 조회한다")
+            void it_locks_product_row() {
+                Member currentMember = member(BUYER_ID);
+                when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+                givenLockedTrade();
+                givenPending(null);
+                when(tradeCancelRepository.save(any())).thenReturn(mock(TradeCancel.class));
+
+                service.execute(PRODUCT_ID, "이유", List.of());
+
+                verify(productRepository).findByIdForUpdate(PRODUCT_ID);
+            }
+        }
+
+        @Nested
+        @DisplayName("상대방이 이미 철회를 요청했을 때")
+        class Context_with_counterpart_request {
+
+            @Test
+            @DisplayName("양측 동의로 보고 즉시 철회하며 새 요청을 저장하지 않는다")
+            void it_applies_cancel_immediately() {
+                Member currentMember = member(SELLER_ID);
+                when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+                givenLockedTrade();
+
+                TradeCancel requestedByBuyer = pendingRequestedBy(BUYER_ID);
+                givenPending(requestedByBuyer);
+
+                TradeCancelResponse response = service.execute(PRODUCT_ID, "저도 철회합니다", List.of(5L));
+
+                // 즉시 철회까지 끝났음을 알려야 한다. 응답 코드는 첫 요청과 같은 200 이다.
+                assertThat(response.cancelled()).isTrue();
+                verify(tradeCancelApplier).apply(requestedByBuyer);
+                verify(tradeCancelRepository, never()).save(any());
+                verify(tradeCancelImageRepository, never()).saveAll(any());
+                verify(imageRepository, never()).findAllById(any());
+                verify(applicationEventPublisher, never()).publishEvent(any(CreateAdminAlertEvent.class));
+            }
+
+            @Test
+            @DisplayName("구매자가 동의하는 방향에서도 똑같이 즉시 철회한다")
+            void it_applies_cancel_for_buyer_side_too() {
+                Member currentMember = member(BUYER_ID);
+                when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+                givenLockedTrade();
+
+                TradeCancel requestedBySeller = pendingRequestedBy(SELLER_ID);
+                givenPending(requestedBySeller);
+
+                service.execute(PRODUCT_ID, "이유", List.of());
+
+                verify(tradeCancelApplier).apply(requestedBySeller);
+                verify(tradeCancelRepository, never()).save(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("같은 요청자가 다시 요청할 때")
+        class Context_with_same_requester {
+
+            @Test
+            @DisplayName("AlreadyTradeCancelRequestException을 던진다")
+            void it_throws_already_trade_cancel_request_exception() {
+                Member currentMember = member(BUYER_ID);
+                when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+                givenLockedTrade();
+                givenPending(pendingRequestedBy(BUYER_ID));
+
+                assertThatThrownBy(() -> service.execute(PRODUCT_ID, "이유", List.of()))
+                        .isInstanceOf(AlreadyTradeCancelRequestException.class);
+
+                verify(tradeCancelApplier, never()).apply(any());
+                verify(tradeCancelRepository, never()).save(any());
+            }
+        }
+
+        @Nested
+        @DisplayName("판매자가 게시글을 삭제한 뒤에도")
+        class Context_with_deleted_product {
+
+            @Test
+            @DisplayName("삭제 여부를 가리지 않는 잠금을 써서 철회를 막지 않는다")
+            void it_does_not_block_cancel_for_deleted_product() {
+                Member currentMember = member(SELLER_ID);
+                when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+                givenLockedTrade();
+
+                TradeCancel requestedByBuyer = pendingRequestedBy(BUYER_ID);
+                givenPending(requestedByBuyer);
+
+                service.execute(PRODUCT_ID, "이유", List.of());
+
+                // findByIdWithLock 은 DELETED 를 제외하므로 여기서 쓰면 환불이 영구히 막힌다.
+                verify(productRepository).findByIdForUpdate(PRODUCT_ID);
+                verify(productRepository, never()).findByIdWithLock(any());
+                verify(tradeCancelApplier).apply(requestedByBuyer);
+            }
+        }
+
+        @Nested
+        @DisplayName("상품이 없을 때")
+        class Context_with_product_not_found {
+
+            @Test
+            @DisplayName("NotFoundProductException을 던진다")
+            void it_throws_not_found_product_exception() {
+                when(memberUtil.getCurrentMember()).thenReturn(mock(Member.class));
+                when(productRepository.findByIdForUpdate(PRODUCT_ID)).thenReturn(Optional.empty());
+
+                assertThatThrownBy(() -> service.execute(PRODUCT_ID, "이유", List.of()))
+                        .isInstanceOf(NotFoundProductException.class);
             }
         }
 
@@ -93,12 +248,12 @@ class TradeCancelServiceImplTest {
             @Test
             @DisplayName("NotFoundTradeCompleteException을 던진다")
             void it_throws_not_found_trade_complete_exception() {
-                Member member = mock(Member.class);
-                when(memberUtil.getCurrentMember()).thenReturn(member);
-                when(tradeCompleteRepository.findByProductIdAndStatus(99L, TradeStatus.COMPLETED))
+                when(memberUtil.getCurrentMember()).thenReturn(mock(Member.class));
+                when(productRepository.findByIdForUpdate(PRODUCT_ID)).thenReturn(Optional.of(mock(Product.class)));
+                when(tradeCompleteRepository.findByProductIdAndStatus(PRODUCT_ID, TradeStatus.COMPLETED))
                         .thenReturn(Optional.empty());
 
-                assertThatThrownBy(() -> service.execute(99L, "이유", List.of()))
+                assertThatThrownBy(() -> service.execute(PRODUCT_ID, "이유", List.of()))
                         .isInstanceOf(NotFoundTradeCompleteException.class);
             }
         }
@@ -110,52 +265,14 @@ class TradeCancelServiceImplTest {
             @Test
             @DisplayName("TradeParticipantOnlyException을 던진다")
             void it_throws_trade_participant_only_exception() {
-                Member member = mock(Member.class);
-                when(member.getId()).thenReturn(99L);
-                when(memberUtil.getCurrentMember()).thenReturn(member);
+                Member currentMember = member(99L);
+                when(memberUtil.getCurrentMember()).thenReturn(currentMember);
+                givenLockedTrade();
 
-                Member buyer = mock(Member.class);
-                when(buyer.getId()).thenReturn(1L);
-                Member seller = mock(Member.class);
-                when(seller.getId()).thenReturn(2L);
-
-                TradeComplete tradeComplete = mock(TradeComplete.class);
-                when(tradeComplete.getBuyer()).thenReturn(buyer);
-                when(tradeComplete.getSeller()).thenReturn(seller);
-
-                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
-                        .thenReturn(Optional.of(tradeComplete));
-
-                assertThatThrownBy(() -> service.execute(100L, "이유", List.of()))
+                assertThatThrownBy(() -> service.execute(PRODUCT_ID, "이유", List.of()))
                         .isInstanceOf(TradeParticipantOnlyException.class);
-            }
-        }
 
-        @Nested
-        @DisplayName("이미 취소 요청이 있을 때")
-        class Context_with_already_requested {
-
-            @Test
-            @DisplayName("AlreadyTradeCancelRequestException을 던진다")
-            void it_throws_already_trade_cancel_request_exception() {
-                Member member = mock(Member.class);
-                when(member.getId()).thenReturn(1L);
-                when(memberUtil.getCurrentMember()).thenReturn(member);
-
-                Member buyer = mock(Member.class);
-                when(buyer.getId()).thenReturn(1L);
-
-                TradeComplete tradeComplete = mock(TradeComplete.class);
-                when(tradeComplete.getId()).thenReturn(10L);
-                when(tradeComplete.getBuyer()).thenReturn(buyer);
-
-                when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
-                        .thenReturn(Optional.of(tradeComplete));
-                when(tradeCancelRepository.existsByTradeCompleteIdAndStatus(10L, TradeCancelStatus.PENDING))
-                        .thenReturn(true);
-
-                assertThatThrownBy(() -> service.execute(100L, "이유", List.of()))
-                        .isInstanceOf(AlreadyTradeCancelRequestException.class);
+                verify(tradeCancelApplier, never()).apply(any());
             }
         }
     }

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelWithdrawServiceImplTest.java
@@ -8,6 +8,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.repository.ProductRepository;
 import team.startup.gwangsan.domain.trade.entity.TradeCancel;
 import team.startup.gwangsan.domain.trade.entity.TradeComplete;
 import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
@@ -32,6 +34,7 @@ class TradeCancelWithdrawServiceImplTest {
     @InjectMocks private TradeCancelWithdrawServiceImpl service;
 
     @Mock private MemberUtil memberUtil;
+    @Mock private ProductRepository productRepository;
     @Mock private TradeCompleteRepository tradeCompleteRepository;
     @Mock private TradeCancelRepository tradeCancelRepository;
     @Mock private TradeCancelImageRepository tradeCancelImageRepository;
@@ -53,6 +56,7 @@ class TradeCancelWithdrawServiceImplTest {
 
                 TradeComplete tradeComplete = mock(TradeComplete.class);
                 when(tradeComplete.getId()).thenReturn(10L);
+                when(productRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(mock(Product.class)));
                 when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(tradeComplete));
 
@@ -81,6 +85,7 @@ class TradeCancelWithdrawServiceImplTest {
             void it_throws_not_found_trade_complete_exception() {
                 Member member = mock(Member.class);
                 when(memberUtil.getCurrentMember()).thenReturn(member);
+                when(productRepository.findByIdForUpdate(99L)).thenReturn(Optional.of(mock(Product.class)));
                 when(tradeCompleteRepository.findByProductIdAndStatus(99L, TradeStatus.COMPLETED))
                         .thenReturn(Optional.empty());
 
@@ -101,6 +106,7 @@ class TradeCancelWithdrawServiceImplTest {
 
                 TradeComplete tradeComplete = mock(TradeComplete.class);
                 when(tradeComplete.getId()).thenReturn(10L);
+                when(productRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(mock(Product.class)));
                 when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(tradeComplete));
                 when(tradeCancelRepository.findByTradeCompleteIdAndStatus(10L, TradeCancelStatus.PENDING))
@@ -124,6 +130,7 @@ class TradeCancelWithdrawServiceImplTest {
 
                 TradeComplete tradeComplete = mock(TradeComplete.class);
                 when(tradeComplete.getId()).thenReturn(10L);
+                when(productRepository.findByIdForUpdate(100L)).thenReturn(Optional.of(mock(Product.class)));
                 when(tradeCompleteRepository.findByProductIdAndStatus(100L, TradeStatus.COMPLETED))
                         .thenReturn(Optional.of(tradeComplete));
 


### PR DESCRIPTION
## 💡 배경 및 개요

완료된 거래에서 한쪽이 철회를 요청하면 `TradeCancel` 이 `PENDING` 으로 생성되고 관리자 승인을 기다립니다. 그런데 중복 검사가 **요청자를 구분하지 않았습니다.**

```java
// 변경 전 TradeCancelServiceImpl:54
if (tradeCancelRepository.existsByTradeCompleteIdAndStatus(tradeComplete.getId(), TradeCancelStatus.PENDING)) {
    throw new AlreadyTradeCancelRequestException();
}
```

그래서 상대방이 "나도 철회에 동의한다"는 뜻으로 요청해도 409 로 막혔고, 양측이 이미 합의한 거래인데도 관리자 승인을 기다려야 했습니다.

이제 상대방의 요청을 **양측 동의 신호**로 해석해 즉시 철회합니다. 철회 결과(광산 환불/차감, 상태 전이, 알림, 채팅 동기화)는 기존 관리자 승인과 완전히 동일합니다.

Resolves: #385

## 📃 작업내용

**요청자 구분 분기** — `exists` 를 `find` 로 바꿔 `TradeCancel.member` 를 확인합니다. 같은 요청자면 기존대로 409, 상대방이면 즉시 철회입니다.

**`TradeCancelApplier` 추출** — 철회 반영 로직을 단일 지점으로 모아 관리자 승인 경로와 공유합니다. 두 경로가 각자 잔액을 건드리면 결과가 갈라지므로, 관리자 인가(`ValidatePlaceUtil`)만 호출자에 남겼습니다.

**동시 요청 직렬화** — 철회 요청·승인·기각·요청취소 4경로가 모두 상품 행을 비관적 잠금으로 확보한 뒤 진행합니다. 첫 요청 시점에는 `TradeCancel` 행이 아직 없으므로 상시 존재하는 상품 행을 잠급니다.

**관리자 알림 정리** — 처리된 요청의 `AdminAlert` 를 삭제해 승인도 기각도 되지 않는 유령 항목이 남지 않게 합니다.

**응답 DTO 추가** — `{ "cancelled": true }` 로 즉시 철회와 승인 대기를 구분합니다.

**동시성 통합 테스트** — Testcontainers 로 실제 MariaDB 를 띄워 두 스레드가 동시에 철회를 요청하는 상황을 검증합니다.

## 🙋‍♂️ 리뷰노트

세 군데를 집중해서 봐주시면 좋겠습니다.

### 1. `READ_COMMITTED` 를 쓴 이유

잠금만으로는 부족했습니다. InnoDB 기본값인 REPEATABLE READ 에서는 트랜잭션의 첫 SELECT 인 `memberUtil.getCurrentMember()` 시점에 read view 가 고정됩니다. 그러면 잠금을 기다리는 동안 상대방 트랜잭션이 철회를 커밋해도 이 트랜잭션은 계속 옛 값을 보고, `status != PENDING` 가드가 통과해 **광산이 두 번 환불됩니다.**

대안으로 "판단에 쓰는 행마다 locking read 메서드 추가" 를 검토했지만 신규 리포지토리 메서드가 3~4개 필요해 접었습니다.

`ApproveTradeCancelServiceImpl` / `RejectAdminAlertServiceImpl` 은 `alertId` 로 진입해 상품 ID 를 모릅니다. `TradeCancel` 을 엔티티로 먼저 읽으면 그게 1차 캐시에 남아 같은 문제가 생기므로, **스칼라 프로젝션(`findProductIdById`)으로 ID 만 먼저 읽어 잠금을 잡고 그 뒤에 엔티티를 로드**합니다.

### 2. 잠금 메서드를 둘로 나눈 이유

| 메서드 | 용도 | `DELETED` |
|---|---|---|
| `findByIdWithLock` (기존) | 거래를 새로 **진행** | 제외 |
| `findByIdForUpdate` (신규) | 성립한 거래를 **되돌림** | 포함 |

게시글 삭제(`DeleteProductByIdServiceImpl`)는 거래 상태를 검사하지 않습니다. 철회 대기 중에 판매자가 글을 지울 수 있는데, 기존 `findByIdWithLock` 을 그대로 쓰면 `DELETED` 가 걸러져 **광산 환불이 영구히 막히고 판매자가 의도적으로 철회를 봉쇄할 수 있습니다.** 잠그는 행은 같으므로 거래 완료 요청 경로와의 직렬화는 유지됩니다.

### 3. ⚠️ 이슈 범위 밖 동작 변경 4건

로직 공유와 경합 정리 과정에서 함께 바뀐 것들입니다. 의도한 변경이며 프론트 대응이 필요합니다.

1. **관리자 승인 시 `AdminAlert` 삭제** — 기존에는 승인해도 남아서 목록에 유령 항목이 됐습니다(기각은 삭제하고 있어 비대칭이었습니다).
2. **관리자 기각에 PENDING 가드 추가** — 기존에는 상태 검사 없이 `REJECTED` 로 덮어써서, 이미 승인된 철회가 기각으로 뒤집힐 수 있었습니다. 이제 `400 CANNOT_PENDING_TRADE_CANCEL` 입니다.
3. **철회 응답에 본문 추가** — `POST /api/trade/cancel/{id}` 가 `{ "cancelled": boolean }` 을 반환합니다. 기존 클라이언트가 본문을 무시하면 그대로 동작합니다.
4. **404 코드 변경** — 상품 자체가 없을 때 `NOT_FOUND_TRADE_COMPLETE` → `NOT_FOUND_PRODUCT`. 상태코드는 404 로 동일합니다.

### 테스트

`./gradlew test` 466개 전부 통과합니다.

동시성 테스트가 실제로 버그를 잡는지 확인했습니다. 잠금을 일반 조회로 바꿔 직렬화를 없애면:

```
expected: 15000
 but was: 10000
```

환불이 아예 일어나지 않습니다. 두 요청이 모두 "첫 요청" 으로 처리돼 `PENDING` 이 2건 생기기 때문입니다.

`build.gradle` 의 Testcontainers 수정은 이 이슈와 무관합니다. Docker Engine 29 가 API 1.40 미만을 거부해 기존 `ChatStreamConsumerIntegrationTest` 도 로컬에서 죽어 있었고, 이번에 함께 되살렸습니다. 되돌리기 쉽도록 별도 커밋으로 뒀습니다.

### 조사 중 발견한 것 (이번 PR 범위 밖)

- `findAllOrphanImages` 가 `tradeCancelImage` 를 조인하지 않습니다. 철회에 정상 첨부된 증빙 이미지가 고아로 오판정되어 2일 뒤 S3 와 DB 양쪽에서 삭제됩니다.
- `MemberDetail.dong` 이 `@ManyToOne` 이 아니라 `@OneToOne` 이라 `dong_id` 에 유니크 제약이 걸립니다. 같은 동 주민 두 명이 가입할 수 없는 스키마입니다.
- `MemberDetail.minusGwangsan` 에 하한이 없어 판매자 잔액이 음수가 될 수 있습니다(기존 승인 경로도 동일).

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (스키마·환경값 변경 없음)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? → 프론트 대응 이슈 별도 등록 예정
- [x] 작업한 코드가 정상적으로 동작하나요? (테스트 466개 통과)
- [x] Merge 대상 브랜치가 올바른가요? (`develop`)
- [x] PR과 관련 없는 작업이 있지는 않나요? (Testcontainers 수정은 별도 커밋으로 분리)
