### PR TITLE
참조 중인 이미지 고아 정리 대상 제외

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/image/repository/custom/impl/ImageCustomRepositoryImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/image/repository/custom/impl/ImageCustomRepositoryImpl.java
@@ -8,10 +8,12 @@ import team.startup.gwangsan.domain.image.repository.custom.ImageCustomRepositor
 
 import java.util.List;
 
+import static team.startup.gwangsan.domain.chat.entity.QChatMessageImage.chatMessageImage;
 import static team.startup.gwangsan.domain.image.entity.QImage.image;
 import static team.startup.gwangsan.domain.notice.entity.QNoticeImage.noticeImage;
 import static team.startup.gwangsan.domain.post.entity.QProductImage.productImage;
 import static team.startup.gwangsan.domain.report.entity.QReportImage.reportImage;
+import static team.startup.gwangsan.domain.trade.entity.QTradeCancelImage.tradeCancelImage;
 
 @Repository
 @RequiredArgsConstructor
@@ -26,10 +28,14 @@ public class ImageCustomRepositoryImpl implements ImageCustomRepository {
                 .leftJoin(productImage).on(productImage.image.eq(image))
                 .leftJoin(noticeImage).on(noticeImage.image.eq(image))
                 .leftJoin(reportImage).on(reportImage.image.eq(image))
+                .leftJoin(chatMessageImage).on(chatMessageImage.image.eq(image))
+                .leftJoin(tradeCancelImage).on(tradeCancelImage.image.eq(image))
                 .where(
                         productImage.id.isNull(),
                         noticeImage.id.isNull(),
-                        reportImage.id.isNull()
+                        reportImage.id.isNull(),
+                        chatMessageImage.id.isNull(),
+                        tradeCancelImage.id.isNull()
                 )
                 .orderBy(image.createdAt.asc(), image.id.asc())
                 .limit(limit)

--- a/src/test/java/team/startup/gwangsan/domain/image/repository/custom/impl/ImageCustomRepositoryImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/image/repository/custom/impl/ImageCustomRepositoryImplTest.java
@@ -1,0 +1,266 @@
+package team.startup.gwangsan.domain.image.repository.custom.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import team.startup.gwangsan.domain.chat.entity.ChatMessage;
+import team.startup.gwangsan.domain.chat.entity.ChatMessageImage;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.notice.entity.Notice;
+import team.startup.gwangsan.domain.notice.entity.NoticeImage;
+import team.startup.gwangsan.domain.place.entity.Head;
+import team.startup.gwangsan.domain.place.entity.Place;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.ProductImage;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.Type;
+import team.startup.gwangsan.domain.report.entity.Report;
+import team.startup.gwangsan.domain.report.entity.ReportImage;
+import team.startup.gwangsan.domain.report.entity.constant.ReportType;
+import team.startup.gwangsan.domain.trade.entity.TradeCancel;
+import team.startup.gwangsan.domain.trade.entity.TradeCancelImage;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Testcontainers
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(QueryDslConfig.class)
+@DisplayName("ImageCustomRepositoryImpl MariaDB integration test")
+class ImageCustomRepositoryImplTest {
+
+    @Container
+    static final MariaDBContainer<?> mariadb = new MariaDBContainer<>("mariadb:11.4");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mariadb::getJdbcUrl);
+        registry.add("spring.datasource.username", mariadb::getUsername);
+        registry.add("spring.datasource.password", mariadb::getPassword);
+        registry.add("spring.datasource.driver-class-name", mariadb::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.flyway.enabled", () -> false);
+    }
+
+    @Autowired
+    private TestEntityManager em;
+
+    @Autowired
+    private JPAQueryFactory queryFactory;
+
+    @Autowired
+    private DataSource dataSource;
+
+    private ImageCustomRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new ImageCustomRepositoryImpl(queryFactory);
+    }
+
+    @Test
+    @DisplayName("returns no candidates from an empty MariaDB database")
+    void returnsNoCandidatesFromAnEmptyMariaDbDatabase() throws SQLException {
+        try (var connection = dataSource.getConnection()) {
+            assertThat(connection.getMetaData().getDatabaseProductName()).contains("MariaDB");
+        }
+
+        assertThat(repository.findAllOrphanImages(10)).extracting(Image::getId).isEmpty();
+    }
+
+    @Test
+    @DisplayName("excludes images referenced only by chat messages or trade cancellations")
+    void excludesImagesReferencedOnlyByChatMessagesOrTradeCancellations() {
+        Relationships relationships = persistRelationships("chat-trade");
+        Image chatOnly = image("chat-only");
+        Image tradeCancelOnly = image("trade-cancel-only");
+        em.persist(ChatMessageImage.builder().chatMessage(relationships.chatMessage()).image(chatOnly).build());
+        em.persist(TradeCancelImage.builder().tradeCancel(relationships.tradeCancel()).image(tradeCancelOnly).build());
+        em.flush();
+        em.clear();
+
+        assertThat(rowCount("tbl_chat_message_image")).isEqualTo(1);
+        assertThat(rowCount("tbl_trade_cancel_image")).isEqualTo(1);
+        assertThat(repository.findAllOrphanImages(10)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("keeps product notice and report images out before limiting candidates")
+    void keepsProductNoticeAndReportImagesOutBeforeLimitingCandidates() {
+        Relationships relationships = persistRelationships("existing-links");
+        Image productOnly = image("product-only");
+        Image noticeOnly = image("notice-only");
+        Image reportOnly = image("report-only");
+        Image firstOrphan = image("first-orphan");
+        Image secondOrphan = image("second-orphan");
+        em.persist(ProductImage.builder().product(relationships.product()).image(productOnly).build());
+        em.persist(NoticeImage.builder().notice(relationships.notice()).image(noticeOnly).build());
+        em.persist(ReportImage.builder().report(relationships.report()).image(reportOnly).build());
+        em.flush();
+
+        LocalDateTime protectedTime = LocalDateTime.of(2024, 1, 1, 9, 0);
+        updateCreatedAt(productOnly, protectedTime);
+        updateCreatedAt(noticeOnly, protectedTime);
+        updateCreatedAt(reportOnly, protectedTime);
+        updateCreatedAt(firstOrphan, LocalDateTime.of(2024, 1, 1, 10, 0));
+        updateCreatedAt(secondOrphan, LocalDateTime.of(2024, 1, 1, 10, 1));
+        em.clear();
+
+        assertThat(repository.findAllOrphanImages(10)).extracting(Image::getId)
+                .containsExactly(firstOrphan.getId(), secondOrphan.getId());
+        assertThat(repository.findAllOrphanImages(1)).extracting(Image::getId)
+                .containsExactly(firstOrphan.getId());
+    }
+
+    @Test
+    @DisplayName("returns each true orphan once in created-at and id order within the limit")
+    void returnsEachTrueOrphanOnceInCreatedAtAndIdOrderWithinTheLimit() {
+        Relationships relationships = persistRelationships("all-links");
+        Image productOnly = image("product-only");
+        Image noticeOnly = image("notice-only");
+        Image reportOnly = image("report-only");
+        Image chatOnly = image("chat-only");
+        Image tradeCancelOnly = image("trade-cancel-only");
+        Image multipleReferences = image("multiple-references");
+        Image later = image("later");
+        Image earlier = image("earlier");
+        Image sameTimeFirst = image("same-time-first");
+        Image sameTimeSecond = image("same-time-second");
+
+        em.persist(ProductImage.builder().product(relationships.product()).image(productOnly).build());
+        em.persist(NoticeImage.builder().notice(relationships.notice()).image(noticeOnly).build());
+        em.persist(ReportImage.builder().report(relationships.report()).image(reportOnly).build());
+        em.persist(ChatMessageImage.builder().chatMessage(relationships.chatMessage()).image(chatOnly).build());
+        em.persist(TradeCancelImage.builder().tradeCancel(relationships.tradeCancel()).image(tradeCancelOnly).build());
+        em.persist(ProductImage.builder().product(relationships.product()).image(multipleReferences).build());
+        em.persist(ProductImage.builder().product(relationships.product()).image(multipleReferences).build());
+        em.persist(ReportImage.builder().report(relationships.report()).image(multipleReferences).build());
+        em.flush();
+
+        LocalDateTime protectedTime = LocalDateTime.of(2024, 1, 1, 9, 0);
+        updateCreatedAt(productOnly, protectedTime);
+        updateCreatedAt(noticeOnly, protectedTime);
+        updateCreatedAt(reportOnly, protectedTime);
+        updateCreatedAt(chatOnly, protectedTime);
+        updateCreatedAt(tradeCancelOnly, protectedTime);
+        updateCreatedAt(multipleReferences, protectedTime);
+        updateCreatedAt(later, LocalDateTime.of(2024, 1, 1, 10, 2));
+        updateCreatedAt(earlier, LocalDateTime.of(2024, 1, 1, 10, 1));
+        LocalDateTime sameTime = LocalDateTime.of(2024, 1, 1, 10, 3);
+        updateCreatedAt(sameTimeFirst, sameTime);
+        updateCreatedAt(sameTimeSecond, sameTime);
+        em.clear();
+
+        assertThat(repository.findAllOrphanImages(10)).extracting(Image::getId)
+                .containsExactly(earlier.getId(), later.getId(), sameTimeFirst.getId(), sameTimeSecond.getId());
+        assertThat(repository.findAllOrphanImages(1)).extracting(Image::getId)
+                .containsExactly(earlier.getId());
+        assertThat(repository.findAllOrphanImages(100)).extracting(Image::getId)
+                .containsExactly(earlier.getId(), later.getId(), sameTimeFirst.getId(), sameTimeSecond.getId());
+    }
+
+    private Relationships persistRelationships(String suffix) {
+        Member buyer = member("buyer-" + suffix, "010-0000-" + suffix.hashCode());
+        Member seller = member("seller-" + suffix, "010-0001-" + suffix.hashCode());
+        Product product = em.persist(Product.builder()
+                .title("product-" + suffix)
+                .description("description")
+                .gwangsan(5_000)
+                .member(seller)
+                .type(Type.SERVICE)
+                .mode(Mode.GIVER)
+                .status(ProductStatus.ONGOING)
+                .build());
+        Head head = em.persist(new Head("head-" + suffix));
+        Place place = em.persist(Place.builder().name("place-" + suffix).head(head).build());
+        Notice notice = em.persist(Notice.builder().title("notice").content("content").place(place).member(seller).build());
+        Report report = em.persist(Report.builder()
+                .reportType(ReportType.ETC)
+                .content("content")
+                .reported(seller)
+                .reporter(buyer)
+                .build());
+        TradeComplete tradeComplete = em.persist(TradeComplete.builder()
+                .product(product)
+                .buyer(buyer)
+                .seller(seller)
+                .status(TradeStatus.COMPLETED)
+                .requestedBySeller(true)
+                .build());
+        TradeCancel tradeCancel = em.persist(TradeCancel.builder()
+                .tradeComplete(tradeComplete)
+                .member(buyer)
+                .reason("reason")
+                .status(TradeCancelStatus.PENDING)
+                .build());
+        ChatRoom chatRoom = em.persist(ChatRoom.builder().buyer(buyer).seller(seller).product(product).isActive(true).build());
+        ChatMessage chatMessage = em.persist(ChatMessage.builder()
+                .id((long) suffix.hashCode())
+                .content("image")
+                .messageType(MessageType.IMAGE)
+                .checked(false)
+                .room(chatRoom)
+                .sender(buyer)
+                .createdAt(LocalDateTime.of(2024, 1, 1, 9, 0))
+                .build());
+        return new Relationships(product, notice, report, chatMessage, tradeCancel);
+    }
+
+    private Member member(String nickname, String phoneNumber) {
+        return em.persist(Member.builder()
+                .name(nickname)
+                .nickname(nickname)
+                .password("pw")
+                .phoneNumber(phoneNumber)
+                .role(MemberRole.ROLE_USER)
+                .status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    private Image image(String name) {
+        return em.persist(Image.builder().imageUrl("https://test.local/" + name).build());
+    }
+
+    private long rowCount(String table) {
+        return ((Number) em.getEntityManager().createNativeQuery("select count(*) from " + table).getSingleResult()).longValue();
+    }
+
+    private void updateCreatedAt(Image image, LocalDateTime createdAt) {
+        em.getEntityManager().createNativeQuery("update tbl_image set created_at = ? where image_id = ?")
+                .setParameter(1, Timestamp.valueOf(createdAt))
+                .setParameter(2, image.getId())
+                .executeUpdate();
+    }
+
+    private record Relationships(Product product, Notice notice, Report report, ChatMessage chatMessage, TradeCancel tradeCancel) {
+    }
+}

--- a/src/test/java/team/startup/gwangsan/global/scheduler/DeleteOrphanImageSchedulerTest.java
+++ b/src/test/java/team/startup/gwangsan/global/scheduler/DeleteOrphanImageSchedulerTest.java
@@ -1,0 +1,355 @@
+package team.startup.gwangsan.global.scheduler;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import team.startup.gwangsan.domain.chat.entity.ChatMessage;
+import team.startup.gwangsan.domain.chat.entity.ChatMessageImage;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.entity.constant.MessageType;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.image.entity.dto.DeleteResult;
+import team.startup.gwangsan.domain.image.repository.ImageRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.notice.entity.Notice;
+import team.startup.gwangsan.domain.notice.entity.NoticeImage;
+import team.startup.gwangsan.domain.place.entity.Head;
+import team.startup.gwangsan.domain.place.entity.Place;
+import team.startup.gwangsan.domain.post.entity.Product;
+import team.startup.gwangsan.domain.post.entity.ProductImage;
+import team.startup.gwangsan.domain.post.entity.constant.Mode;
+import team.startup.gwangsan.domain.post.entity.constant.ProductStatus;
+import team.startup.gwangsan.domain.post.entity.constant.Type;
+import team.startup.gwangsan.domain.report.entity.Report;
+import team.startup.gwangsan.domain.report.entity.ReportImage;
+import team.startup.gwangsan.domain.report.entity.constant.ReportType;
+import team.startup.gwangsan.domain.trade.entity.TradeCancel;
+import team.startup.gwangsan.domain.trade.entity.TradeCancelImage;
+import team.startup.gwangsan.domain.trade.entity.TradeComplete;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeCancelStatus;
+import team.startup.gwangsan.domain.trade.entity.constant.TradeStatus;
+import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+import team.startup.gwangsan.global.thirdparty.aws.s3.service.S3DeleteService;
+
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@DataJpaTest
+@Testcontainers
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import({QueryDslConfig.class, DeleteOrphanImageScheduler.class})
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@DisplayName("DeleteOrphanImageScheduler MariaDB integration test")
+class DeleteOrphanImageSchedulerTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Container
+    static final MariaDBContainer<?> mariadb = new MariaDBContainer<>("mariadb:11.4");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mariadb::getJdbcUrl);
+        registry.add("spring.datasource.username", mariadb::getUsername);
+        registry.add("spring.datasource.password", mariadb::getPassword);
+        registry.add("spring.datasource.driver-class-name", mariadb::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+        registry.add("spring.flyway.enabled", () -> false);
+    }
+
+    @Autowired private DeleteOrphanImageScheduler scheduler;
+    @Autowired private ImageRepository imageRepository;
+    @Autowired private EntityManager entityManager;
+    @Autowired private PlatformTransactionManager transactionManager;
+    @Autowired private ApplicationContext applicationContext;
+
+    @MockitoBean private S3DeleteService s3DeleteService;
+
+    private TransactionTemplate transactions;
+
+    @BeforeEach
+    void setUp() {
+        transactions = new TransactionTemplate(transactionManager);
+        reset(s3DeleteService);
+        assertThat(applicationContext.getBeanProvider(S3AsyncClient.class).getIfAvailable()).isNull();
+        assertThat(applicationContext.getBeansOfType(ScheduledAnnotationBeanPostProcessor.class)).isEmpty();
+        inTransaction(() -> {
+            assertThat(rowCount("tbl_image")).isZero();
+            assertThat(rowCount("tbl_product_image")).isZero();
+            assertThat(rowCount("tbl_notice_image")).isZero();
+            assertThat(rowCount("tbl_report_image")).isZero();
+            assertThat(rowCount("tbl_chat_message_image")).isZero();
+            assertThat(rowCount("tbl_trade_cancel_image")).isZero();
+            return null;
+        });
+    }
+
+    @AfterEach
+    void cleanUpCommittedFixtures() {
+        inTransaction(() -> {
+            delete("tbl_chat_message_image");
+            delete("tbl_trade_cancel_image");
+            delete("tbl_product_image");
+            delete("tbl_notice_image");
+            delete("tbl_report_image");
+            delete("tbl_chat_message");
+            delete("tbl_chat_room");
+            delete("tbl_trade_cancel");
+            delete("tbl_trade_complete");
+            delete("tbl_notice");
+            delete("tbl_report");
+            delete("tbl_product");
+            delete("tbl_place");
+            delete("tbl_head_place");
+            delete("tbl_member");
+            delete("tbl_image");
+            return null;
+        });
+    }
+
+    @Test
+    @DisplayName("deletes only old unreferenced images and preserves all references and recent images")
+    void deletesOnlyOldUnreferencedImages() {
+        List<ImageFixture> fixtures = inTransaction(() -> {
+            Relationships relationships = persistRelationships();
+            List<ImageFixture> protectedImages = List.of(
+                    image("product"), image("notice"), image("report"), image("chat"), image("trade-cancel"));
+            entityManager.persist(ProductImage.builder().product(relationships.product()).image(reference(protectedImages, 0)).build());
+            entityManager.persist(NoticeImage.builder().notice(relationships.notice()).image(reference(protectedImages, 1)).build());
+            entityManager.persist(ReportImage.builder().report(relationships.report()).image(reference(protectedImages, 2)).build());
+            entityManager.persist(ChatMessageImage.builder().chatMessage(relationships.message()).image(reference(protectedImages, 3)).build());
+            entityManager.persist(TradeCancelImage.builder().tradeCancel(relationships.cancel()).image(reference(protectedImages, 4)).build());
+            ImageFixture oldOrphan = image("old-orphan");
+            ImageFixture recentOrphan = image("recent-orphan");
+            entityManager.flush();
+            protectedImages.forEach(image -> updateCreatedAt(image, oldTime()));
+            updateCreatedAt(oldOrphan, oldTime());
+            updateCreatedAt(recentOrphan, recentTime());
+            entityManager.clear();
+            List<ImageFixture> result = new ArrayList<>(protectedImages);
+            result.add(oldOrphan);
+            result.add(recentOrphan);
+            return result;
+        });
+        ImageFixture oldOrphan = fixtures.get(5);
+        ImageFixture recentOrphan = fixtures.get(6);
+        AtomicReference<List<String>> keys = successfulS3();
+
+        assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+        scheduler.deleteOrphanImages();
+        assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+
+        assertThat(keys.get()).containsExactly(oldOrphan.url());
+        assertThat(imageExists(oldOrphan.id())).isFalse();
+        assertThat(fixtures.subList(0, 5)).allSatisfy(image -> assertThat(imageExists(image.id())).isTrue());
+        assertThat(imageExists(recentOrphan.id())).isTrue();
+    }
+
+    @Test
+    @DisplayName("keeps failed S3 images while deleting successful old orphan images")
+    void keepsFailedS3ImagesWhileDeletingSuccessfulOldOrphans() {
+        List<ImageFixture> images = inTransaction(() -> oldImages("mixed", 2));
+        when(s3DeleteService.deleteAll(anyList())).thenAnswer(invocation -> {
+            assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+            return new DeleteResult(1, 1, List.of(images.get(1).url()));
+        });
+
+        scheduler.deleteOrphanImages();
+
+        assertThat(imageExists(images.get(0).id())).isFalse();
+        assertThat(imageExists(images.get(1).id())).isTrue();
+        verify(s3DeleteService).deleteAll(List.of(images.get(0).url(), images.get(1).url()));
+    }
+
+    @Test
+    @DisplayName("keeps every old orphan when every S3 delete fails")
+    void keepsEveryOldOrphanWhenEveryS3DeleteFails() {
+        List<ImageFixture> images = inTransaction(() -> oldImages("all-fail", 2));
+        when(s3DeleteService.deleteAll(anyList())).thenReturn(new DeleteResult(0, 2, images.stream().map(ImageFixture::url).toList()));
+
+        scheduler.deleteOrphanImages();
+
+        assertThat(imageExists(images.get(0).id())).isTrue();
+        assertThat(imageExists(images.get(1).id())).isTrue();
+        verify(s3DeleteService).deleteAll(List.of(images.get(0).url(), images.get(1).url()));
+    }
+
+    @Test
+    @DisplayName("does not call S3 for empty or recent-only candidate sets")
+    void doesNotCallS3ForEmptyOrRecentOnlyCandidateSets() {
+        scheduler.deleteOrphanImages();
+        verifyNoInteractions(s3DeleteService);
+
+        ImageFixture recent = inTransaction(() -> {
+            ImageFixture fixture = image("recent-only");
+            entityManager.flush();
+            updateCreatedAt(fixture, recentTime());
+            entityManager.clear();
+            return fixture;
+        });
+        scheduler.deleteOrphanImages();
+
+        verifyNoInteractions(s3DeleteService);
+        assertThat(imageExists(recent.id())).isTrue();
+    }
+
+    @Test
+    @DisplayName("keeps database images when the S3 double throws")
+    void keepsDatabaseImagesWhenS3Throws() {
+        ImageFixture image = inTransaction(() -> oldImages("throws", 1).getFirst());
+        doThrow(new IllegalStateException("S3 unavailable")).when(s3DeleteService).deleteAll(anyList());
+
+        scheduler.deleteOrphanImages();
+
+        assertThat(imageExists(image.id())).isTrue();
+        verify(s3DeleteService).deleteAll(List.of(image.url()));
+    }
+
+    @Test
+    @DisplayName("deletes the first 500 old orphans in id order and leaves the 501st")
+    void deletesTheFirstFiveHundredOldOrphansInIdOrder() {
+        List<ImageFixture> images = inTransaction(() -> oldImages("batch", 501));
+        AtomicReference<List<String>> keys = successfulS3();
+
+        scheduler.deleteOrphanImages();
+
+        assertThat(keys.get()).containsExactlyElementsOf(images.subList(0, 500).stream().map(ImageFixture::url).toList());
+        assertThat(images.subList(0, 500)).allSatisfy(image -> assertThat(imageExists(image.id())).isFalse());
+        assertThat(imageExists(images.get(500).id())).isTrue();
+    }
+
+    private AtomicReference<List<String>> successfulS3() {
+        AtomicReference<List<String>> keys = new AtomicReference<>();
+        when(s3DeleteService.deleteAll(anyList())).thenAnswer(invocation -> {
+            assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+            List<String> requestedKeys = List.copyOf(invocation.getArgument(0));
+            keys.set(requestedKeys);
+            return new DeleteResult(requestedKeys.size(), 0, List.of());
+        });
+        return keys;
+    }
+
+    private List<ImageFixture> oldImages(String prefix, int count) {
+        List<ImageFixture> images = new ArrayList<>();
+        LocalDateTime createdAt = oldTime();
+        for (int index = 0; index < count; index++) {
+            images.add(image(prefix + "-" + index));
+        }
+        entityManager.flush();
+        images.forEach(image -> updateCreatedAt(image, createdAt));
+        entityManager.clear();
+        return images;
+    }
+
+    private Relationships persistRelationships() {
+        Member buyer = member("buyer", "010-1000-0001");
+        Member seller = member("seller", "010-1000-0002");
+        Product product = persist(Product.builder().title("product").description("description").gwangsan(5_000)
+                .member(seller).type(Type.SERVICE).mode(Mode.GIVER).status(ProductStatus.ONGOING).build());
+        Head head = persist(new Head("head"));
+        Place place = persist(Place.builder().name("place").head(head).build());
+        Notice notice = persist(Notice.builder().title("notice").content("content").place(place).member(seller).build());
+        Report report = persist(Report.builder().reportType(ReportType.ETC).content("content").reported(seller).reporter(buyer).build());
+        TradeComplete complete = persist(TradeComplete.builder().product(product).buyer(buyer).seller(seller)
+                .status(TradeStatus.COMPLETED).requestedBySeller(true).build());
+        TradeCancel cancel = persist(TradeCancel.builder().tradeComplete(complete).member(buyer).reason("reason")
+                .status(TradeCancelStatus.PENDING).build());
+        ChatRoom room = persist(ChatRoom.builder().buyer(buyer).seller(seller).product(product).isActive(true).build());
+        ChatMessage message = persist(ChatMessage.builder().id(1L).content("image").messageType(MessageType.IMAGE)
+                .checked(false).room(room).sender(buyer).createdAt(oldTime()).build());
+        return new Relationships(product, notice, report, message, cancel);
+    }
+
+    private Member member(String nickname, String phoneNumber) {
+        return persist(Member.builder().name(nickname).nickname(nickname).password("pw").phoneNumber(phoneNumber)
+                .role(MemberRole.ROLE_USER).status(MemberStatus.ACTIVE).build());
+    }
+
+    private ImageFixture image(String name) {
+        Image image = persist(Image.builder().imageUrl("scheduler/" + name).build());
+        return new ImageFixture(image, image.getId(), image.getImageUrl());
+    }
+
+    private Image reference(List<ImageFixture> images, int index) {
+        return images.get(index).entity();
+    }
+
+    private void updateCreatedAt(ImageFixture image, LocalDateTime createdAt) {
+        entityManager.createNativeQuery("update tbl_image set created_at = ? where image_id = ?")
+                .setParameter(1, Timestamp.valueOf(createdAt))
+                .setParameter(2, image.id())
+                .executeUpdate();
+    }
+
+    private boolean imageExists(Long imageId) {
+        return inTransaction(() -> imageRepository.existsById(imageId));
+    }
+
+    private long rowCount(String table) {
+        return ((Number) entityManager.createNativeQuery("select count(*) from " + table).getSingleResult()).longValue();
+    }
+
+    private <T> T persist(T entity) {
+        entityManager.persist(entity);
+        return entity;
+    }
+
+    private LocalDateTime oldTime() {
+        return LocalDateTime.now(SEOUL).minusDays(3);
+    }
+
+    private LocalDateTime recentTime() {
+        return LocalDateTime.now(SEOUL).minusDays(1);
+    }
+
+    private <T> T inTransaction(Supplier<T> work) {
+        return transactions.execute(status -> work.get());
+    }
+
+    private void delete(String table) {
+        entityManager.createNativeQuery("delete from " + table).executeUpdate();
+    }
+
+    private record ImageFixture(Image entity, Long id, String url) {
+    }
+
+    private record Relationships(Product product, Notice notice, Report report, ChatMessage message, TradeCancel cancel) {
+    }
+}


### PR DESCRIPTION
## 💡 배경 및 개요

고아 이미지 후보 조회에서 거래 철회 증빙과 채팅 이미지 참조가 누락되어, 사용 중인 이미지도 S3 삭제 대상으로 분류될 수 있었습니다. 기존 참조 유형 전체를 확인하여 누락된 두 관계를 후보에서 제외하였습니다.

Resolves: #388

## 📃 작업내용

- 거래 철회·채팅 이미지의 LEFT JOIN과 참조 부재 조건을 추가하였습니다.
- 기존 상품·공지·신고 이미지 제외 조건과 생성 시각·ID 정렬, 조회 제한을 유지하였습니다.
- 실제 MariaDB에서 참조 5종, 복수 참조, 정렬 및 limit을 검증하는 회귀 테스트를 추가하였습니다.
- 실제 S3 대신 테스트 대역을 사용하여 공개 스케줄러의 이미지 보존, 부분·전체 삭제 실패, 예외, 최근 이미지 및 500건 제한을 검증하였습니다.

## 🙋‍♂️ 리뷰노트

- 스케줄러의 self-invocation을 테스트 트랜잭션이 가리지 않도록, 데이터를 별도 트랜잭션에서 커밋한 뒤 공개 메서드를 트랜잭션 밖에서 호출하였습니다. 결과도 새 트랜잭션에서 조회하였습니다.
- 2일 보존 기준 및 삭제 구조는 변경하지 않았습니다. S3 선삭제 이후 DB 실패와 후보 조회 이후 참조 추가 경쟁은 이번 수정 범위에 포함하지 않았습니다.

## ✅ PR 체크리스트

- [x] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (환경값·API 계약·사용법 변경 없음)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요?
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요? (`develop`)
- [x] PR과 관련 없는 작업이 있지는 않나요? (수정 코드 1개·회귀 테스트 2개만 포함)

## 🎸 기타

- 수정 전 MariaDB 회귀 테스트에서 참조 누락 2건의 실패를 확인하였고, 수정 후 저장소 4개·스케줄러 6개 테스트가 통과하였습니다.
- 전체 테스트 487개가 실패·오류·건너뜀 없이 통과하였고, `./gradlew bootJar`가 성공하였습니다.
- 운영 DB와 실제 S3에는 접근하지 않았습니다.
