### PR TITLE
회원 동 다대일 매핑 및 유니크 제약 수정

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
+++ b/src/main/java/team/startup/gwangsan/domain/member/entity/MemberDetail.java
@@ -22,7 +22,7 @@ public class MemberDetail {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "dong_id", nullable = false)
     private Dong dong;
 

--- a/src/main/resources/db/migration/V8__drop_member_detail_dong_unique.sql
+++ b/src/main/resources/db/migration/V8__drop_member_detail_dong_unique.sql
@@ -1,0 +1,74 @@
+SET @old_group_concat_max_len := @@SESSION.group_concat_max_len;
+SET SESSION group_concat_max_len = 65535;
+
+SELECT COUNT(*),
+       GROUP_CONCAT(
+           CONCAT('DROP INDEX `', REPLACE(INDEX_NAME, '`', '``'), '`')
+           ORDER BY INDEX_NAME SEPARATOR ', '
+       ),
+       COALESCE(
+           SUM(CHAR_LENGTH(CONCAT('DROP INDEX `', REPLACE(INDEX_NAME, '`', '``'), '`')))
+               + GREATEST(COUNT(*) - 1, 0) * 2,
+           0
+       )
+INTO @dong_unique_count, @dong_unique_drops, @dong_unique_drops_length
+FROM (
+    SELECT INDEX_NAME
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tbl_member_detail'
+      AND NON_UNIQUE = 0
+      AND INDEX_NAME <> 'PRIMARY'
+    GROUP BY INDEX_NAME
+    HAVING COUNT(*) = 1 AND MIN(COLUMN_NAME) = 'dong_id'
+) AS dong_unique_indexes;
+
+SET SESSION group_concat_max_len = @old_group_concat_max_len;
+
+SET @guard_sql := IF(
+    @dong_unique_count = 0 OR CHAR_LENGTH(@dong_unique_drops) = @dong_unique_drops_length,
+    'DO 0',
+    'SIGNAL SQLSTATE ''45000'' SET MESSAGE_TEXT = ''dong_id unique index list was truncated'''
+);
+PREPARE guard_stmt FROM @guard_sql;
+EXECUTE guard_stmt;
+DEALLOCATE PREPARE guard_stmt;
+
+SET @has_dong_fk_index := EXISTS (
+    SELECT 1
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tbl_member_detail'
+      AND NON_UNIQUE = 1
+      AND INDEX_TYPE = 'BTREE'
+      AND SEQ_IN_INDEX = 1
+      AND COLUMN_NAME = 'dong_id'
+      AND SUB_PART IS NULL
+);
+
+SET @replacement_name_exists := EXISTS (
+    SELECT 1
+    FROM information_schema.STATISTICS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tbl_member_detail'
+      AND INDEX_NAME = 'idx_member_detail_dong_id'
+);
+
+SET @ensure_index_sql := CASE
+    WHEN @dong_unique_count = 0 OR @has_dong_fk_index THEN 'DO 0'
+    WHEN @replacement_name_exists THEN
+        'SIGNAL SQLSTATE ''45000'' SET MESSAGE_TEXT = ''idx_member_detail_dong_id exists with an incompatible definition'''
+    ELSE 'CREATE INDEX idx_member_detail_dong_id ON tbl_member_detail (dong_id)'
+END;
+PREPARE ensure_index_stmt FROM @ensure_index_sql;
+EXECUTE ensure_index_stmt;
+DEALLOCATE PREPARE ensure_index_stmt;
+
+SET @drop_unique_sql := IF(
+    @dong_unique_count = 0,
+    'DO 0',
+    CONCAT('ALTER TABLE tbl_member_detail ', @dong_unique_drops)
+);
+PREPARE drop_unique_stmt FROM @drop_unique_sql;
+EXECUTE drop_unique_stmt;
+DEALLOCATE PREPARE drop_unique_stmt;

