### PR TITLE
sendable 이미지 메타데이터 검증 및 응답 추가

### DIFF
--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/ChatController.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/ChatController.java
@@ -3,12 +3,14 @@ package team.startup.gwangsan.domain.chat.presentation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import team.startup.gwangsan.domain.chat.presentation.dto.request.UpdateMessageCheckedRequest;
 import team.startup.gwangsan.domain.chat.presentation.dto.response.CreateChatRoomResponse;
 import team.startup.gwangsan.domain.chat.presentation.dto.response.GetChatMessagesResponse;
 import team.startup.gwangsan.domain.chat.presentation.dto.response.GetRoomIdResponse;
 import team.startup.gwangsan.domain.chat.presentation.dto.response.GetRoomsResponse;
+import team.startup.gwangsan.domain.chat.presentation.dto.response.ValidateChatSendableResponse;
 import team.startup.gwangsan.domain.chat.service.CreateChatRoomService;
 import team.startup.gwangsan.domain.chat.service.DeleteChatRoomService;
 import team.startup.gwangsan.domain.chat.service.FindChatMessageByRoomIdService;
@@ -70,9 +72,11 @@ public class ChatController {
 
     // 채팅 서버가 소켓 메시지를 브로드캐스트하기 전에 호출한다.
     @GetMapping("/room/{room_id}/sendable")
-    public ResponseEntity<Void> validateSendable(@PathVariable("room_id") Long roomId) {
-        validateChatSendableService.execute(roomId);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<ValidateChatSendableResponse> validateSendable(
+            @PathVariable("room_id") Long roomId,
+            @RequestParam MultiValueMap<String, String> queryParameters
+    ) {
+        return ResponseEntity.ok(validateChatSendableService.execute(roomId, queryParameters.get("imageIds")));
     }
 
     @DeleteMapping("/room/{room_id}")

--- a/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/response/ValidateChatSendableResponse.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/presentation/dto/response/ValidateChatSendableResponse.java
@@ -1,0 +1,8 @@
+package team.startup.gwangsan.domain.chat.presentation.dto.response;
+
+import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
+
+import java.util.List;
+
+public record ValidateChatSendableResponse(List<GetImageResponse> images) {
+}

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/ValidateChatSendableService.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/ValidateChatSendableService.java
@@ -1,5 +1,9 @@
 package team.startup.gwangsan.domain.chat.service;
 
+import team.startup.gwangsan.domain.chat.presentation.dto.response.ValidateChatSendableResponse;
+
+import java.util.List;
+
 public interface ValidateChatSendableService {
-    void execute(Long roomId);
+    ValidateChatSendableResponse execute(Long roomId, List<String> imageIds);
 }

--- a/src/main/java/team/startup/gwangsan/domain/chat/service/impl/ValidateChatSendableServiceImpl.java
+++ b/src/main/java/team/startup/gwangsan/domain/chat/service/impl/ValidateChatSendableServiceImpl.java
@@ -5,11 +5,22 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import team.startup.gwangsan.domain.chat.entity.ChatRoom;
 import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
+import team.startup.gwangsan.domain.chat.presentation.dto.response.ValidateChatSendableResponse;
 import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
 import team.startup.gwangsan.domain.chat.service.ValidateChatSendableService;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.image.exception.InvalidImageIdsException;
+import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
+import team.startup.gwangsan.domain.image.repository.ImageRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
 import team.startup.gwangsan.global.util.BlockValidator;
+import team.startup.gwangsan.global.util.ImageValidateUtil;
 import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,10 +29,11 @@ public class ValidateChatSendableServiceImpl implements ValidateChatSendableServ
     private final ChatRoomRepository chatRoomRepository;
     private final MemberUtil memberUtil;
     private final BlockValidator blockValidator;
+    private final ImageRepository imageRepository;
 
     @Override
     @Transactional(readOnly = true)
-    public void execute(Long roomId) {
+    public ValidateChatSendableResponse execute(Long roomId, List<String> imageIds) {
         Member member = memberUtil.getCurrentMember();
         ChatRoom chatRoom = chatRoomRepository.findChatRoomByRoomId(roomId)
                 .orElseThrow(NotFoundChatRoomException::new);
@@ -32,5 +44,36 @@ public class ValidateChatSendableServiceImpl implements ValidateChatSendableServ
         }
 
         blockValidator.validate(member, chatRoom.getOtherMember(member));
+
+        if (imageIds == null) {
+            return null;
+        }
+        if (imageIds.isEmpty()) {
+            throw new InvalidImageIdsException();
+        }
+
+        List<Long> parsedIds = imageIds.stream().map(this::parseImageId).toList();
+        List<Image> images = imageRepository.findAllById(parsedIds);
+        ImageValidateUtil.validateExistence(parsedIds, images);
+        Map<Long, Image> imagesById = images.stream()
+                .collect(Collectors.toMap(Image::getId, Function.identity()));
+        return new ValidateChatSendableResponse(parsedIds.stream()
+                .map(id -> new GetImageResponse(id, imagesById.get(id).getImageUrl()))
+                .toList());
+    }
+
+    private Long parseImageId(String value) {
+        if (value == null || !value.matches("[0-9]+")) {
+            throw new InvalidImageIdsException();
+        }
+        try {
+            long id = Long.parseLong(value);
+            if (id <= 0 || id > 9_007_199_254_740_991L) {
+                throw new InvalidImageIdsException();
+            }
+            return id;
+        } catch (NumberFormatException exception) {
+            throw new InvalidImageIdsException();
+        }
     }
 }

--- a/src/main/java/team/startup/gwangsan/domain/image/exception/InvalidImageIdsException.java
+++ b/src/main/java/team/startup/gwangsan/domain/image/exception/InvalidImageIdsException.java
@@ -1,0 +1,10 @@
+package team.startup.gwangsan.domain.image.exception;
+
+import team.startup.gwangsan.global.exception.ErrorCode;
+import team.startup.gwangsan.global.exception.GlobalException;
+
+public class InvalidImageIdsException extends GlobalException {
+    public InvalidImageIdsException() {
+        super(ErrorCode.INVALID_IMAGE_IDS);
+    }
+}

--- a/src/main/java/team/startup/gwangsan/global/exception/ErrorCode.java
+++ b/src/main/java/team/startup/gwangsan/global/exception/ErrorCode.java
@@ -48,6 +48,7 @@ public enum ErrorCode {
     INAPPROPRIATE_CONTENT(400, "부적절한 내용이 포함되어 있습니다."),
 
     // image
+    INVALID_IMAGE_IDS(400, "이미지 ID는 양의 안전 정수여야 합니다."),
     IMAGE_NOT_FOUND(404, "해당 이미지를 찾을 수 없습니다."),
     OBJECT_REQUIRED_IMAGE(400, "해당 게시글은 이미지가 필수입니다."),
     NOT_FOUND_IMAGE_IDS(404, "존재하지 않는 이미지 ID가 포함되어 있습니다."),

--- a/src/test/java/team/startup/gwangsan/domain/chat/presentation/ChatSendableControllerTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/presentation/ChatSendableControllerTest.java
@@ -1,0 +1,124 @@
+package team.startup.gwangsan.domain.chat.presentation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import team.startup.gwangsan.domain.chat.entity.ChatRoom;
+import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.chat.service.impl.ValidateChatSendableServiceImpl;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.image.repository.ImageRepository;
+import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.global.exception.GlobalExceptionHandler;
+import team.startup.gwangsan.global.util.BlockValidator;
+import team.startup.gwangsan.global.util.MemberUtil;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("채팅 sendable HTTP 계약")
+class ChatSendableControllerTest {
+    private MockMvc mvc;
+    private ImageRepository imageRepository;
+
+    @BeforeEach
+    void setup() {
+        ChatRoomRepository rooms = mock(ChatRoomRepository.class);
+        MemberUtil members = mock(MemberUtil.class);
+        BlockValidator blocks = mock(BlockValidator.class);
+        imageRepository = mock(ImageRepository.class);
+        Member member = mock(Member.class);
+        ChatRoom room = mock(ChatRoom.class);
+        when(members.getCurrentMember()).thenReturn(member);
+        when(rooms.findChatRoomByRoomId(10L)).thenReturn(Optional.of(room));
+        when(room.isParticipant(member)).thenReturn(true);
+        ValidateChatSendableServiceImpl service = new ValidateChatSendableServiceImpl(rooms, members, blocks, imageRepository);
+        ChatController controller = new ChatController(null, null, null, null, null, null, service);
+        mvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler()).build();
+    }
+
+    @Nested
+    @DisplayName("sendable 요청은")
+    class Describe_sendable {
+
+        @Test
+        @DisplayName("쿼리 생략 시 빈 본문을 유지한다")
+        void it_absent_query_preserves_empty_success_body() throws Exception {
+            mvc.perform(get("/api/chat/room/10/sendable"))
+                    .andExpect(status().isOk()).andExpect(content().string(""));
+            verifyNoInteractions(imageRepository);
+        }
+
+        @Test
+        @DisplayName("반복 쿼리의 중복 메타데이터를 반환한다")
+        void it_repeated_query_returns_ordered_image_metadata() throws Exception {
+            Image image = mock(Image.class);
+            when(image.getId()).thenReturn(11L);
+            when(image.getImageUrl()).thenReturn("https://example.com/11.jpg");
+            when(imageRepository.findAllById(List.of(11L, 11L))).thenReturn(List.of(image));
+            mvc.perform(get("/api/chat/room/10/sendable?imageIds=11&imageIds=11"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.images.length()").value(2))
+                    .andExpect(jsonPath("$.images[0].imageId").value(11))
+                    .andExpect(jsonPath("$.images[1].imageUrl").value("https://example.com/11.jpg"));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", " ", "0", "-1", "1.5", "abc", "9007199254740992", "9223372036854775808", "+11", "11 ", " 11", "11,12", "0xB", "1e1", "１１"})
+        @DisplayName("잘못된 형식은 조회 없이 400을 반환한다")
+        void it_invalid_query_returns_bad_request_without_lookup(String id) throws Exception {
+            mvc.perform(get("/api/chat/room/10/sendable").param("imageIds", id))
+                    .andExpect(status().isBadRequest());
+            verifyNoInteractions(imageRepository);
+        }
+
+        @Test
+        @DisplayName("빈 값이 섞인 반복 쿼리는 400을 반환한다")
+        void it_empty_repeated_value_returns_bad_request() throws Exception {
+            mvc.perform(get("/api/chat/room/10/sendable").param("imageIds", "11", ""))
+                    .andExpect(status().isBadRequest());
+            verifyNoInteractions(imageRepository);
+        }
+
+        @Test
+        @DisplayName("없는 이미지는 기존 404를 반환한다")
+        void it_missing_image_returns_existing_not_found_status() throws Exception {
+            when(imageRepository.findAllById(List.of(11L))).thenReturn(List.of());
+            mvc.perform(get("/api/chat/room/10/sendable").param("imageIds", "11"))
+                    .andExpect(status().isNotFound());
+        }
+        @Test
+        @DisplayName("값 없는 쿼리를 생략으로 취급하지 않는다")
+        void it_rejects_bare_query_key() throws Exception {
+            mvc.perform(get("/api/chat/room/10/sendable?imageIds"))
+                    .andExpect(status().isBadRequest());
+            verifyNoInteractions(imageRepository);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"1", "9007199254740991", "00011"})
+        @DisplayName("유효한 단일 ID는 DB 메타데이터를 반환한다")
+        void it_returns_single_image(String value) throws Exception {
+            long id = Long.parseLong(value);
+            Image image = mock(Image.class);
+            when(image.getId()).thenReturn(id);
+            when(image.getImageUrl()).thenReturn("https://example.com/image.jpg");
+            when(imageRepository.findAllById(List.of(id))).thenReturn(List.of(image));
+            mvc.perform(get("/api/chat/room/10/sendable?imageIds=" + value))
+                    .andExpect(status().isOk())
+                    .andExpect(content().json("{\"images\":[{\"imageId\":" + id
+                            + ",\"imageUrl\":\"https://example.com/image.jpg\"}]}"));
+        }
+    }
+
+}

--- a/src/test/java/team/startup/gwangsan/domain/chat/service/impl/ValidateChatSendableServiceImplTest.java
+++ b/src/test/java/team/startup/gwangsan/domain/chat/service/impl/ValidateChatSendableServiceImplTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -11,13 +13,20 @@ import team.startup.gwangsan.domain.block.exception.BlockedMemberException;
 import team.startup.gwangsan.domain.chat.entity.ChatRoom;
 import team.startup.gwangsan.domain.chat.exception.NotFoundChatRoomException;
 import team.startup.gwangsan.domain.chat.repository.ChatRoomRepository;
+import team.startup.gwangsan.domain.image.entity.Image;
+import team.startup.gwangsan.domain.image.exception.ImageNotFoundException;
+import team.startup.gwangsan.domain.image.exception.InvalidImageIdsException;
+import team.startup.gwangsan.domain.image.presentation.dto.response.GetImageResponse;
+import team.startup.gwangsan.domain.image.repository.ImageRepository;
 import team.startup.gwangsan.domain.member.entity.Member;
+import team.startup.gwangsan.global.security.exception.InvalidMemberPrincipalException;
 import team.startup.gwangsan.global.util.BlockValidator;
 import team.startup.gwangsan.global.util.MemberUtil;
 
+import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -28,9 +37,104 @@ class ValidateChatSendableServiceImplTest {
     @Mock private ChatRoomRepository chatRoomRepository;
     @Mock private MemberUtil memberUtil;
     @Mock private BlockValidator blockValidator;
+    @Mock private ImageRepository imageRepository;
 
     @InjectMocks
     private ValidateChatSendableServiceImpl service;
+
+    @Nested
+    @DisplayName("이미지 메타데이터 검증은")
+    class Describe_images {
+
+        @Test
+        @DisplayName("인증 실패 시 방과 이미지를 조회하지 않는다")
+        void it_unauthenticated_request_never_reads_room_or_images() {
+            when(memberUtil.getCurrentMember()).thenThrow(
+                    new InvalidMemberPrincipalException());
+            assertThatThrownBy(() -> service.execute(10L, List.of("11")))
+                    .isInstanceOf(InvalidMemberPrincipalException.class);
+            verifyNoInteractions(chatRoomRepository, blockValidator, imageRepository);
+        }
+
+        @Test
+        @DisplayName("DB 반환 순서와 무관하게 요청 순서와 중복을 보존한다")
+        void it_returns_images_in_requested_order_with_duplicates() {
+            allowRoom();
+            Image first = mock(Image.class);
+            Image second = mock(Image.class);
+            when(first.getId()).thenReturn(11L);
+            when(first.getImageUrl()).thenReturn("https://example.com/11.jpg");
+            when(second.getId()).thenReturn(12L);
+            when(second.getImageUrl()).thenReturn("https://example.com/12.jpg");
+            List<Long> ids = List.of(12L, 11L, 12L);
+            when(imageRepository.findAllById(ids)).thenReturn(List.of(first, second));
+
+            assertThat(service.execute(10L, List.of("12", "11", "12")).images()).containsExactly(
+                    new GetImageResponse(12L, "https://example.com/12.jpg"),
+                    new GetImageResponse(11L, "https://example.com/11.jpg"),
+                    new GetImageResponse(12L, "https://example.com/12.jpg"));
+        }
+
+        @Test
+        @DisplayName("이미지가 전부 없으면 404 예외를 던진다")
+        void it_rejects_missing_images_without_partial_response() {
+            allowRoom();
+            when(imageRepository.findAllById(List.of(11L))).thenReturn(List.of());
+            assertThatThrownBy(() -> service.execute(10L, List.of("11")))
+                    .isInstanceOf(ImageNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("일부 이미지가 없으면 전체 요청이 실패한다")
+        void it_rejects_partially_missing_images() {
+            allowRoom();
+            Image image = mock(Image.class);
+            when(image.getId()).thenReturn(11L);
+            when(imageRepository.findAllById(List.of(11L, 12L))).thenReturn(List.of(image));
+
+            assertThatThrownBy(() -> service.execute(10L, List.of("11", "12")))
+                    .isInstanceOf(ImageNotFoundException.class);
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"1", "9007199254740991", "00011"})
+        @DisplayName("양의 안전 정수 경계와 선행 0을 허용한다")
+        void it_accepts_safe_integer_boundaries(String value) {
+            allowRoom();
+            long id = Long.parseLong(value);
+            Image image = mock(Image.class);
+            when(image.getId()).thenReturn(id);
+            when(image.getImageUrl()).thenReturn("https://example.com/image.jpg");
+            when(imageRepository.findAllById(List.of(id))).thenReturn(List.of(image));
+
+            assertThat(service.execute(10L, List.of(value)).images())
+                    .containsExactly(new GetImageResponse(id, "https://example.com/image.jpg"));
+            var order = inOrder(blockValidator, imageRepository);
+            order.verify(blockValidator).validate(any(Member.class), nullable(Member.class));
+            order.verify(imageRepository).findAllById(List.of(id));
+        }
+
+        @Test
+        @DisplayName("빈 목록과 null 요소는 조회 전에 거부한다")
+        void it_rejects_empty_list_and_null_element() {
+            allowRoom();
+            assertThatThrownBy(() -> service.execute(10L, List.of()))
+                    .isInstanceOf(InvalidImageIdsException.class);
+            assertThatThrownBy(() -> service.execute(10L, java.util.Arrays.asList("11", null)))
+                    .isInstanceOf(InvalidImageIdsException.class);
+            verifyNoInteractions(imageRepository);
+        }
+
+    }
+
+    private void allowRoom() {
+
+        Member member = mock(Member.class);
+        ChatRoom room = mock(ChatRoom.class);
+        when(memberUtil.getCurrentMember()).thenReturn(member);
+        when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(room));
+        when(room.isParticipant(member)).thenReturn(true);
+    }
 
     @Nested
     @DisplayName("execute() 메서드는")
@@ -42,10 +146,10 @@ class ValidateChatSendableServiceImplTest {
             when(memberUtil.getCurrentMember()).thenReturn(mock(Member.class));
             when(chatRoomRepository.findChatRoomByRoomId(1L)).thenReturn(Optional.empty());
 
-            assertThatThrownBy(() -> service.execute(1L))
+            assertThatThrownBy(() -> service.execute(1L, List.of("11")))
                     .isInstanceOf(NotFoundChatRoomException.class);
 
-            verifyNoInteractions(blockValidator);
+            verifyNoInteractions(blockValidator, imageRepository);
         }
 
         @Test
@@ -57,10 +161,10 @@ class ValidateChatSendableServiceImplTest {
             when(chatRoomRepository.findChatRoomByRoomId(10L)).thenReturn(Optional.of(chatRoom));
             when(chatRoom.isParticipant(member)).thenReturn(false);
 
-            assertThatThrownBy(() -> service.execute(10L))
+            assertThatThrownBy(() -> service.execute(10L, List.of("11")))
                     .isInstanceOf(NotFoundChatRoomException.class);
 
-            verifyNoInteractions(blockValidator);
+            verifyNoInteractions(blockValidator, imageRepository);
         }
 
         @Test
@@ -75,8 +179,9 @@ class ValidateChatSendableServiceImplTest {
             when(chatRoom.getOtherMember(member)).thenReturn(otherMember);
             doThrow(new BlockedMemberException()).when(blockValidator).validate(member, otherMember);
 
-            assertThatThrownBy(() -> service.execute(10L))
+            assertThatThrownBy(() -> service.execute(10L, List.of("11")))
                     .isInstanceOf(BlockedMemberException.class);
+            verifyNoInteractions(imageRepository);
         }
 
         @Test
@@ -90,7 +195,8 @@ class ValidateChatSendableServiceImplTest {
             when(chatRoom.isParticipant(member)).thenReturn(true);
             when(chatRoom.getOtherMember(member)).thenReturn(otherMember);
 
-            assertThatCode(() -> service.execute(10L)).doesNotThrowAnyException();
+            assertThat(service.execute(10L, null)).isNull();
+            verifyNoInteractions(imageRepository);
 
             verify(blockValidator).validate(member, otherMember);
         }


### PR DESCRIPTION
## 💡 배경 및 개요

채팅 서버가 IMAGE 메시지를 Redis Stream에 발행하기 전에 이미지 존재와 메타데이터를 확인할 수 있도록 기존 sendable API를 확장하였습니다.

Resolves: #393

관련 이슈: https://github.com/School-of-Company/Gwangsan-Chatting-Server/issues/35

## 📃 작업내용

- `GET /api/chat/room/{roomId}/sendable`에 반복 쿼리 `imageIds`를 추가하였습니다.
- `imageIds` 생략 시 기존 인증·방 참여·차단 검증 후 `200` 빈 본문을 유지하였습니다.
- ID가 있으면 동일한 권한 검증 후 DB의 `imageId`·`imageUrl`을 `images` 배열로 반환하도록 하였습니다.
- ASCII 십진수 숫자열 및 양의 JavaScript 안전 정수 범위를 검증하였습니다. 빈 값·공백·부호·쉼표·잘못된 형식·범위 초과는 `400`으로 처리하였습니다.
- 기존 `ImageRepository.findAllById()`와 `ImageValidateUtil.validateExistence()`를 재사용하여 일부 이미지라도 없으면 기존 이미지 `404`로 전체 실패하도록 하였습니다.
- 응답의 요청 순서와 중복 횟수를 보존하고 서비스·컨트롤러 회귀 테스트를 추가하였습니다.

## 🙋‍♂️ 리뷰노트

- `?imageIds=12&imageIds=11&imageIds=12` 요청에는 같은 순서와 횟수로 DB 메타데이터를 반환하도록 하였습니다. 선행 0은 허용하였습니다.
- Spring을 먼저 배포한 뒤 채팅 서버를 배포해야 합니다. 기존 채팅 서버와 하위호환을 유지하였으며, 새 채팅 서버는 구 Spring의 빈 IMAGE 응답을 Redis 발행 전에 거부하도록 연동하였습니다.
- 메타데이터 검증은 Redis 발행 전에 완료해야 하며 echo는 DB 저장 완료를 보장하지 않습니다.
- 이미지 소유자 모델·스키마 변경, Redis 동기 저장, `clientMessageId` 중복 저장 방지는 포함하지 않았습니다.

## ✅ PR 체크리스트

- [ ] 이 작업으로 인해 변경이 필요한 문서가 변경되었나요? (e.g. `.env`, `노션`, `README`)
- [ ] 이 작업을 하고나서 공유해야할 팀원들에게 공유되었나요? (e.g. `"API 개발 완료됐어요"`, `"환경값 추가되었어요"`)
- [x] 작업한 코드가 정상적으로 동작하나요?
- [x] Merge 대상 브랜치가 올바른가요?
- [x] PR과 관련 없는 작업이 있지는 않나요?

## 🎸 기타

- API 계약과 배포 순서는 위 본문에 기재하였습니다. 별도 문서 수정과 팀원 공유는 아직 하지 않았습니다.
- 최신 develop 반영 후 Spring 전체 테스트 532개와 관련 테스트 35개, JAR 빌드가 통과하였습니다. 격리 MariaDB·Redis 환경에서 실제 HTTP 계약, 이미지 404의 발행 차단, 양쪽 TEXT/IMAGE 응답과 동일 메시지 ID의 REST 저장 결과를 확인하였습니다.
- 연동 검증 중 기존 REST 읽음 처리 UPDATE가 비동기 저장과 겹치면 MariaDB 충돌로 `500`이 발생하는 것을 관측하였습니다. 이번 변경에는 포함하지 않았으며, 최종 연동은 DB 커밋을 확인한 뒤 동일 메시지 ID의 REST 저장 결과를 검증하였습니다.
