### PR TITLE
fix: 배포 스크립트 docker system prune에 -a 옵션 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,7 +90,7 @@ jobs:
             --env-file /home/ubuntu/.env \\
             $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
 
-          docker system prune -f
+          docker system prune -af
           EOF
 
           chmod +x codedeploy/scripts/deploy.sh


### PR DESCRIPTION
## 문제
배포(CodeDeploy)마다 새 커밋 SHA 태그로 이미지를 pull하는데, 배포 스크립트의 `docker system prune -f`는 태그된(unused여도) 이미지를 지우지 않고 dangling 이미지만 정리합니다. 그 결과 배포할 때마다 이전 버전 이미지(각 ~300MB)가 계속 쌓여서 서버 디스크가 반복적으로 꽉 차는 장애가 있었습니다 (2026-08-26, 2026-09-11 등 여러 차례 발생, 서비스 크래시로 이어짐).

## 변경 사항
`.github/workflows/cd.yml`에서 배포 스크립트 생성 부분의 `docker system prune -f` → `docker system prune -af`로 변경. 컨테이너가 사용 중이지 않은 이미지는 전부 정리되어, 배포할 때마다 이전 버전들이 누적되지 않습니다.

## 테스트
서버에서 직접 확인 완료 — 안 쓰는 이미지 정리로 디스크 사용량이 100%/94% 상태에서 정상 범위로 회복되는 것을 반복 확인했습니다.