--- a/src/test/java/team/startup/gwangsan/domain/member/repository/MemberDetailDongMigrationTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/member/repository/MemberDetailDongMigrationTest.java
@@ -1,0 +1,453 @@
+package team.startup.gwangsan.domain.member.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import org.flywaydb.core.Flyway;
+import org.flywaydb.core.api.output.MigrateResult;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+import org.springframework.orm.jpa.EntityManagerFactoryUtils;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.SharedEntityManagerCreator;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import team.startup.gwangsan.domain.dong.entity.Dong;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.place.entity.Place;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+@DisplayName("MemberDetail Dong legacy schema migration")
+class MemberDetailDongMigrationTest {
+
+    @Container
+    static final MariaDBContainer<?> mariadb = new MariaDBContainer<>("mariadb:11.4");
+
+    private static final AtomicInteger schemaSequence = new AtomicInteger();
+    private static final Set<String> schemas = new LinkedHashSet<>();
+
+    @BeforeAll
+    static void reportContainer() {
+        System.out.printf("QA_RESOURCE_CREATED container=%s image=%s%n",
+                mariadb.getContainerId(), mariadb.getDockerImageName());
+    }
+
+    @AfterAll
+    static void dropSchemas() throws SQLException {
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            for (String schema : schemas) {
+                statement.execute("DROP DATABASE `" + schema + "`");
+                System.out.printf("QA_RESOURCE_CLEANED schema=%s%n", schema);
+            }
+        }
+        System.out.printf("QA_RESOURCE_CLEANUP container=%s managed_by=testcontainers%n", mariadb.getContainerId());
+    }
+
+    @Test
+    @DisplayName("sole FK-supporting legacy uniques are replaced and shared-Dong repository writes succeed")
+    void migratesSoleSupportingUniquesAndPreservesSchema() throws Exception {
+        TestSchema schema = createSchema();
+        seed(schema);
+        execute(schema, """
+                ALTER TABLE tbl_member_detail
+                    ADD UNIQUE INDEX uk_legacy_dong (dong_id),
+                    ADD UNIQUE INDEX `uk``escaped` (dong_id),
+                    ADD UNIQUE INDEX uk_place_description (place_id, description)
+                """);
+        dropOrdinaryDongIndexes(schema);
+
+        assertThat(indexCount(schema, "NON_UNIQUE = 1 AND INDEX_TYPE = 'BTREE'"
+                + " AND SEQ_IN_INDEX = 1 AND COLUMN_NAME = 'dong_id' AND SUB_PART IS NULL")).isZero();
+        assertThat(dongOnlyUniqueCount(schema)).isEqualTo(2);
+        assertThat(queryLong(schema, "SELECT @@foreign_key_checks")).isOne();
+        assertLegacyDuplicateFails(schema);
+        printMetadata("BEFORE", schema);
+
+        Flyway flyway = baselineAtSeven(schema);
+        MigrateResult migrated = flyway.migrate();
+
+        assertThat(migrated.migrationsExecuted).isEqualTo(1);
+        assertThat(dongOnlyUniqueCount(schema)).isZero();
+        assertThat(indexColumns(schema, "idx_member_detail_dong_id")).isEqualTo("dong_id");
+        assertThat(indexCount(schema, "INDEX_NAME = 'idx_member_detail_dong_id'"
+                + " AND NON_UNIQUE = 1 AND INDEX_TYPE = 'BTREE' AND SUB_PART IS NULL")).isOne();
+        assertThat(indexColumns(schema, "uk_place_description")).isEqualTo("place_id,description");
+        assertThat(indexColumns(schema, "PRIMARY")).isEqualTo("member_id");
+        assertThat(queryString(schema, "SELECT IS_NULLABLE FROM information_schema.COLUMNS"
+                + " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tbl_member_detail'"
+                + " AND COLUMN_NAME = 'dong_id'")).isEqualTo("NO");
+        assertThat(queryLong(schema, "SELECT COUNT(*) FROM tbl_member_detail")).isOne();
+        assertThat(queryLong(schema, "SELECT @@foreign_key_checks")).isOne();
+
+        insertDetail(schema, 2, 1, 1, "shared");
+        assertThat(queryLong(schema, "SELECT COUNT(*) FROM tbl_member_detail WHERE dong_id = 1")).isEqualTo(2);
+        assertThatThrownBy(() -> insertDetail(schema, 4, 999999, 1, "dangling"))
+                .isInstanceOfSatisfying(SQLException.class,
+                        error -> assertThat(error.getErrorCode()).isEqualTo(1452));
+        assertThatThrownBy(() -> insertDetail(schema, 5, null, 1, "null-dong"))
+                .isInstanceOfSatisfying(SQLException.class,
+                        error -> assertThat(error.getErrorCode()).isEqualTo(1048));
+        assertThatThrownBy(() -> execute(schema, "INSERT INTO tbl_dong (dong_id, name) VALUES (2, 'seed-dong')"))
+                .isInstanceOfSatisfying(SQLException.class,
+                        error -> assertThat(error.getErrorCode()).isEqualTo(1062));
+
+        try (RepositoryContext context = repositoryContext(schema, "validate")) {
+            MemberDetailRepository repository = context.context().getBean(MemberDetailRepository.class);
+            PlatformTransactionManager transactions = context.context().getBean(PlatformTransactionManager.class);
+            EntityManagerFactory entityManagerFactory = context.context().getBean(EntityManagerFactory.class);
+
+            new TransactionTemplate(transactions).executeWithoutResult(status -> {
+                EntityManager entityManager = EntityManagerFactoryUtils
+                        .getTransactionalEntityManager(entityManagerFactory);
+                repository.saveAndFlush(MemberDetail.builder()
+                        .member(entityManager.getReference(Member.class, 3L))
+                        .dong(entityManager.getReference(Dong.class, 1))
+                        .place(entityManager.getReference(Place.class, 1))
+                        .gwangsan(0).light(0).description("repository")
+                        .build());
+            });
+        }
+
+        assertThat(queryLong(schema, "SELECT COUNT(*) FROM tbl_member_detail WHERE dong_id = 1")).isEqualTo(3);
+        assertThat(flyway.migrate().migrationsExecuted).isZero();
+        printMetadata("AFTER", schema);
+    }
+
+    @Test
+    @DisplayName("already-fixed schema executes the actual migration as a no-op")
+    void noOpsWhenDongUniqueIsAbsent() throws Exception {
+        TestSchema schema = createSchema();
+        seed(schema);
+        String before = showCreate(schema);
+
+        Flyway flyway = baselineAtSeven(schema);
+
+        assertThat(flyway.migrate().migrationsExecuted).isEqualTo(1);
+        assertThat(showCreate(schema)).isEqualTo(before);
+        assertThat(flyway.migrate().migrationsExecuted).isZero();
+    }
+
+    @Test
+    @DisplayName("an existing full Dong-leading BTREE index is reused")
+    void reusesExistingCompositeIndex() throws Exception {
+        TestSchema schema = createSchema();
+        seed(schema);
+        execute(schema, "ALTER TABLE tbl_member_detail ADD UNIQUE INDEX arbitrary_dong_unique (dong_id)");
+        execute(schema, "CREATE INDEX existing_dong_place ON tbl_member_detail (dong_id, place_id)");
+        dropOrdinaryDongIndexesExcept(schema, "existing_dong_place");
+
+        assertThat(indexCount(schema, "NON_UNIQUE = 1 AND INDEX_TYPE = 'BTREE'"
+                + " AND SEQ_IN_INDEX = 1 AND COLUMN_NAME = 'dong_id' AND SUB_PART IS NULL")).isOne();
+
+        Flyway flyway = baselineAtSeven(schema);
+
+        assertThat(flyway.migrate().migrationsExecuted).isEqualTo(1);
+        assertThat(dongOnlyUniqueCount(schema)).isZero();
+        assertThat(indexColumns(schema, "existing_dong_place")).isEqualTo("dong_id,place_id");
+        assertThat(indexColumns(schema, "idx_member_detail_dong_id")).isNull();
+    }
+
+    @Test
+    @DisplayName("an incompatible replacement-index name fails before legacy uniqueness is dropped")
+    void failsSafelyOnReplacementNameCollision() throws Exception {
+        TestSchema schema = createSchema();
+        seed(schema);
+        execute(schema, "ALTER TABLE tbl_member_detail ADD UNIQUE INDEX keep_until_failure (dong_id)");
+        dropOrdinaryDongIndexes(schema);
+        execute(schema, "CREATE INDEX idx_member_detail_dong_id ON tbl_member_detail (place_id)");
+        Flyway flyway = baselineAtSeven(schema);
+
+        assertThatThrownBy(flyway::migrate)
+                .rootCause()
+                .hasMessageContaining("idx_member_detail_dong_id exists with an incompatible definition");
+
+        assertThat(dongOnlyUniqueCount(schema)).isOne();
+        assertThat(indexColumns(schema, "idx_member_detail_dong_id")).isEqualTo("place_id");
+        assertThat(queryLong(schema, "SELECT COUNT(*) FROM tbl_member_detail")).isOne();
+        assertThat(queryLong(schema, "SELECT COUNT(*) FROM information_schema.REFERENTIAL_CONSTRAINTS"
+                + " WHERE CONSTRAINT_SCHEMA = DATABASE() AND TABLE_NAME = 'tbl_member_detail'")).isEqualTo(3);
+        assertThatThrownBy(() -> insertDetail(schema, 4, 999999, 1, "still-protected"))
+                .isInstanceOfSatisfying(SQLException.class,
+                        error -> assertThat(error.getErrorCode()).isEqualTo(1452));
+    }
+
+    private static TestSchema createSchema() throws SQLException {
+        String name = "member_dong_v8_" + schemaSequence.incrementAndGet();
+        try (Connection connection = adminConnection(); Statement statement = connection.createStatement()) {
+            statement.execute("CREATE DATABASE `" + name + "` CHARACTER SET utf8mb4");
+            statement.execute("GRANT ALL ON `" + name + "`.* TO '" + mariadb.getUsername() + "'@'%'");
+        }
+        schemas.add(name);
+        TestSchema schema = new TestSchema(name, schemaUrl(name));
+        System.out.printf("QA_RESOURCE_CREATED schema=%s%n", name);
+        try (RepositoryContext ignored = repositoryContext(schema, "create")) {
+        }
+        return schema;
+    }
+
+    private static RepositoryContext repositoryContext(TestSchema schema, String ddlMode) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.getEnvironment().getPropertySources().addFirst(new org.springframework.core.env.MapPropertySource(
+                "migrationTest", Map.of("migration.jdbc-url", schema.url(), "migration.ddl-auto", ddlMode)));
+        context.register(PersistenceConfiguration.class);
+        context.refresh();
+        return new RepositoryContext(context);
+    }
+
+    private static Flyway baselineAtSeven(TestSchema schema) {
+        Flyway flyway = Flyway.configure()
+                .dataSource(schema.url(), mariadb.getUsername(), mariadb.getPassword())
+                .locations("classpath:db/migration")
+                .baselineVersion("7")
+                .load();
+        flyway.baseline();
+        return flyway;
+    }
+
+    private static void seed(TestSchema schema) throws SQLException {
+        execute(schema, "INSERT INTO tbl_head_place (head_id, name) VALUES (1, 'seed-head')");
+        execute(schema, "INSERT INTO tbl_place (place_id, name, head_id) VALUES (1, 'seed-place', 1)");
+        execute(schema, "INSERT INTO tbl_dong (dong_id, name) VALUES (1, 'seed-dong')");
+        for (long id = 1; id <= 5; id++) {
+            execute(schema, "INSERT INTO tbl_member"
+                    + " (member_id, name, nickname, password, phone_number, role, member_status, joined_at) VALUES ("
+                    + id + ", 'member', 'nickname" + id + "', 'pw', '010-0000-000" + id
+                    + "', 'ROLE_USER', 'ACTIVE', CURRENT_TIMESTAMP)");
+        }
+        insertDetail(schema, 1, 1, 1, "seed");
+    }
+
+    private static void assertLegacyDuplicateFails(TestSchema schema) {
+        assertThatThrownBy(() -> insertDetail(schema, 2, 1, 1, "legacy-red"))
+                .isInstanceOfSatisfying(SQLException.class, error -> {
+                    assertThat(error.getErrorCode()).isEqualTo(1062);
+                    System.out.printf("LEGACY_RED errorCode=%s duplicate_dong=%s%n",
+                            error.getErrorCode(), error.getMessage());
+                });
+    }
+
+    private static void insertDetail(TestSchema schema, long memberId, Integer dongId,
+                                     int placeId, String description) throws SQLException {
+        String dong = dongId == null ? "NULL" : dongId.toString();
+        execute(schema, "INSERT INTO tbl_member_detail"
+                + " (member_id, dong_id, place_id, gwangsan, light, description) VALUES ("
+                + memberId + ", " + dong + ", " + placeId + ", 0, 0, '" + description + "')");
+    }
+
+    private static void dropOrdinaryDongIndexes(TestSchema schema) throws SQLException {
+        dropOrdinaryDongIndexesExcept(schema, "");
+    }
+
+    private static void dropOrdinaryDongIndexesExcept(TestSchema schema, String retainedName) throws SQLException {
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement();
+             ResultSet indexes = statement.executeQuery("""
+                     SELECT DISTINCT INDEX_NAME
+                     FROM information_schema.STATISTICS
+                     WHERE TABLE_SCHEMA = DATABASE()
+                       AND TABLE_NAME = 'tbl_member_detail'
+                       AND NON_UNIQUE = 1
+                       AND SEQ_IN_INDEX = 1
+                       AND COLUMN_NAME = 'dong_id'
+                     """)) {
+            Set<String> names = new LinkedHashSet<>();
+            while (indexes.next()) {
+                names.add(indexes.getString(1));
+            }
+            for (String name : names) {
+                if (name.equals(retainedName)) {
+                    continue;
+                }
+                try (Statement drop = connection.createStatement()) {
+                    drop.execute("ALTER TABLE tbl_member_detail DROP INDEX `" + name.replace("`", "``") + "`");
+                }
+            }
+        }
+    }
+
+    private static long dongOnlyUniqueCount(TestSchema schema) throws SQLException {
+        return queryLong(schema, """
+                SELECT COUNT(*) FROM (
+                    SELECT INDEX_NAME
+                    FROM information_schema.STATISTICS
+                    WHERE TABLE_SCHEMA = DATABASE()
+                      AND TABLE_NAME = 'tbl_member_detail'
+                      AND NON_UNIQUE = 0
+                      AND INDEX_NAME <> 'PRIMARY'
+                    GROUP BY INDEX_NAME
+                    HAVING COUNT(*) = 1 AND MIN(COLUMN_NAME) = 'dong_id'
+                ) AS dong_unique_indexes
+                """);
+    }
+
+    private static long indexCount(TestSchema schema, String condition) throws SQLException {
+        return queryLong(schema, "SELECT COUNT(*) FROM information_schema.STATISTICS"
+                + " WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'tbl_member_detail' AND " + condition);
+    }
+
+    private static String indexColumns(TestSchema schema, String name) throws SQLException {
+        try (Connection connection = connection(schema);
+             var statement = connection.prepareStatement("""
+                     SELECT GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX)
+                     FROM information_schema.STATISTICS
+                     WHERE TABLE_SCHEMA = DATABASE()
+                       AND TABLE_NAME = 'tbl_member_detail'
+                       AND INDEX_NAME = ?
+                     """)) {
+            statement.setString(1, name);
+            try (ResultSet result = statement.executeQuery()) {
+                result.next();
+                return result.getString(1);
+            }
+        }
+    }
+
+    private static String showCreate(TestSchema schema) throws SQLException {
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("SHOW CREATE TABLE tbl_member_detail")) {
+            result.next();
+            return result.getString(2);
+        }
+    }
+
+    private static void printMetadata(String phase, TestSchema schema) throws SQLException {
+        System.out.printf("MIGRATION_%s_SCHEMA %s%n", phase, showCreate(schema));
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("SHOW INDEX FROM tbl_member_detail")) {
+            while (result.next()) {
+                System.out.printf("MIGRATION_%s_INDEX name=%s nonUnique=%s seq=%s column=%s type=%s%n",
+                        phase, result.getString("Key_name"), result.getInt("Non_unique"),
+                        result.getInt("Seq_in_index"), result.getString("Column_name"),
+                        result.getString("Index_type"));
+            }
+        }
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery("""
+                     SELECT CONSTRAINT_NAME, REFERENCED_TABLE_NAME
+                     FROM information_schema.REFERENTIAL_CONSTRAINTS
+                     WHERE CONSTRAINT_SCHEMA = DATABASE()
+                       AND TABLE_NAME = 'tbl_member_detail'
+                     ORDER BY CONSTRAINT_NAME
+                     """)) {
+            while (result.next()) {
+                System.out.printf("MIGRATION_%s_FK name=%s referencedTable=%s%n",
+                        phase, result.getString(1), result.getString(2));
+            }
+        }
+    }
+
+    private static long queryLong(TestSchema schema, String sql) throws SQLException {
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            result.next();
+            return result.getLong(1);
+        }
+    }
+
+    private static String queryString(TestSchema schema, String sql) throws SQLException {
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement();
+             ResultSet result = statement.executeQuery(sql)) {
+            result.next();
+            return result.getString(1);
+        }
+    }
+
+    private static void execute(TestSchema schema, String sql) throws SQLException {
+        try (Connection connection = connection(schema); Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private static Connection adminConnection() throws SQLException {
+        return java.sql.DriverManager.getConnection(
+                mariadb.getJdbcUrl(), "root", mariadb.getPassword());
+    }
+
+    private static Connection connection(TestSchema schema) throws SQLException {
+        return java.sql.DriverManager.getConnection(
+                schema.url(), mariadb.getUsername(), mariadb.getPassword());
+    }
+
+    private static String schemaUrl(String schema) {
+        String database = "/" + mariadb.getDatabaseName();
+        return mariadb.getJdbcUrl().replace(database, "/" + schema);
+    }
+
+    private record TestSchema(String name, String url) {
+    }
+
+    private record RepositoryContext(AnnotationConfigApplicationContext context) implements AutoCloseable {
+        @Override
+        public void close() {
+            context.close();
+        }
+    }
+
+    @Configuration
+    @EnableTransactionManagement
+    @EnableJpaAuditing
+    @EnableJpaRepositories(basePackageClasses = MemberDetailRepository.class)
+    static class PersistenceConfiguration {
+
+        @Bean
+        DataSource dataSource(org.springframework.core.env.Environment environment) {
+            DriverManagerDataSource dataSource = new DriverManagerDataSource();
+            dataSource.setDriverClassName(mariadb.getDriverClassName());
+            dataSource.setUrl(environment.getRequiredProperty("migration.jdbc-url"));
+            dataSource.setUsername(mariadb.getUsername());
+            dataSource.setPassword(mariadb.getPassword());
+            return dataSource;
+        }
+
+        @Bean
+        LocalContainerEntityManagerFactoryBean entityManagerFactory(
+                DataSource dataSource, org.springframework.core.env.Environment environment) {
+            LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+            factory.setDataSource(dataSource);
+            factory.setPackagesToScan("team.startup.gwangsan.domain");
+            factory.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
+            factory.setJpaPropertyMap(Map.of(
+                    "hibernate.hbm2ddl.auto", environment.getRequiredProperty("migration.ddl-auto"),
+                    "hibernate.show_sql", "false"
+            ));
+            return factory;
+        }
+
+        @Bean
+        PlatformTransactionManager transactionManager(EntityManagerFactory entityManagerFactory) {
+            return new JpaTransactionManager(entityManagerFactory);
+        }
+
+        @Bean
+        JPAQueryFactory queryFactory(EntityManagerFactory entityManagerFactory) {
+            return new JPAQueryFactory(SharedEntityManagerCreator.createSharedEntityManager(entityManagerFactory));
+        }
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/member/repository/MemberDetailRepositoryTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/member/repository/MemberDetailRepositoryTest.java
@@ -1,0 +1,196 @@
+package team.startup.gwangsan.domain.member.repository;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import team.startup.gwangsan.domain.dong.entity.Dong;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.domain.member.entity.MemberDetail;
+import team.startup.gwangsan.domain.member.entity.constant.MemberRole;
+import team.startup.gwangsan.domain.member.entity.constant.MemberStatus;
+import team.startup.gwangsan.domain.place.entity.Head;
+import team.startup.gwangsan.domain.place.entity.Place;
+import team.startup.gwangsan.global.querydsl.QueryDslConfig;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+@Import(QueryDslConfig.class)
+@Testcontainers
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@DisplayName("MemberDetail Dong 관계 통합 테스트")
+class MemberDetailRepositoryTest {
+
+    @Container
+    static final MariaDBContainer<?> mariadb = new MariaDBContainer<>("mariadb:11.4");
+
+    @DynamicPropertySource
+    static void datasource(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", mariadb::getJdbcUrl);
+        registry.add("spring.datasource.username", mariadb::getUsername);
+        registry.add("spring.datasource.password", mariadb::getPassword);
+        registry.add("spring.datasource.driver-class-name", mariadb::getDriverClassName);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create-drop");
+    }
+
+    @Autowired private EntityManager entityManager;
+    @Autowired private MemberDetailRepository memberDetailRepository;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    @Test
+    @DisplayName("같은 동을 사용하는 두 회원 상세 정보를 저장하고 다시 읽는다")
+    void savesAndReloadsTwoDetailsWithOneDong() {
+        inTransaction(() -> {
+            Place place = place("공유");
+            Dong dong = persist(Dong.builder().name("공유동").build());
+            Member first = member("첫회원", "010-0000-0001");
+            Member second = member("둘회원", "010-0000-0002");
+
+            memberDetailRepository.save(MemberDetail.builder()
+                    .member(first).dong(dong).place(place).gwangsan(0).light(0).description("소개")
+                    .build());
+            memberDetailRepository.save(MemberDetail.builder()
+                    .member(second).dong(dong).place(place).gwangsan(0).light(0).description("소개")
+                    .build());
+            entityManager.flush();
+            entityManager.clear();
+
+            List<MemberDetail> details = memberDetailRepository.findAllByMemberIdIn(List.of(first.getId(), second.getId()));
+
+            assertThat(details).hasSize(2);
+            assertThat(details).extracting(detail -> detail.getDong().getId())
+                    .containsOnly(dong.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("서로 다른 동을 사용하는 회원 상세 정보도 저장한다")
+    void savesDetailsWithDistinctDongs() {
+        inTransaction(() -> {
+            Place place = place("서로다름");
+            Member first = member("셋회원", "010-0000-0003");
+            Member second = member("넷회원", "010-0000-0004");
+
+            memberDetailRepository.save(MemberDetail.builder()
+                    .member(first).dong(persist(Dong.builder().name("첫동").build())).place(place)
+                    .gwangsan(0).light(0).description("소개").build());
+            memberDetailRepository.save(MemberDetail.builder()
+                    .member(second).dong(persist(Dong.builder().name("둘동").build())).place(place)
+                    .gwangsan(0).light(0).description("소개").build());
+
+            entityManager.flush();
+            entityManager.clear();
+
+            assertThat(memberDetailRepository.findAllByMemberIdIn(List.of(first.getId(), second.getId()))).hasSize(2);
+        });
+    }
+
+    @Test
+    @DisplayName("fresh schema는 member_id 기본 키와 Dong FK 및 NOT NULL을 유지하고 Dong 단독 유니크를 만들지 않는다")
+    void retainsRequiredConstraintsWithoutDongOnlyUnique() {
+        ConstraintFixture fixture = inTransaction(() -> {
+            Place place = place("제약");
+            Member danglingMember = member("다섯회원", "010-0000-0005");
+            Member nullDongMember = member("여섯회원", "010-0000-0006");
+            entityManager.flush();
+            return new ConstraintFixture(place.getId(), danglingMember.getId(), nullDongMember.getId());
+        });
+
+        assertThatThrownBy(() -> inTransaction(() -> {
+            entityManager.createNativeQuery("""
+                    INSERT INTO tbl_member_detail (member_id, description, gwangsan, light, dong_id, place_id)
+                    VALUES (?, '소개', 0, 0, 999999, ?)
+                    """)
+                    .setParameter(1, fixture.danglingMemberId())
+                    .setParameter(2, fixture.placeId())
+                    .executeUpdate();
+        })).hasMessageContaining("foreign key constraint fails");
+
+        assertThatThrownBy(() -> inTransaction(() -> {
+            entityManager.createNativeQuery("""
+                    INSERT INTO tbl_member_detail (member_id, description, gwangsan, light, dong_id, place_id)
+                    VALUES (?, '소개', 0, 0, NULL, ?)
+                    """)
+                    .setParameter(1, fixture.nullDongMemberId())
+                    .setParameter(2, fixture.placeId())
+                    .executeUpdate();
+        })).hasMessageContaining("cannot be null");
+
+        assertThat(inTransaction(() -> singleIndexColumns("PRIMARY"))).isEqualTo("member_id");
+        assertThat(inTransaction(this::dongOnlyUniqueIndexCount)).isZero();
+    }
+
+    private void inTransaction(Runnable action) {
+        new TransactionTemplate(transactionManager).executeWithoutResult(status -> action.run());
+    }
+
+    private <T> T inTransaction(Supplier<T> action) {
+        return new TransactionTemplate(transactionManager).execute(status -> action.get());
+    }
+
+    private Place place(String suffix) {
+        Head head = persist(new Head("본부-" + suffix));
+        return persist(Place.builder().name("지점-" + suffix).head(head).build());
+    }
+
+    private Member member(String name, String phoneNumber) {
+        return persist(Member.builder()
+                .name(name).nickname(name).password("pw").phoneNumber(phoneNumber)
+                .role(MemberRole.ROLE_USER).status(MemberStatus.ACTIVE)
+                .build());
+    }
+
+    private <T> T persist(T entity) {
+        entityManager.persist(entity);
+        return entity;
+    }
+
+    private String singleIndexColumns(String indexName) {
+        return (String) entityManager.createNativeQuery("""
+                SELECT GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX)
+                FROM information_schema.STATISTICS
+                WHERE TABLE_SCHEMA = DATABASE()
+                  AND TABLE_NAME = 'tbl_member_detail'
+                  AND INDEX_NAME = ?
+                """)
+                .setParameter(1, indexName)
+                .getSingleResult();
+    }
+
+    private long dongOnlyUniqueIndexCount() {
+        return ((Number) entityManager.createNativeQuery("""
+                SELECT COUNT(*)
+                FROM (
+                    SELECT INDEX_NAME
+                    FROM information_schema.STATISTICS
+                    WHERE TABLE_SCHEMA = DATABASE()
+                      AND TABLE_NAME = 'tbl_member_detail'
+                      AND NON_UNIQUE = 0
+                      AND INDEX_NAME <> 'PRIMARY'
+                    GROUP BY INDEX_NAME
+                    HAVING GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX) = 'dong_id'
+                ) AS dong_unique_indexes
+                """).getSingleResult()).longValue();
+    }
+
+    private record ConstraintFixture(Integer placeId, Long danglingMemberId, Long nullDongMemberId) {
+    }
+}

--- a/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelConcurrencyTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/trade/service/impl/TradeCancelConcurrencyTest.java
@@ -178,20 +178,16 @@ class TradeCancelConcurrencyTest {
             entityManager.persist(head);
             Place place = Place.builder().name("지점").head(head).build();
             entityManager.persist(place);
-            // MemberDetail.dong 이 @OneToOne 이라 dong_id 에 유니크 제약이 걸린다.
-            // 두 회원이 같은 동을 공유할 수 없어 따로 만든다.
-            Dong buyerDong = Dong.builder().name("구매자동").build();
-            Dong sellerDong = Dong.builder().name("판매자동").build();
-            entityManager.persist(buyerDong);
-            entityManager.persist(sellerDong);
+            Dong dong = Dong.builder().name("공유동").build();
+            entityManager.persist(dong);
 
             Member buyer = member("구매자", "010-0000-0001");
             Member seller = member("판매자", "010-0000-0002");
             entityManager.persist(buyer);
             entityManager.persist(seller);
 
-            entityManager.persist(memberDetail(buyer, buyerDong, place));
-            entityManager.persist(memberDetail(seller, sellerDong, place));
+            entityManager.persist(memberDetail(buyer, dong, place));
+            entityManager.persist(memberDetail(seller, dong, place));
 
             Product product = Product.builder()
                     .title("상품").description("설명").gwangsan(GWANGSAN)


### PR DESCRIPTION
## 💡 배경 및 개요

`MemberDetail.dong`의 일대일 매핑으로 생성된 UNIQUE 제약이 동일한 동을 선택한 여러 회원의 등록을 막는 문제를 수정하였습니다. 회원가입에서 기존 Dong을 재사용하는 흐름에 맞게 관계와 기존 스키마의 제약을 함께 수정하였습니다.

Resolves: #389

## 📃 작업내용

- `MemberDetail.dong`을 지연 로딩하는 `ManyToOne`으로 변경하였습니다.
- `dong_id` 단독 UNIQUE를 찾아 제거하는 V8 마이그레이션을 추가하였습니다. FK 지원 인덱스를 먼저 확보하고 기존 데이터와 다른 제약을 보존하도록 하였습니다.
- 제약 없음, 여러 제약 이름, 백틱을 포함한 이름, 기존 일반 인덱스 재사용 및 대체 인덱스 이름 충돌을 검증하였습니다.
- 실제 MariaDB 기반 매핑·마이그레이션 회귀 테스트를 추가하고, 거래 동시성 테스트에서 Dong을 따로 생성하던 우회를 제거하였습니다.

## 🙋‍♂️ 리뷰노트

- 매핑만 변경하면 기존 UNIQUE가 남을 수 있어 마이그레이션을 함께 추가하였습니다. FK 지원 인덱스 보존과 제거 대상 범위를 중심으로 검토 부탁드립니다.
- 운영 프로필과 스키마는 확인하지 않았습니다. 기본 설정은 Flyway 비활성, prod 설정은 Flyway 활성 및 `ddl-auto: validate`이므로 실제 적용 전 활성 설정과 스키마 이력 확인이 필요합니다.
- 테스트는 Hibernate로 생성한 스키마를 V7 기준으로 baseline하여 V8을 검증하였습니다. 기존 V2–V7 전체의 빈 DB 초기화를 검증한 것은 아닙니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (별도 문서·환경값 변경 없음)
- [x] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요?
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

- 전체 테스트 484개 통과, 실패·오류·건너뜀 0개를 확인하였습니다.
- `bootJar` 빌드를 검증하였습니다.
- 운영 DB 및 S3에는 접근하지 않았습니다.
